### PR TITLE
fix: Adjust capture scheduling to ensure proper alignment and padding in Measurement class

### DIFF
--- a/src/qubex/measurement/measurement.py
+++ b/src/qubex/measurement/measurement.py
@@ -1089,7 +1089,7 @@ class Measurement:
                 )
             last_range = ranges[-1]
             last_duration = len(last_range)
-            # last_post_blank is the time to the end of the schedul
+            # last_post_blank is the time to the end of the schedule
             last_post_blank = schedule.length - last_range.stop
 
             cap_sub_sequence.capture_slots.append(


### PR DESCRIPTION
- ensure the first capture of each channel begins at a multiple of 64 samples (1 block)
  - an extra capture is inserted at the beginning and ignore the data
- raise exception when blank time readout pulses is not a multiple of 4 samples (1 word)