### PR TITLE
fix: fix seed type for compatible with >=3.11

### DIFF
--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -5073,9 +5073,9 @@ class Experiment:
         """
 
         if seeds is None:
-            seeds = np.random.randint(0, 2**32, n_trials)
+            seeds = np.random.randint(0, 2**32, n_trials).tolist()
         else:
-            seeds = np.array(seeds, dtype=int)
+            seeds = [int(s) for s in np.array(seeds, dtype=int)]
             if len(seeds) != n_trials:
                 raise ValueError(
                     "The number of seeds must be equal to the number of trials."
@@ -5237,9 +5237,9 @@ class Experiment:
         ... )
         """
         if seeds is None:
-            seeds = np.random.randint(0, 2**32, n_trials)
+            seeds = np.random.randint(0, 2**32, n_trials).tolist()
         else:
-            seeds = np.array(seeds, dtype=int)
+            seeds = [int(s) for s in np.array(seeds, dtype=int)]
             if len(seeds) != n_trials:
                 raise ValueError(
                     "The number of seeds must be equal to the number of trials."


### PR DESCRIPTION
## Ticket

#102 

## Test

checked with following code:

```python
result = ex.randomized_benchmarking(
    target=target,
    n_cliffords_range=np.arange(0, 1001, 100),
    n_trials=30,
    x90=drag_hpi,
    save_image=True,
)
```

