### PR TITLE
v1.2.5

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-backend = ["qubecalib @ git+https://github.com/qiqb-osaka/qube-calib.git@3.1.3"]
+backend = ["qubecalib @ git+https://github.com/qiqb-osaka/qube-calib.git@3.1.4"]
 
 [tool.setuptools.dynamic]
 version = { attr = "qubex.version.get_version" }

--- a/src/qubex/analysis/fitting.py
+++ b/src/qubex/analysis/fitting.py
@@ -457,6 +457,8 @@ def fit_rabi(
     offset = popt[3]
     frequency = omega / (2 * np.pi)
 
+    tau = popt[4] if is_damped else None
+
     # print(f"Phase shift: {angle:.3g} rad, {angle * 180 / np.pi:.3g} deg")
     print(f"Rabi frequency: {frequency * 1e3:.6g} MHz")
     # print(f"Rabi period: {1 / frequency:.3g} ns")
@@ -490,7 +492,8 @@ def fit_rabi(
             yref="paper",
             x=0.95,
             y=0.95,
-            text=f"f = {frequency * 1e3:.2f} MHz",
+            text=f"f = {frequency * 1e3:.2f} MHz"
+            + (f", τ = {tau * 1e-3:.2f} μs" if tau else ""),
             showarrow=False,
         )
         fig.update_layout(

--- a/src/qubex/analysis/fitting.py
+++ b/src/qubex/analysis/fitting.py
@@ -869,6 +869,7 @@ def fit_rb(
     x: npt.NDArray[np.int64],
     y: npt.NDArray[np.float64],
     error_y: npt.NDArray[np.float64] | None = None,
+    dimension: int = 2,
     p0=None,
     bounds=None,
     plot: bool = True,
@@ -891,6 +892,8 @@ def fit_rb(
         Amplitude data for the decay.
     error_y : npt.NDArray[np.float64], optional
         Error data for the decay.
+    dimension : int, optional
+        Dimension of the Hilbert space.
     p0 : optional
         Initial guess for the fitting parameters.
     bounds : optional
@@ -934,7 +937,6 @@ def fit_rb(
     A, p, C = popt
     A_err, p_err, C_err = np.sqrt(np.diag(pcov))
 
-    dimension = 2
     depolarizing_rate = 1 - p
     avg_gate_error = (dimension - 1) * (1 - p) / dimension
     avg_gate_fidelity = 1 - avg_gate_error

--- a/src/qubex/clifford/clifford_generator.py
+++ b/src/qubex/clifford/clifford_generator.py
@@ -16,11 +16,14 @@ CLIFFORD_LIST_2Q = "clifford_list_2q"
 
 
 class CliffordGenerator:
-    generators = {
+    cliffords = {
         "I": Clifford.I(),
         "X90": Clifford.X90(),
         "Y90": Clifford.Y90(),
         "Z90": Clifford.Z90(),
+        "X180": Clifford.X180(),
+        "Y180": Clifford.Y180(),
+        "Z180": Clifford.Z180(),
         "II": Clifford.II(),
         "IX90": Clifford.IX90(),
         "IY90": Clifford.IY90(),
@@ -559,9 +562,9 @@ class CliffordGenerator:
         for item in data:
             sequence = []
             for gate in item["sequence"]:
-                if gate not in self.generators:
+                if gate not in self.cliffords:
                     raise ValueError("Invalid gate name.")
-                sequence.append(self.generators[gate])
+                sequence.append(self.cliffords[gate])
 
             map = {operator: Pauli(*item["map"][operator]) for operator in item["map"]}
 

--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -6875,6 +6875,7 @@ class Experiment:
         amplitude: float = 0.5,
         duration: float = 200,
         ramptime: float = 50,
+        n_repetitions: int = 1,
         degree: int = 3,
         x180: TargetMap[Waveform] | Waveform | None = None,
         use_zvalues: bool = False,
@@ -6902,6 +6903,7 @@ class Experiment:
                     ramptime=ramptime,
                     amplitude_range=amplitude_range,  # type: ignore
                     initial_state=initial_state,
+                    n_repetitions=n_repetitions,
                     degree=degree,
                     x180=x180,
                     use_zvalues=use_zvalues,
@@ -6918,6 +6920,7 @@ class Experiment:
                     duration_range=duration_range,  # type: ignore
                     ramptime=ramptime,
                     initial_state=initial_state,
+                    n_repetitions=n_repetitions,
                     degree=degree,
                     x180=x180,
                     use_zvalues=use_zvalues,
@@ -6976,6 +6979,7 @@ class Experiment:
         ramptime: float = 20,
         amplitude_range: ArrayLike = np.linspace(0.0, 1.0, 51),
         initial_state: str = "0",
+        n_repetitions: int = 1,
         degree: int = 3,
         x180: TargetMap[Waveform] | Waveform | None = None,
         use_zvalues: bool = False,
@@ -7015,7 +7019,7 @@ class Experiment:
                 cancel_phase=cancel_phase,
                 echo=True,
                 pi_pulse=x180[control_qubit],
-            )
+            ).repeated(n_repetitions)
             with PulseSchedule([control_qubit, cr_label, target_qubit]) as ps:
                 if initial_state != "0":
                     ps.add(
@@ -7085,6 +7089,7 @@ class Experiment:
         duration_range: ArrayLike = np.arange(100, 201, 2),
         ramptime: float = 20,
         initial_state: str = "0",
+        n_repetitions: int = 1,
         degree: int = 3,
         x180: TargetMap[Waveform] | Waveform | None = None,
         use_zvalues: bool = False,
@@ -7124,7 +7129,7 @@ class Experiment:
                 cancel_phase=cancel_phase,
                 echo=True,
                 pi_pulse=x180[control_qubit],
-            )
+            ).repeated(n_repetitions)
             with PulseSchedule([control_qubit, cr_label, target_qubit]) as ps:
                 if initial_state != "0":
                     ps.add(

--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -1787,6 +1787,7 @@ class Experiment:
         time_range: ArrayLike = RABI_TIME_RANGE,
         amplitudes: dict[str, float] | None = None,
         frequencies: dict[str, float] | None = None,
+        is_damped: bool = False,
         shots: int = CALIBRATION_SHOTS,
         interval: int = DEFAULT_INTERVAL,
         plot: bool = True,
@@ -1805,6 +1806,8 @@ class Experiment:
             Amplitudes of the control pulses. Defaults to None.
         frequencies : dict[str, float], optional
             Frequencies of the qubits. Defaults to None.
+        is_damped : bool, optional
+            Whether to fit as a damped oscillation. Defaults to False.
         shots : int, optional
             Number of shots. Defaults to CALIBRATION_SHOTS.
         interval : int, optional
@@ -1835,6 +1838,7 @@ class Experiment:
             amplitudes=amplitudes,
             time_range=time_range,
             frequencies=frequencies,
+            is_damped=is_damped,
             shots=shots,
             interval=interval,
             plot=plot,
@@ -1847,6 +1851,7 @@ class Experiment:
         targets: Collection[str] | None = None,
         *,
         time_range: ArrayLike = RABI_TIME_RANGE,
+        is_damped: bool = False,
         shots: int = CALIBRATION_SHOTS,
         interval: int = DEFAULT_INTERVAL,
         plot: bool = True,
@@ -1860,6 +1865,8 @@ class Experiment:
             Target labels to check the Rabi oscillation.
         time_range : ArrayLike, optional
             Time range of the experiment in ns. Defaults to RABI_TIME_RANGE.
+        is_damped : bool, optional
+            Whether to fit as a damped oscillation. Defaults to False.
         shots : int, optional
             Number of shots. Defaults to CALIBRATION_SHOTS.
         interval : int, optional
@@ -1895,6 +1902,7 @@ class Experiment:
             data = self.ef_rabi_experiment(
                 amplitudes={label: amplitudes[label]},
                 time_range=time_range,
+                is_damped=is_damped,
                 shots=shots,
                 interval=interval,
                 store_params=True,
@@ -1916,6 +1924,7 @@ class Experiment:
         time_range: ArrayLike = RABI_TIME_RANGE,
         frequencies: dict[str, float] | None = None,
         detuning: float | None = None,
+        is_damped: bool = False,
         shots: int = DEFAULT_SHOTS,
         interval: int = DEFAULT_INTERVAL,
         plot: bool = True,
@@ -1934,6 +1943,8 @@ class Experiment:
             Frequencies of the qubits. Defaults to None.
         detuning : float, optional
             Detuning of the control frequency. Defaults to None.
+        is_damped : bool, optional
+            Whether to fit as a damped oscillation. Defaults to False.
         shots : int, optional
             Number of shots. Defaults to DEFAULT_SHOTS.
         interval : int, optional
@@ -2002,6 +2013,7 @@ class Experiment:
                 times=data.sweep_range,
                 data=data.data,
                 plot=plot,
+                is_damped=is_damped,
             )
             for target, data in sweep_data.items()
         }
@@ -2038,6 +2050,7 @@ class Experiment:
         time_range: ArrayLike,
         frequencies: dict[str, float] | None = None,
         detuning: float | None = None,
+        is_damped: bool = False,
         shots: int = DEFAULT_SHOTS,
         interval: int = DEFAULT_INTERVAL,
         plot: bool = True,
@@ -2056,6 +2069,8 @@ class Experiment:
             Frequencies of the qubits. Defaults to None.
         detuning : float, optional
             Detuning of the control frequency. Defaults to None.
+        is_damped : bool, optional
+            Whether to fit as a damped oscillation. Defaults to False.
         shots : int, optional
             Number of shots. Defaults to DEFAULT_SHOTS.
         interval : int, optional
@@ -2133,6 +2148,7 @@ class Experiment:
                 times=data.sweep_range,
                 data=data.data,
                 plot=plot,
+                is_damped=is_damped,
             )
             for target, data in sweep_data.items()
         }

--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -3826,7 +3826,7 @@ class Experiment:
             def t1_sequence(T: int) -> PulseSchedule:
                 with PulseSchedule(subgroup) as ps:
                     for target in subgroup:
-                        ps.add(target, self.pi_pulse[target])
+                        ps.add(target, self.hpi_pulse[target].repeated(2))
                         ps.add(target, Blank(T))
                 return ps
 

--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -3289,7 +3289,7 @@ class Experiment:
         targets: Collection[str] | None = None,
         *,
         pulse_type: Literal["pi", "hpi"] = "hpi",
-        beta_range: ArrayLike = np.linspace(-0.2, 1.0, 21),
+        beta_range: ArrayLike = np.linspace(-0.5, 1.5, 41),
         n_turns: int = 1,
         degree: int = 3,
         shots: int = CALIBRATION_SHOTS,
@@ -3305,7 +3305,7 @@ class Experiment:
         pulse_type : Literal["pi", "hpi"]
             Type of the pulse to calibrate.
         beta_range : ArrayLike, optional
-            Range of the beta to sweep. Defaults to np.linspace(-0.2, 1.0, 21).
+            Range of the beta to sweep. Defaults to np.linspace(-0.5, 1.5, 41).
         n_turns : int, optional
             Number of turns to |0> state. Defaults to 1.
         degree : int, optional
@@ -3585,7 +3585,7 @@ class Experiment:
         n_turns: int = 1,
         n_iterations: int = 2,
         calibrate_beta: bool = True,
-        beta_range: ArrayLike = np.linspace(-0.2, 1.0, 21),
+        beta_range: ArrayLike = np.linspace(-0.5, 1.5, 41),
         drag_coeff: float = DRAG_COEFF,
         shots: int = CALIBRATION_SHOTS,
         interval: int = DEFAULT_INTERVAL,
@@ -3606,7 +3606,7 @@ class Experiment:
         calibrate_beta : bool, optional
             Whether to calibrate the DRAG beta. Defaults to True.
         beta_range : ArrayLike, optional
-            Range of the beta to sweep. Defaults to np.linspace(-0.2, 1.0, 21).
+            Range of the beta to sweep. Defaults to np.linspace(-0.5, 1.5, 41).
         drag_coeff : float, optional
             DRAG coefficient. Defaults to DRAG_COEFF.
         shots : int, optional
@@ -3672,7 +3672,7 @@ class Experiment:
         n_turns: int = 1,
         n_iterations: int = 2,
         calibrate_beta: bool = True,
-        beta_range: ArrayLike = np.linspace(-0.2, 1.0, 21),
+        beta_range: ArrayLike = np.linspace(-0.5, 1.5, 41),
         drag_coeff: float = DRAG_COEFF,
         degree: int = 3,
         shots: int = CALIBRATION_SHOTS,
@@ -3694,7 +3694,7 @@ class Experiment:
         calibrate_beta : bool, optional
             Whether to calibrate the DRAG beta. Defaults to False.
         beta_range : ArrayLike, optional
-            Range of the beta to sweep. Defaults to np.linspace(-0.2, 1.0, 21).
+            Range of the beta to sweep. Defaults to np.linspace(-0.5, 1.5, 41).
         drag_coeff : float, optional
             DRAG coefficient. Defaults to DRAG_COEFF.
         degree : int, optional
@@ -4872,6 +4872,7 @@ class Experiment:
             target=target,
             x=n_cliffords_range,
             y=np.array(fidelities),
+            dimension=4,
             title="Randomized benchmarking",
             xaxis_title="Number of Cliffords",
             yaxis_title="Normalized signal",
@@ -5004,6 +5005,7 @@ class Experiment:
             x=n_cliffords_range,
             y=mean,
             error_y=std,
+            dimension=4 if is_2q else 2,
             plot=plot,
             title="Randomized benchmarking",
             xaxis_title="Number of Cliffords",
@@ -5206,6 +5208,7 @@ class Experiment:
             x=n_cliffords_range,
             y=rb_mean,
             error_y=rb_std,
+            dimension=4 if is_2q else 2,
             plot=plot,
         )
         A_rb = rb_fit_result["A"]
@@ -5220,6 +5223,7 @@ class Experiment:
             x=n_cliffords_range,
             y=irb_mean,
             error_y=irb_std,
+            dimension=4 if is_2q else 2,
             plot=plot,
             title="Interleaved randomized benchmarking",
         )
@@ -5227,7 +5231,7 @@ class Experiment:
         p_irb = irb_fit_result["p"]
         C_irb = irb_fit_result["C"]
 
-        dimension = 2**2 if is_2q else 2
+        dimension = 4 if is_2q else 2
         gate_error = (dimension - 1) * (1 - (p_irb / p_rb)) / dimension
         gate_fidelity = 1 - gate_error
 

--- a/src/qubex/version.py
+++ b/src/qubex/version.py
@@ -1,7 +1,7 @@
 import importlib.metadata
 import subprocess
 
-VERSION = "1.2.4"
+VERSION = "1.2.5"
 
 
 def get_version():


### PR DESCRIPTION
This pull request includes several updates and enhancements to the `qubex` package, primarily focusing on the addition of new parameters for fitting and calibration functions, as well as a minor dependency update. The most important changes involve the introduction of the `is_damped` parameter for Rabi oscillation fitting, the addition of the `dimension` parameter for randomized benchmarking, and the renaming of the `generators` attribute to `cliffords` in the `CliffordGenerator` class.

### Enhancements to fitting functions:

* [`src/qubex/analysis/fitting.py`](diffhunk://#diff-5b041a85d59c4866fe77ab631c33114b0c360ca2924adbca23d3f0ca95876333R460-R461): Added `tau` parameter to `fit_rabi` function and updated the plot text to include `τ` if `is_damped` is true. [[1]](diffhunk://#diff-5b041a85d59c4866fe77ab631c33114b0c360ca2924adbca23d3f0ca95876333R460-R461) [[2]](diffhunk://#diff-5b041a85d59c4866fe77ab631c33114b0c360ca2924adbca23d3f0ca95876333L493-R496)
* [`src/qubex/analysis/fitting.py`](diffhunk://#diff-5b041a85d59c4866fe77ab631c33114b0c360ca2924adbca23d3f0ca95876333R875): Introduced `dimension` parameter to `fit_rb` function and updated the docstring accordingly. [[1]](diffhunk://#diff-5b041a85d59c4866fe77ab631c33114b0c360ca2924adbca23d3f0ca95876333R875) [[2]](diffhunk://#diff-5b041a85d59c4866fe77ab631c33114b0c360ca2924adbca23d3f0ca95876333R898-R899)

### Updates to `CliffordGenerator` class:

* [`src/qubex/clifford/clifford_generator.py`](diffhunk://#diff-0da36e6a2154aa2e52253f521c5df9e6f9c83271a81e89b967e00112079c876eL19-R26): Renamed `generators` attribute to `cliffords` and updated the `load` method to reflect this change. [[1]](diffhunk://#diff-0da36e6a2154aa2e52253f521c5df9e6f9c83271a81e89b967e00112079c876eL19-R26) [[2]](diffhunk://#diff-0da36e6a2154aa2e52253f521c5df9e6f9c83271a81e89b967e00112079c876eL562-R567)
* [`src/qubex/experiment/experiment.py`](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8L623-R623): Updated references to `generators` to `cliffords` in the `clifford` property method.

### New parameters for experiment functions:

* [`src/qubex/experiment/experiment.py`](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8R1790): Added `is_damped` parameter to multiple Rabi-related functions (`obtain_rabi_params`, `obtain_ef_rabi_params`, `rabi_experiment`, `ef_rabi_experiment`). [[1]](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8R1790) [[2]](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8R1854) [[3]](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8R1927) [[4]](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8R2053)
* [`src/qubex/experiment/experiment.py`](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8R3189): Added `spectator_state` parameter to `calibrate_drag_amplitude` and `calibrate_drag_beta` functions. [[1]](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8R3189) [[2]](diffhunk://#diff-d31b78f695be82f567eaa4312e1e216b2ac21518eba8993d27fb5d3704656ef8R3340-R3343)

### Dependency update:

* [`pyproject.toml`](diffhunk://#diff-50c86b7ed8ac2cf95bd48334961bf0530cdc77b5a56f852c5c61b89d735fd711L37-R37): Updated the `qubecalib` dependency from version 3.1.3 to 3.1.4.