### PR TITLE
fix: drag_pi_pulse and drag_half_pi_pulse filterling by self._qubits

### DIFF
--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -461,28 +461,33 @@ class Experiment(
 
         if calib_amplitude is None or calib_beta is None:
             return {}
+
         return {
             target: Drag(
                 duration=DRAG_HPI_DURATION,
                 amplitude=calib_amplitude[target],
                 beta=calib_beta[target],
             )
-            for target in calib_amplitude
+            for target in self._qubits
+            if target in calib_amplitude and target in calib_beta
         }
 
     @property
     def drag_pi_pulse(self) -> dict[str, Waveform]:
         calib_amplitude: dict[str, float] = self._system_note.get(DRAG_PI_AMPLITUDE)
         calib_beta: dict[str, float] = self._system_note.get(DRAG_PI_BETA)
+
         if calib_amplitude is None or calib_beta is None:
             return {}
+
         return {
             target: Drag(
                 duration=DRAG_PI_DURATION,
                 amplitude=calib_amplitude[target],
                 beta=calib_beta[target],
             )
-            for target in calib_amplitude
+            for target in self._qubits
+            if target in calib_amplitude and target in calib_beta
         }
 
     @property


### PR DESCRIPTION

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
	- Improved data validation for pulse generation by filtering targets with valid calibration data.
	- Enhanced robustness of `drag_hpi_pulse` and `drag_pi_pulse` properties to prevent potential errors from missing calibration information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->


## Test

checked with following code.

```
result = ex.repeat_sequence(
	ex.drag_hpi_pulse
)
```