### PR TITLE
Fix tutorial.ipynb

### DIFF
--- a/docs/examples/experiment/tutorial.ipynb
+++ b/docs/examples/experiment/tutorial.ipynb
@@ -7,7 +7,7 @@
    "outputs": [],
    "source": [
     "# Install qubex library if not already installed\n",
-    "# !pip install git+https://github.com/amachino/qubex.git[backend]"
+    "# !pip install \"git+https://github.com/amachino/qubex.git@v1.0.0#egg=qubex[backend]\""
    ]
   },
   {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated the installation command for the `qubex` library in the Jupyter notebook tutorial to specify version `v1.0.0` and include the `#egg=qubex[backend]` option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->