### PR TITLE
v1.2.2

### DIFF
--- a/docs/examples/analysis/rotation3d.ipynb
+++ b/docs/examples/analysis/rotation3d.ipynb
@@ -6,6 +6,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%load_ext autoreload\n",
+    "%autoreload 2"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "import numpy as np\n",
     "import plotly.graph_objects as go\n",
     "from qctrlvisualizer import display_bloch_sphere_from_bloch_vectors\n",
@@ -18,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -66,7 +76,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": 4,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -86,7 +96,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 4,
+   "execution_count": 5,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -139,13 +149,14 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
-    "def create_data(Omega, r_0, n, times, noise, delta):\n",
-    "    r_t = np.array([R_z(t, delta) @ rotation_matrix(t, Omega, n) @ r_0 for t in times])\n",
-    "    return r_t + np.random.normal(0, noise, r_t.shape)\n",
+    "def create_data(Omega, r_0, n, times, noise, decay_rate):\n",
+    "    r_t = np.array([rotation_matrix(t, Omega, n) @ r_0 for t in times])\n",
+    "    decay_factor = np.exp(-decay_rate * times)\n",
+    "    return r_t * decay_factor[:, None] + np.random.normal(0, noise, r_t.shape)\n",
     "\n",
     "\n",
     "Omega = 4 * np.pi\n",
@@ -162,9 +173,9 @@
    "outputs": [],
    "source": [
     "noise = 0.05\n",
-    "delta = 0.0\n",
+    "decay_factor = 0.5\n",
     "\n",
-    "data = create_data(Omega, r_0, n, times, noise, delta)\n",
+    "data = create_data(Omega, r_0, n, times, noise, decay_factor)\n",
     "\n",
     "plot_bloch_vectors(times, data)\n",
     "display_bloch_sphere_from_bloch_vectors(data)"
@@ -176,24 +187,21 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "def simulate_rotation(times, Omega, theta, phi):\n",
+    "def simulate_rotation(times, Omega, theta, phi, alpha):\n",
     "    n_x = np.sin(theta) * np.cos(phi)\n",
     "    n_y = np.sin(theta) * np.sin(phi)\n",
     "    n_z = np.cos(theta)\n",
-    "    return np.array(\n",
-    "        [\n",
-    "            rotation_matrix(t, Omega, (n_x, n_y, n_z)) @ r_0\n",
-    "            for t in times\n",
-    "        ]\n",
-    "    ).astype(float)\n",
+    "    r_t = np.array([rotation_matrix(t, Omega, (n_x, n_y, n_z)) @ r_0 for t in times])\n",
+    "    decay_factor = np.exp(-alpha * times)\n",
+    "    return r_t * decay_factor[:, None]\n",
     "\n",
     "\n",
     "def residual(params, times, data):\n",
-    "    Omega, theta, phi = params\n",
-    "    return (simulate_rotation(times, Omega, theta, phi) - data).flatten()\n",
+    "    Omega, theta, phi, alpha = params\n",
+    "    return (simulate_rotation(times, Omega, theta, phi, alpha) - data).flatten()\n",
     "\n",
     "\n",
-    "initial_guess = [4 * np.pi, 0, 0]\n",
+    "initial_guess = [4 * np.pi, 0, 0, 0]\n",
     "result = least_squares(residual, initial_guess, args=(times, data))\n",
     "result.x"
    ]
@@ -294,7 +302,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "3.9.18",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },

--- a/docs/examples/experiment/8_cr_calibration.ipynb
+++ b/docs/examples/experiment/8_cr_calibration.ipynb
@@ -2,7 +2,7 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -21,9 +21,8 @@
     "from qubex.experiment import Experiment\n",
     "\n",
     "ex = Experiment(\n",
-    "    chip_id=\"16Q\",\n",
+    "    chip_id=\"xxQ\",\n",
     "    qubits=[8, 10],\n",
-    "    config_dir=\"/home/shared/config\",\n",
     ")"
    ]
   },
@@ -53,40 +52,46 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 5,
+   "execution_count": 28,
    "metadata": {},
    "outputs": [],
    "source": [
     "cr_control = ex.qubit_labels[0]\n",
     "cr_target = ex.qubit_labels[1]\n",
     "cr_pair = (cr_control, cr_target)\n",
-    "\n",
+    "cr_label = f\"{cr_control}-{cr_target}\""
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "result_cr = ex.obtain_cr_params(\n",
+    "    *cr_pair,\n",
+    "    flattop_range=np.arange(0, 401, 10),\n",
+    "    cr_amplitude=1.0,\n",
+    "    cr_ramptime=50,\n",
+    "    n_iterations=2,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "cr_duration = 100\n",
-    "cr_ramptime = 40"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result_cr = ex.obtain_cr_params(*cr_pair)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result_cr_calib = ex.calibrate_zx90_by_amplitude(\n",
-    "    *cr_pair,\n",
-    "    duration=cr_duration,\n",
-    "    ramptime=cr_ramptime,\n",
-    ")\n",
+    "cr_ramptime = 40\n",
     "\n",
-    "root = result_cr_calib[\"root\"]"
+    "result_cr_calib = ex.calibrate_zx90(\n",
+    "    *cr_pair,\n",
+    "    duration=cr_duration,\n",
+    "    ramptime=cr_ramptime,\n",
+    "    amplitude_range=np.linspace(0.4, 0.6, 50),\n",
+    ")"
    ]
   },
   {
@@ -95,11 +100,13 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result_cr_calib = ex.calibrate_zx90_by_amplitude(\n",
+    "center = result_cr_calib[\"calibrated_value\"]\n",
+    "\n",
+    "result_cr_calib = ex.calibrate_zx90(\n",
     "    *cr_pair,\n",
     "    duration=cr_duration,\n",
     "    ramptime=cr_ramptime,\n",
-    "    amplitude_range=np.linspace(root - 0.1, root + 0.1, 100),\n",
+    "    amplitude_range=np.linspace(center - 0.1, center + 0.1, 51),\n",
     ")"
    ]
   },
@@ -120,7 +127,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "result = ex.repeat_sequence(zx90, repetitions=4)"
+    "result = ex.repeat_sequence(zx90)"
    ]
   },
   {
@@ -147,20 +154,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "ex.measure_bell_state(*cr_pair)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "result_rb = ex.randomized_benchmarking(\n",
-    "    target=f\"{cr_control}-{cr_target}\",\n",
-    "    n_cliffords_range=np.arange(0, 21, 2),\n",
-    "    n_trials=30,\n",
-    ")"
+    "result_bell = ex.measure_bell_state(*cr_pair)"
    ]
   },
   {
@@ -170,18 +164,27 @@
    "outputs": [],
    "source": [
     "result_irb = ex.interleaved_randomized_benchmarking(\n",
-    "    target=f\"{cr_control}-{cr_target}\",\n",
+    "    target=cr_label,\n",
     "    n_cliffords_range=np.arange(0, 21, 2),\n",
     "    n_trials=30,\n",
     "    interleaved_waveform=zx90,\n",
     "    interleaved_clifford=ex.clifford[\"ZX90\"],\n",
     ")"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "ex.save_defaults()"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": ".venv",
    "language": "python",
    "name": "python3"
   },

--- a/src/qubex/analysis/fitting.py
+++ b/src/qubex/analysis/fitting.py
@@ -1786,7 +1786,7 @@ def fit_rotation(
     if bounds is None:
         bounds = (
             (0, 0, -np.pi, 0),
-            (np.inf, np.pi, np.pi, np.inf),
+            (np.inf, np.pi, np.pi, 1e-3),
         )
 
     result = least_squares(
@@ -1800,6 +1800,8 @@ def fit_rotation(
     Omega = fitted_params[0]
     theta = fitted_params[1]
     phi = fitted_params[2]
+    alpha = fitted_params[3]
+    tau = 1 / alpha * 1e-3  # μs
     Omega_x = Omega * np.sin(theta) * np.cos(phi)
     Omega_y = Omega * np.sin(theta) * np.sin(phi)
     Omega_z = Omega * np.cos(theta)
@@ -1862,6 +1864,14 @@ def fit_rotation(
             name="Z (fit)",
             line=dict(color=COLORS[2]),
         )
+    )
+    fig.add_annotation(
+        xref="paper",
+        yref="paper",
+        x=0.95,
+        y=0.95,
+        text=f"τ = {tau:.3f} μs",
+        showarrow=False,
     )
     fig.update_layout(
         title=title,
@@ -1936,6 +1946,7 @@ def fit_rotation(
     return {
         "Omega": np.array([Omega_x, Omega_y, Omega_z]),
         "fig": fig,
+        "fig3d": fig3d,
     }
 
 

--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -5091,8 +5091,6 @@ class Experiment:
         ...     plot=True,
         ... )
         """
-        n_cliffords_range = np.array(n_cliffords_range, dtype=int)
-
         if seeds is None:
             seeds = np.random.randint(0, 2**32, n_trials)
         else:
@@ -5112,6 +5110,8 @@ class Experiment:
             self._validate_rabi_params([target])
             if n_cliffords_range is None:
                 n_cliffords_range = np.arange(0, 1001, 100)
+
+        n_cliffords_range = np.array(n_cliffords_range, dtype=int)
 
         rb_results = []
         irb_results = []

--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -6683,7 +6683,7 @@ class Experiment:
         control_qubit: str,
         target_qubit: str,
         *,
-        flattop_range: ArrayLike = np.arange(0, 401, 10),
+        flattop_range: ArrayLike = np.arange(0, 401, 20),
         cr_amplitude: float = 1.0,
         cr_ramptime: float = 50,
         n_iterations: int = 2,
@@ -6850,6 +6850,108 @@ class Experiment:
             "hamiltonian_coeffs": hamiltonian_coeffs,
         }
 
+    def calibrate_zx90(
+        self,
+        control_qubit: str,
+        target_qubit: str,
+        *,
+        amplitude_range: ArrayLike | None = None,
+        duration_range: ArrayLike | None = None,
+        amplitude: float = 0.5,
+        duration: float = 200,
+        ramptime: float = 50,
+        degree: int = 3,
+        x180: TargetMap[Waveform] | Waveform | None = None,
+        use_zvalues: bool = False,
+        shots: int = CALIBRATION_SHOTS,
+        interval: int = DEFAULT_INTERVAL,
+        plot: bool = True,
+    ):
+        if amplitude_range is not None and duration_range is not None:
+            raise ValueError("Both amplitude_range and duration_range are specified.")
+        elif amplitude_range is not None:
+            sweep_parameter = "amplitude"
+        elif duration_range is not None:
+            sweep_parameter = "duration"
+        else:
+            raise ValueError(
+                "Either amplitude_range or duration_range must be specified."
+            )
+
+        def calibrate(sweep_parameter: str, initial_state: str):
+            if sweep_parameter == "amplitude":
+                return self.calibrate_zx90_by_amplitude(
+                    control_qubit=control_qubit,
+                    target_qubit=target_qubit,
+                    duration=duration,
+                    ramptime=ramptime,
+                    amplitude_range=amplitude_range,  # type: ignore
+                    initial_state=initial_state,
+                    degree=degree,
+                    x180=x180,
+                    use_zvalues=use_zvalues,
+                    store_params=False,
+                    shots=shots,
+                    interval=interval,
+                    plot=plot,
+                )
+            elif sweep_parameter == "duration":
+                return self.calibrate_zx90_by_duration(
+                    control_qubit=control_qubit,
+                    target_qubit=target_qubit,
+                    amplitude=amplitude,
+                    duration_range=duration_range,  # type: ignore
+                    ramptime=ramptime,
+                    initial_state=initial_state,
+                    degree=degree,
+                    x180=x180,
+                    use_zvalues=use_zvalues,
+                    store_params=False,
+                    shots=shots,
+                    interval=interval,
+                    plot=plot,
+                )
+            else:
+                raise ValueError("Invalid sweep parameter.")
+
+        result_0 = calibrate(sweep_parameter, "0")
+        result_1 = calibrate(sweep_parameter, "1")
+        calibrated_value = (result_0["root"] + result_1["root"]) / 2
+
+        cr_label = f"{control_qubit}-{target_qubit}"
+        cr_params = self._system_note.get(CR_PARAMS)[cr_label]
+        cr_ramptime = ramptime
+        cr_duration = calibrated_value if sweep_parameter == "duration" else duration
+        cr_amplitude = calibrated_value if sweep_parameter == "amplitude" else amplitude
+        cr_phase = cr_params["cr_pulse"]["phase"]
+        cr_cancel_ratio = cr_params["cr_cancel_ratio"]
+        cancel_amplitude = cr_amplitude * cr_cancel_ratio
+        cancel_phase = cr_params["cancel_pulse"]["phase"]
+
+        self._system_note.put(
+            CR_PARAMS,
+            {
+                cr_label: {
+                    "duration": cr_duration,
+                    "ramptime": cr_ramptime,
+                    "cr_pulse": {
+                        "amplitude": cr_amplitude,
+                        "phase": cr_phase,
+                    },
+                    "cancel_pulse": {
+                        "amplitude": cancel_amplitude,
+                        "phase": cancel_phase,
+                    },
+                },
+            },
+        )
+
+        return {
+            "calibrated_value": calibrated_value,
+            "result_0": result_0,
+            "result_1": result_1,
+        }
+
     def calibrate_zx90_by_amplitude(
         self,
         control_qubit: str,
@@ -6858,9 +6960,11 @@ class Experiment:
         duration: float = 100,
         ramptime: float = 20,
         amplitude_range: ArrayLike = np.linspace(0.0, 1.0, 51),
+        initial_state: str = "0",
         degree: int = 3,
         x180: TargetMap[Waveform] | Waveform | None = None,
         use_zvalues: bool = False,
+        store_params: bool = True,
         shots: int = CALIBRATION_SHOTS,
         interval: int = DEFAULT_INTERVAL,
         plot: bool = True,
@@ -6884,8 +6988,8 @@ class Experiment:
         elif isinstance(x180, Waveform):
             x180 = {control_qubit: x180}
 
-        sweep_result = self.sweep_parameter(
-            lambda amplitude: CrossResonance(
+        def ecr_sequence(amplitude: float) -> PulseSchedule:
+            ecr = CrossResonance(
                 control_qubit=control_qubit,
                 target_qubit=target_qubit,
                 cr_amplitude=amplitude,
@@ -6895,8 +6999,20 @@ class Experiment:
                 cancel_amplitude=amplitude * cr_cancel_ratio,
                 cancel_phase=cancel_phase,
                 echo=True,
-                pi_pulse=x180[target_qubit],
-            ),
+                pi_pulse=x180[control_qubit],
+            )
+            with PulseSchedule([control_qubit, cr_label, target_qubit]) as ps:
+                if initial_state != "0":
+                    ps.add(
+                        control_qubit,
+                        self.get_pulse_for_state(control_qubit, initial_state),
+                    )
+                    ps.barrier()
+                ps.call(ecr)
+            return ps
+
+        sweep_result = self.sweep_parameter(
+            ecr_sequence,
             sweep_range=amplitude_range,
             shots=shots,
             interval=interval,
@@ -6920,23 +7036,24 @@ class Experiment:
 
         amplitude = fit_result["root"]
 
-        self._system_note.put(
-            CR_PARAMS,
-            {
-                f"{control_qubit}-{target_qubit}": {
-                    "duration": duration,
-                    "ramptime": cr_ramptime,
-                    "cr_pulse": {
-                        "amplitude": amplitude,
-                        "phase": cr_phase,
-                    },
-                    "cancel_pulse": {
-                        "amplitude": amplitude * cr_cancel_ratio,
-                        "phase": cancel_phase,
+        if store_params:
+            self._system_note.put(
+                CR_PARAMS,
+                {
+                    cr_label: {
+                        "duration": duration,
+                        "ramptime": cr_ramptime,
+                        "cr_pulse": {
+                            "amplitude": amplitude,
+                            "phase": cr_phase,
+                        },
+                        "cancel_pulse": {
+                            "amplitude": amplitude * cr_cancel_ratio,
+                            "phase": cancel_phase,
+                        },
                     },
                 },
-            },
-        )
+            )
 
         return {
             "amplitude_range": amplitude_range,
@@ -6946,15 +7063,17 @@ class Experiment:
 
     def calibrate_zx90_by_duration(
         self,
-        *,
         control_qubit: str,
         target_qubit: str,
+        *,
         amplitude: float = 0.5,
         duration_range: ArrayLike = np.arange(100, 201, 2),
         ramptime: float = 20,
+        initial_state: str = "0",
         degree: int = 3,
         x180: TargetMap[Waveform] | Waveform | None = None,
         use_zvalues: bool = False,
+        store_params: bool = True,
         shots: int = CALIBRATION_SHOTS,
         interval: int = DEFAULT_INTERVAL,
         plot: bool = True,
@@ -6978,8 +7097,8 @@ class Experiment:
         elif isinstance(x180, Waveform):
             x180 = {control_qubit: x180}
 
-        sweep_result = self.sweep_parameter(
-            lambda duration: CrossResonance(
+        def ecr_sequence(duration: float) -> PulseSchedule:
+            ecr = CrossResonance(
                 control_qubit=control_qubit,
                 target_qubit=target_qubit,
                 cr_amplitude=amplitude,
@@ -6989,8 +7108,20 @@ class Experiment:
                 cancel_amplitude=amplitude * cr_cancel_ratio,
                 cancel_phase=cancel_phase,
                 echo=True,
-                pi_pulse=x180[target_qubit],
-            ),
+                pi_pulse=x180[control_qubit],
+            )
+            with PulseSchedule([control_qubit, cr_label, target_qubit]) as ps:
+                if initial_state != "0":
+                    ps.add(
+                        control_qubit,
+                        self.get_pulse_for_state(control_qubit, initial_state),
+                    )
+                    ps.barrier()
+                ps.call(ecr)
+            return ps
+
+        sweep_result = self.sweep_parameter(
+            ecr_sequence,
             sweep_range=duration_range,
             shots=shots,
             interval=interval,
@@ -7012,25 +7143,26 @@ class Experiment:
             yaxis_title="Signal",
         )
 
-        duration = fit_result["root"]
+        duration = round(fit_result["root"] / SAMPLING_PERIOD) * SAMPLING_PERIOD
 
-        self._system_note.put(
-            CR_PARAMS,
-            {
-                f"{control_qubit}-{target_qubit}": {
-                    "duration": duration,
-                    "ramptime": cr_ramptime,
-                    "cr_pulse": {
-                        "amplitude": amplitude,
-                        "phase": cr_phase,
-                    },
-                    "cancel_pulse": {
-                        "amplitude": amplitude * cr_cancel_ratio,
-                        "phase": cancel_phase,
+        if store_params:
+            self._system_note.put(
+                CR_PARAMS,
+                {
+                    cr_label: {
+                        "duration": duration,
+                        "ramptime": cr_ramptime,
+                        "cr_pulse": {
+                            "amplitude": amplitude,
+                            "phase": cr_phase,
+                        },
+                        "cancel_pulse": {
+                            "amplitude": amplitude * cr_cancel_ratio,
+                            "phase": cancel_phase,
+                        },
                     },
                 },
-            },
-        )
+            )
 
         return {
             "duration_range": duration_range,
@@ -7049,16 +7181,20 @@ class Experiment:
         cancel_amplitude: float | None = None,
         cancel_phase: float | None = None,
         echo: bool = True,
-        x180: Waveform | None = None,
+        x180: TargetMap[Waveform] | Waveform | None = None,
     ) -> PulseSchedule:
         cr_label = f"{control_qubit}-{target_qubit}"
         cr_params = self._system_note.get(CR_PARAMS)[cr_label]
 
         if x180 is None:
             if control_qubit in self.drag_pi_pulse:
-                x180 = self.drag_pi_pulse[control_qubit]
+                pi_pulse = self.drag_pi_pulse[control_qubit]
             else:
-                x180 = self.pi_pulse[control_qubit]
+                pi_pulse = self.pi_pulse[control_qubit]
+        elif isinstance(x180, Waveform):
+            pi_pulse = x180
+        else:
+            pi_pulse = x180[control_qubit]
 
         if cr_amplitude is not None and cancel_amplitude is None:
             cr_cancel_ratio = (
@@ -7077,38 +7213,23 @@ class Experiment:
             cancel_amplitude=cancel_amplitude or cr_params["cancel_pulse"]["amplitude"],
             cancel_phase=cancel_phase or cr_params["cancel_pulse"]["phase"],
             echo=echo,
-            pi_pulse=x180,
+            pi_pulse=pi_pulse,
         )
 
     def cnot(
         self,
         control_qubit: str,
         target_qubit: str,
-        cr_duration: float | None = None,
-        cr_ramptime: float | None = None,
-        cr_amplitude: float | None = None,
-        cr_phase: float | None = None,
-        cancel_amplitude: float | None = None,
-        cancel_phase: float | None = None,
-        echo: bool = True,
-        x180: Waveform | None = None,
+        zx90: PulseSchedule | None = None,
         x90: Waveform | None = None,
     ) -> PulseSchedule:
         cr_label = f"{control_qubit}-{target_qubit}"
-        zx90 = self.zx90(
-            control_qubit=control_qubit,
-            target_qubit=target_qubit,
-            cr_duration=cr_duration,
-            cr_ramptime=cr_ramptime,
-            cr_amplitude=cr_amplitude,
-            cr_phase=cr_phase,
-            cancel_amplitude=cancel_amplitude,
-            cancel_phase=cancel_phase,
-            echo=echo,
-            x180=x180,
-        )
+        zx90 = zx90 or self.zx90(control_qubit, target_qubit)
         if x90 is None:
-            x90 = self.hpi_pulse[target_qubit]
+            if target_qubit in self.drag_hpi_pulse:
+                x90 = self.drag_hpi_pulse[target_qubit]
+            else:
+                x90 = self.hpi_pulse[target_qubit]
 
         with PulseSchedule([control_qubit, cr_label, target_qubit]) as ps:
             ps.call(zx90)
@@ -7121,8 +7242,7 @@ class Experiment:
         self,
         control_qubit: str,
         target_qubit: str,
-        x90: Waveform | None = None,
-        x180: Waveform | None = None,
+        zx90: PulseSchedule | None = None,
         shots: int = DEFAULT_SHOTS,
         interval: int = DEFAULT_INTERVAL,
         plot: bool = True,
@@ -7133,8 +7253,7 @@ class Experiment:
         cnot = self.cnot(
             control_qubit=control_qubit,
             target_qubit=target_qubit,
-            x90=x90,
-            x180=x180,
+            zx90=zx90,
         )
         result = self.measure(
             cnot,

--- a/src/qubex/version.py
+++ b/src/qubex/version.py
@@ -1,7 +1,7 @@
 import importlib.metadata
 import subprocess
 
-VERSION = "1.2.1"
+VERSION = "1.2.2"
 
 
 def get_version():


### PR DESCRIPTION
This pull request includes significant updates to the `docs/examples/analysis/rotation3d.ipynb`, `docs/examples/experiment/8_cr_calibration.ipynb`, `src/qubex/analysis/fitting.py`, and `src/qubex/experiment/experiment.py` files. The changes enhance the functionality of the rotation simulation and calibration processes, introduce decay factors, and update benchmarking methods.

Enhancements to rotation simulation:

* [`docs/examples/analysis/rotation3d.ipynb`](diffhunk://#diff-cd4213e3c99ba75a8e26f9635b5a48a0327f70e149680d6fad5ef0d83920b258L142-R159): Added decay factor to `create_data` and `simulate_rotation` functions to account for exponential decay in the rotation simulation. [[1]](diffhunk://#diff-cd4213e3c99ba75a8e26f9635b5a48a0327f70e149680d6fad5ef0d83920b258L142-R159) [[2]](diffhunk://#diff-cd4213e3c99ba75a8e26f9635b5a48a0327f70e149680d6fad5ef0d83920b258L179-R204)
* [`src/qubex/analysis/fitting.py`](diffhunk://#diff-5b041a85d59c4866fe77ab631c33114b0c360ca2924adbca23d3f0ca95876333R1745): Updated `rotate` function to include an `alpha` parameter for decay rate and modified the `residuals` function to accommodate the new parameter. [[1]](diffhunk://#diff-5b041a85d59c4866fe77ab631c33114b0c360ca2924adbca23d3f0ca95876333R1745) [[2]](diffhunk://#diff-5b041a85d59c4866fe77ab631c33114b0c360ca2924adbca23d3f0ca95876333R1760-R1768) [[3]](diffhunk://#diff-5b041a85d59c4866fe77ab631c33114b0c360ca2924adbca23d3f0ca95876333L1780-R1789)

Updates to calibration process:

* [`docs/examples/experiment/8_cr_calibration.ipynb`](diffhunk://#diff-38defad89ac7c9d6a5f9f6039ce3da525dbad641e7a19be7dbe5f860e7748e6cL24-L26): Modified the calibration process to use a new `cr_label` and updated the `calibrate_zx90` function to handle additional parameters. [[1]](diffhunk://#diff-38defad89ac7c9d6a5f9f6039ce3da525dbad641e7a19be7dbe5f860e7748e6cL24-L26) [[2]](diffhunk://#diff-38defad89ac7c9d6a5f9f6039ce3da525dbad641e7a19be7dbe5f860e7748e6cL83-R94) [[3]](diffhunk://#diff-38defad89ac7c9d6a5f9f6039ce3da525dbad641e7a19be7dbe5f860e7748e6cL98-R109)

Improvements to benchmarking methods:

* [`src/qubex/experiment/experiment.py`](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8L4941-R4956): Refactored the `randomized_benchmarking` and `interleaved_randomized_benchmarking` functions to better handle 1Q and 2Q gates, ensuring correct parameter validation and range settings. [[1]](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8L4941-R4956) [[2]](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8L5092-L5093) [[3]](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8L5104-R5187)

Additional changes:

* [`docs/examples/analysis/rotation3d.ipynb`](diffhunk://#diff-cd4213e3c99ba75a8e26f9635b5a48a0327f70e149680d6fad5ef0d83920b258R8-R17): Added `%autoreload` magic commands to ensure that the latest versions of modules are loaded automatically.
* [`docs/examples/experiment/8_cr_calibration.ipynb`](diffhunk://#diff-38defad89ac7c9d6a5f9f6039ce3da525dbad641e7a19be7dbe5f860e7748e6cL172-R187): Updated the kernel display name to `.venv` to reflect the virtual environment being used.