### PR TITLE
Add get_memory method to MeasureResult class

### DIFF
--- a/src/qubex/measurement/measurement_result.py
+++ b/src/qubex/measurement/measurement_result.py
@@ -284,17 +284,29 @@ class MeasureResult:
             ]
         )
 
+    def get_memory(
+        self,
+        targets: Collection[str] | None = None,
+        *,
+        threshold: float | None = None,
+    ) -> list[str]:
+        """
+        Returns memory: list of bitstrings (e.g., ['0110', '1010', ...])
+        representing each shot's classified result.
+        """
+        classified_data = self.get_classified_data(targets, threshold=threshold)
+        return ["".join(map(str, row)) for row in classified_data]
+
     def get_counts(
         self,
         targets: Collection[str] | None = None,
         *,
         threshold: float | None = None,
     ) -> Counter:
-        classified_data = self.get_classified_data(targets, threshold=threshold)
         classified_labels = np.array(
-            ["".join(map(str, row)) for row in classified_data]
+            self.get_memory(targets, threshold=threshold)
         )
-        return Counter(classified_labels)
+        return Counter(classified_labels)    
 
     def get_probabilities(
         self,


### PR DESCRIPTION
The commit adds a new method `get_memory` to extract raw measurement results as bitstrings, improving code reusability by factoring out functionality previously embedded in `get_counts`. This change makes the raw measurement data directly accessible to users.

```python
memory = meas_res.get_memory()
print(len(memory), "shots in total")
print(memory)
```

```bash
1024 shots in total
['11', '11', '01', '01', '10', '11', '01', '11', '11', '00', '00', '00', '00', '01', '00', '00', '10', '10', '11', '11', '00', '00', '00', '11', '00', '11', '10', '10', '11', '00', '00', '00', '00', '11', '11', '00', '11', '00', '11', '10', '00', '00', '11', '01', '00', '00', '11', '11', '11', '00', '11', '00', '00', '00', '00', '10', '00', '11', '11', '00', '00', '10', '11', '00', '00', '00', '10', '00', '00', '00', '00', '10', '11', '00', '11', '01', '00', '00', '11', '11', '11', '00', '11', '00', '01', '10', '01', '11', '01', '00', '01', '00', '11', '00', '10', '11', '00', '10', '10', '00', '01', '11', '00', '11', '00', '11', '10', '00', '11', '11', '00', '10', '11', '11', '11', '00', '00', '00', '01', '11', '00', '00', '11', '11', '11', '00', '10', '00', '00', '01', '11', '01', '00', '00', '11', '00', '00', '00', '11', '00', '11', '01', '11', '00', '01', '10', '00', '00', '10', '00', '10', '00', '00', '00', '00', '11', '00', '10', '10', '10', '11', '10', '00', '00', '11', '01', '11', '11', '11', '10', '10', '11', '01', '00', '10', '10', '11', '00', '00', '00', '11', '10', '11', '11', '11', '10', '00', '00', '00', '00', '00', '11', '00', '11', '10', '00', '00', '00', '00', '11', '00', '00', '11', '11', '00', '01', '01', '01', '10', '00', '10', '00', '00', '00', '01', '00', '00', '11', '10', '01', '11', '10', '11', '00', '00', '11', '01', '11', '10', '10', '11', '00', '10', '11', '10', '00', '00', '11', '00', '01', '00', '01', '10', '10', '00', '00', '01', '11', '11', '11', '11', '00', '11', '00', '00', '10', '01', '01', '11', '10', '01', '00', '11', '11', '00', '00', '00', '11', '00', '11', '01', '01', '11', '11', '10', '00', '11', '11', '11', '00', '11', '01', '11', '11', '10', '11', '11', '00', '00', '01', '00', '11', '11', '11', '11', '00', '00', '11', '00', '01', '11', '11', '01', '01', '01', '00', '00', '11', '01', '00', '00', '00', '11', '01', '00', '11', '11', '00', '01', '10', '00', '01', '10', '11', '00', '01', '11', '00', '01', '01', '01', '00', '00', '00', '11', '11', '10', '00', '00', '11', '00', '00', '11', '00', '11', '11', '11', '00', '00', '10', '00', '00', '01', '00', '11', '10', '00', '00', '11', '00', '11', '00', '10', '11', '11', '11', '10', '00', '11', '00', '11', '00', '11', '01', '00', '10', '11', '11', '00', '10', '01', '01', '11', '01', '00', '10', '01', '10', '00', '10', '11', '00', '01', '00', '01', '00', '00', '01', '11', '11', '11', '01', '01', '11', '00', '00', '11', '10', '00', '11', '11', '00', '01', '10', '10', '10', '11', '00', '01', '00', '10', '10', '00', '01', '00', '11', '00', '11', '00', '10', '00', '11', '11', '00', '11', '01', '11', '00', '10', '10', '00', '10', '11', '00', '00', '00', '00', '11', '10', '00', '00', '00', '11', '11', '00', '01', '00', '11', '00', '11', '11', '00', '00', '11', '11', '11', '11', '01', '00', '11', '11', '00', '00', '10', '00', '11', '11', '11', '11', '11', '00', '10', '01', '00', '11', '10', '10', '01', '00', '01', '10', '10', '01', '11', '00', '00', '11', '11', '00', '10', '11', '11', '01', '00', '10', '00', '11', '11', '11', '11', '00', '11', '01', '01', '11', '11', '10', '00', '00', '01', '10', '01', '01', '11', '00', '11', '01', '11', '10', '11', '00', '01', '10', '00', '01', '00', '00', '00', '00', '11', '00', '10', '11', '00', '11', '11', '00', '00', '11', '01', '01', '10', '00', '10', '01', '00', '00', '10', '10', '01', '00', '00', '00', '00', '11', '00', '00', '00', '10', '10', '11', '11', '11', '00', '00', '11', '00', '00', '11', '10', '01', '00', '00', '00', '11', '11', '11', '01', '00', '11', '10', '11', '00', '10', '10', '00', '00', '10', '00', '10', '01', '00', '11', '10', '00', '00', '11', '00', '00', '00', '11', '00', '10', '01', '10', '11', '11', '10', '01', '00', '00', '01', '11', '00', '11', '00', '11', '00', '01', '00', '11', '00', '00', '00', '10', '00', '01', '10', '00', '11', '11', '00', '00', '00', '00', '01', '01', '00', '00', '11', '01', '00', '01', '11', '00', '11', '01', '00', '11', '11', '11', '00', '11', '00', '00', '11', '00', '00', '00', '00', '00', '00', '00', '00', '01', '00', '01', '01', '11', '11', '11', '10', '10', '00', '00', '00', '10', '00', '11', '00', '11', '00', '00', '00', '00', '00', '11', '00', '11', '00', '10', '11', '00', '00', '00', '11', '11', '11', '11', '00', '00', '10', '00', '01', '00', '10', '11', '11', '00', '11', '11', '01', '00', '00', '00', '00', '00', '00', '00', '11', '00', '00', '00', '11', '11', '10', '11', '00', '11', '10', '00', '11', '00', '00', '00', '00', '00', '00', '11', '11', '00', '11', '00', '11', '11', '11', '00', '10', '00', '10', '00', '10', '01', '10', '01', '11', '01', '00', '11', '11', '00', '11', '10', '11', '00', '00', '10', '00', '10', '11', '10', '10', '00', '00', '00', '00', '01', '11', '00', '01', '11', '00', '11', '00', '00', '00', '00', '11', '11', '11', '00', '11', '00', '01', '11', '00', '11', '11', '11', '00', '00', '00', '11', '00', '01', '11', '10', '01', '00', '11', '01', '01', '11', '10', '11', '11', '00', '01', '11', '00', '01', '11', '11', '00', '11', '11', '00', '10', '00', '01', '00', '11', '11', '00', '11', '00', '11', '00', '00', '10', '10', '00', '11', '10', '10', '10', '11', '01', '11', '10', '11', '11', '11', '11', '10', '01', '00', '00', '11', '11', '10', '10', '10', '00', '11', '00', '11', '01', '01', '11', '00', '01', '11', '11', '00', '00', '00', '01', '01', '11', '00', '00', '00', '11', '00', '00', '11', '10', '01', '10', '11', '10', '00', '00', '00', '11', '11', '11', '10', '11', '11', '10', '11', '00', '00', '11', '11', '00', '11', '10', '00', '01', '00', '10', '10', '10', '00', '11', '10', '01', '00', '11', '10', '00', '00', '00', '00', '10', '00', '11', '00', '00', '10', '00', '00', '00', '00', '01', '10', '10', '00', '11', '00', '00', '00', '11', '00', '10', '00', '11', '11', '11', '10', '11', '11', '11', '01', '01', '10', '00', '00', '11', '11', '00', '00', '01', '00', '00', '11', '11', '10', '11', '00', '00', '00', '00', '00', '11', '00', '01', '01', '00', '11', '00', '00', '00', '10', '01', '00', '10', '11', '00', '01', '00', '10', '10', '00', '01', '11', '10', '00', '00', '00', '11', '11', '11', '00', '01', '00', '11', '00', '11', '00', '01']
```