### PR TITLE
Add MLE density matrix fitting for quantum state tomography

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,8 @@ dependencies = [
     "scikit-learn ~= 1.0",
     "scipy ~= 1.0",
     "tqdm ~= 4.0",
+    "cvxopt~=1.3.2",
+    "cvxpy~=1.6.5",
 ]
 
 [project.optional-dependencies]

--- a/src/qubex/experiment/mixin/measurement_mixin.py
+++ b/src/qubex/experiment/mixin/measurement_mixin.py
@@ -1286,6 +1286,58 @@ class MeasurementMixin(
 
         return result_pops, result_errs
 
+    def mle_fit_density_matrix(self, expected_values: dict[str, float]) -> np.ndarray:
+        import cvxpy as cp
+        """
+        Fit a physical density matrix (Hermitian, PSD, trace=1) using
+        maximum likelihood estimation (MLE) from expectation values.
+
+        This implementation is inspired by Qiskit-Ignis's MLE tomography fitter:
+        https://github.com/qiskit-community/qiskit-ignis/blob/master/qiskit/ignis/verification/tomography/fitters/base_fitter.py
+
+        While independently implemented for the Qubex project, it follows the same
+        core methodology (e.g., CVXPY-based convex optimization with physical constraints).
+
+        Args:
+            expected_values: A dictionary mapping Pauli label strings like 'XX', 'XY', etc.
+                            to their corresponding measured expectation values.
+
+        Returns:
+            A 4x4 complex numpy array representing the fitted physical density matrix.
+        """
+        paulis = {
+            "I": np.array([[1, 0], [0, 1]], dtype=complex),
+            "X": np.array([[0, 1], [1, 0]], dtype=complex),
+            "Y": np.array([[0, -1j], [1j, 0]], dtype=complex),
+            "Z": np.array([[1, 0], [0, -1]], dtype=complex),
+        }
+
+        A_list: list[NDArray] = []
+        b_list: list[float] = []
+        for basis, val in expected_values.items():
+            p1, p2 = basis[0], basis[1]
+            pauli_op = np.kron(paulis[p1], paulis[p2])
+            A_list.append(pauli_op.reshape(1, -1).conj())
+            b_list.append(val)
+        A = np.vstack(A_list)
+        b = np.array(b_list)
+
+        rho = cp.Variable((4, 4), hermitian=True)
+        constraints = [rho >> 0, cp.trace(rho) == 1]
+        objective = cp.Minimize(cp.sum_squares(A @ cp.vec(rho, order='F') - b))
+        problem = cp.Problem(objective, constraints)
+        problem.solve(solver=cp.SCS)
+
+        if rho.value is None:
+            raise RuntimeError("CVXPY failed to solve the MLE problem.")
+
+        # Post-process: clip tiny negative eigenvalues
+        eigvals, eigvecs = np.linalg.eigh(rho.value)
+        eigvals_clipped = np.clip(eigvals, 0, None)
+        rho_fixed = eigvecs @ np.diag(eigvals_clipped) @ eigvecs.conj().T
+        rho_fixed /= np.trace(rho_fixed)
+
+        return rho_fixed
     def measure_bell_state(
         self,
         control_qubit: str,
@@ -1398,6 +1450,7 @@ class MeasurementMixin(
         interval: float = DEFAULT_INTERVAL,
         plot: bool = True,
         save_image: bool = True,
+        mle_fit: bool = True,
     ) -> dict:
         probabilities = {}
         for control_basis, target_basis in tqdm(
@@ -1449,7 +1502,10 @@ class MeasurementMixin(
                 rho += e * pauli
                 expected_values[basis] = e
 
-        rho = rho / 4
+        if mle_fit:
+            rho = self.mle_fit_density_matrix(expected_values)
+        else:
+            rho = rho / 4
         phi = np.array([1, 0, 0, 1]) / np.sqrt(2)
         fidelity = np.real(phi @ rho @ phi.T.conj())
 


### PR DESCRIPTION
Add maximum likelihood estimation (MLE) method for fitting physical density
matrices from tomography measurements. This improves the accuracy of state
reconstruction by enforcing physical constraints (Hermitian, positive
semi-definite, trace=1). Add cvxopt and cvxpy as dependencies for
optimization.

▼before

![image](https://github.com/user-attachments/assets/4be9b84d-8e07-48e7-ac57-3ca77fad3d23)


▼after
![image](https://github.com/user-attachments/assets/0e62a360-6741-4005-8790-910877ee24f0)
