### PR TITLE
Bump actions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -18,7 +18,7 @@ jobs:
         python-version: ["3.9", "3.10", "3.11"]
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v3
         with:


### PR DESCRIPTION
## Description

I guess it is probably the code recommended by LLM, but the actions used are not the latest.
If there are no problems, I recommend using the latest major version.
Basically, differences due to major versions only change the internal Node.js runtime. So it's no breaking changes in behavior.


## See Also

* https://github.com/actions/checkout/releases/tag/v4.0.0
* https://github.com/actions/setup-python/releases/tag/v5.0.0