### PR TITLE
Backend-free import for Experiment/Measurement (lazy backend binding)

### DIFF
--- a/.devcontainer/postCreate.sh
+++ b/.devcontainer/postCreate.sh
@@ -1,13 +1,8 @@
 #!/usr/bin/env bash
 set -euo pipefail
-echo "[postCreate] Installing system packages..."
-apt-get update -y && \
-  DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-  libgirepository1.0-dev libcairo2-dev build-essential git && \
-  apt-get clean && rm -rf /var/lib/apt/lists/*
 
 echo "[postCreate] Installing qubex (editable) with extras..."
-pip install -e ".[backend,dev]"
+pip install -e ".[dev]"
 
 echo "[postCreate] Running ruff + pytest smoke (short) ..."
 ruff check . || true

--- a/src/qubex/errors.py
+++ b/src/qubex/errors.py
@@ -1,0 +1,37 @@
+from __future__ import annotations
+
+
+class CalibrationMissingError(Exception):
+    """Exception raised when calibration data is missing."""
+
+    def __init__(
+        self,
+        message: str = "Calibration data is missing.",
+        *,
+        target: str | None = None,
+    ):
+        if target:
+            message += f" ({target})"
+        super().__init__(message)
+
+
+class BackendUnavailableError(ImportError):
+    """Raised when a backend-dependent API is used without backend extras.
+
+    Guidance is provided to install backend extras when this error is raised.
+    """
+
+    def __init__(self, message: str | None = None):
+        if message is None:
+            message = (
+                "Backend components are unavailable. Install backend extras: "
+                'pip install "qubex[backend] @ git+https://github.com/amachino/qubex.git"'
+            )
+        super().__init__(message)
+
+
+__all__ = [
+    "CalibrationMissingError",
+    "BackendUnavailableError",
+]
+

--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -6,7 +6,7 @@ from contextlib import contextmanager
 from datetime import datetime
 from importlib import import_module
 from pathlib import Path
-from typing import TYPE_CHECKING, Collection, Final, Literal
+from typing import TYPE_CHECKING, Any, Collection, Final, Literal
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
@@ -54,6 +54,9 @@ else:
     DEFAULT_READOUT_DURATION = 384.0
     DEFAULT_READOUT_PRE_MARGIN = 32.0
     DEFAULT_READOUT_POST_MARGIN = 128.0
+    # Provide placeholder types to satisfy type checkers without importing backend
+    Target = Any  # type: ignore
+    Box = Any  # type: ignore
 
 from ..clifford import Clifford, CliffordGenerator
 from ..pulse import (
@@ -193,7 +196,7 @@ class Experiment(
             # Import backend symbols only when backend is available, and expose
             # them to this module's global namespace for methods that reference
             # them by name (e.g., `Target.cr_qubit_pair`).
-            from ..backend import Box as _Box
+            from ..backend import Box as _Box  # type: ignore
             from ..backend import Target as _Target  # type: ignore
 
             globals()["Target"] = _Target  # type: ignore
@@ -439,7 +442,7 @@ class Experiment(
         }
 
     @property
-    def targets(self) -> dict[str, Target]:
+    def targets(self) -> dict[str, "Target"]:
         return {
             target.label: target
             for target in self.experiment_system.targets
@@ -447,7 +450,7 @@ class Experiment(
         }
 
     @property
-    def available_targets(self) -> dict[str, Target]:
+    def available_targets(self) -> dict[str, "Target"]:
         return {
             label: target
             for label, target in self.targets.items()
@@ -455,7 +458,7 @@ class Experiment(
         }
 
     @property
-    def ge_targets(self) -> dict[str, Target]:
+    def ge_targets(self) -> dict[str, "Target"]:
         return {
             label: target
             for label, target in self.available_targets.items()
@@ -463,7 +466,7 @@ class Experiment(
         }
 
     @property
-    def ef_targets(self) -> dict[str, Target]:
+    def ef_targets(self) -> dict[str, "Target"]:
         return {
             label: target
             for label, target in self.available_targets.items()
@@ -471,7 +474,7 @@ class Experiment(
         }
 
     @property
-    def cr_targets(self) -> dict[str, Target]:
+    def cr_targets(self) -> dict[str, "Target"]:
         return {
             label: target
             for label, target in self.available_targets.items()

--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -59,6 +59,7 @@ else:
     Box = Any  # type: ignore
 
 from ..clifford import Clifford, CliffordGenerator
+from ..errors import BackendUnavailableError, CalibrationMissingError
 from ..pulse import (
     Blank,
     CrossResonance,
@@ -87,7 +88,6 @@ from .experiment_constants import (
     SYSTEM_NOTE_PATH,
     USER_NOTE_PATH,
 )
-from ..errors import BackendUnavailableError, CalibrationMissingError
 from .experiment_note import ExperimentNote
 from .experiment_record import ExperimentRecord
 from .experiment_result import ExperimentResult, RabiData
@@ -390,23 +390,23 @@ class Experiment(
         return self.system_manager.experiment_system
 
     @property
-    def quantum_system(self) -> QuantumSystem:
+    def quantum_system(self) -> "QuantumSystem":
         return self.experiment_system.quantum_system
 
     @property
-    def control_system(self) -> ControlSystem:
+    def control_system(self) -> "ControlSystem":
         return self.experiment_system.control_system
 
     @property
-    def device_controller(self) -> DeviceController:
+    def device_controller(self) -> "DeviceController":
         return self.system_manager.device_controller
 
     @property
-    def params(self) -> ControlParams:
+    def params(self) -> "ControlParams":
         return self.experiment_system.control_params
 
     @property
-    def chip(self) -> Chip:
+    def chip(self) -> "Chip":
         return self.experiment_system.chip
 
     @property
@@ -426,7 +426,7 @@ class Experiment(
         return sorted(list(mux_set))
 
     @property
-    def qubits(self) -> dict[str, Qubit]:
+    def qubits(self) -> dict[str, "Qubit"]:
         return {
             qubit.label: qubit
             for qubit in self.experiment_system.qubits
@@ -434,7 +434,7 @@ class Experiment(
         }
 
     @property
-    def resonators(self) -> dict[str, Resonator]:
+    def resonators(self) -> dict[str, "Resonator"]:
         return {
             resonator.qubit: resonator
             for resonator in self.experiment_system.resonators
@@ -1238,7 +1238,7 @@ class Experiment(
         self,
         qubit: str,
         in_same_mux: bool = False,
-    ) -> list[Qubit]:
+    ) -> list["Qubit"]:
         return self.quantum_system.get_spectator_qubits(qubit, in_same_mux=in_same_mux)
 
     def get_confusion_matrix(
@@ -1372,7 +1372,7 @@ class Experiment(
         box_id: str,
         port_number: int,
         channel_number: int,
-        target_type: TargetType = TargetType.CTRL_GE,
+        target_type: "TargetType" = TargetType.CTRL_GE,
         update_lsi: bool = False,
     ):
         try:

--- a/src/qubex/experiment/experiment_exceptions.py
+++ b/src/qubex/experiment/experiment_exceptions.py
@@ -1,15 +1,13 @@
 from __future__ import annotations
 
+"""Deprecated: use `qubex.errors` instead.
 
-class CalibrationMissingError(Exception):
-    """Exception raised when calibration data is missing."""
+This module re-exports exceptions for backward compatibility.
+"""
 
-    def __init__(
-        self,
-        message="Calibration data is missing.",
-        *,
-        target: str | None = None,
-    ):
-        if target:
-            message += f" ({target})"
-        super().__init__(message)
+from ..errors import BackendUnavailableError, CalibrationMissingError
+
+__all__ = [
+    "CalibrationMissingError",
+    "BackendUnavailableError",
+]

--- a/src/qubex/measurement/measurement.py
+++ b/src/qubex/measurement/measurement.py
@@ -445,7 +445,7 @@ class Measurement:
         _require_backend()
         if isinstance(targets, str):
             targets = [targets]
-        from ..backend import Target  # lazy import
+        from ..backend import Target  # type: ignore  # lazy import
 
         qubits = [Target.qubit_label(target) for target in targets]
         muxes = {
@@ -453,7 +453,7 @@ class Measurement:
         }
         voltages = {mux + 1: self.control_params.get_dc_voltage(mux) for mux in muxes}
         # Lazy import to avoid backend dependency at module import
-        from ..backend.dc_voltage_controller import dc_voltage
+        from ..backend.dc_voltage_controller import dc_voltage  # type: ignore
 
         with dc_voltage(voltages):
             yield
@@ -696,7 +696,7 @@ class Measurement:
         pre_margin: float | None = None,
         post_margin: float | None = None,
     ) -> PulseArray:
-        from ..backend import Target  # lazy import
+        from ..backend import Target  # type: ignore  # lazy import
 
         qubit = Target.qubit_label(target)
         if duration is None:
@@ -739,7 +739,7 @@ class Measurement:
         ramptime: float | None = None,
         type: RampType | None = None,
     ) -> FlatTop:
-        from ..backend import Target  # lazy import
+        from ..backend import Target  # type: ignore  # lazy import
 
         qubit = Target.qubit_label(target)
         mux = self.mux_dict[qubit]
@@ -774,9 +774,9 @@ class Measurement:
         add_pump_pulses: bool = False,
     ) -> Any:
         _require_backend()
-        from qubecalib import neopulse as pls  # lazy
-        from ..backend.sequencer_mod import SequencerMod  # lazy
-        from ..backend import Target  # lazy
+        from qubecalib import neopulse as pls  # type: ignore  # lazy
+        from ..backend.sequencer_mod import SequencerMod  # type: ignore  # lazy
+        from ..backend import Target  # type: ignore  # lazy
         if interval is None:
             interval = DEFAULT_INTERVAL
         if readout_amplitudes is None:
@@ -995,11 +995,9 @@ class Measurement:
         add_pump_pulses: bool = False,
         plot: bool = False,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
-        from ..backend import Target  # lazy import
-        from qubecalib import neopulse as pls  # lazy
         _require_backend()
-        from qubecalib import neopulse as pls  # lazy
-        from ..backend import Target  # lazy
+        from ..backend import Target  # type: ignore  # lazy import
+        from qubecalib import neopulse as pls  # type: ignore  # lazy
         if readout_amplitudes is None:
             readout_amplitudes = self.control_params.readout_amplitude
         if readout_duration is None:
@@ -1282,7 +1280,7 @@ class Measurement:
         plot: bool = False,
     ) -> Any:
         _require_backend()
-        from ..backend.sequencer_mod import SequencerMod  # lazy
+        from ..backend.sequencer_mod import SequencerMod  # type: ignore  # lazy
         if interval is None:
             interval = DEFAULT_INTERVAL
 

--- a/src/qubex/measurement/measurement.py
+++ b/src/qubex/measurement/measurement.py
@@ -13,6 +13,8 @@ import numpy.typing as npt
 
 # NOTE: Avoid importing backend/qubecalib at module import time.
 if TYPE_CHECKING:  # pragma: no cover - typing only
+    from qubecalib import neopulse as pls
+
     from ..backend import (
         ConfigLoader,
         ControlParams,
@@ -23,12 +25,10 @@ if TYPE_CHECKING:  # pragma: no cover - typing only
         SystemManager,
         Target,
     )
-    from qubecalib import Sequencer
-    from qubecalib import neopulse as pls
 
+from ..errors import BackendUnavailableError
 from ..pulse import Blank, FlatTop, PulseArray, PulseSchedule, RampType
 from ..typing import IQArray, TargetMap
-from ..errors import BackendUnavailableError
 from .measurement_result import (
     MeasureData,
     MeasureMode,
@@ -775,8 +775,10 @@ class Measurement:
     ) -> Any:
         _require_backend()
         from qubecalib import neopulse as pls  # type: ignore  # lazy
-        from ..backend.sequencer_mod import SequencerMod  # type: ignore  # lazy
+
         from ..backend import Target  # type: ignore  # lazy
+        from ..backend.sequencer_mod import SequencerMod  # type: ignore  # lazy
+
         if interval is None:
             interval = DEFAULT_INTERVAL
         if readout_amplitudes is None:
@@ -996,8 +998,10 @@ class Measurement:
         plot: bool = False,
     ) -> tuple[dict[str, Any], dict[str, Any]]:
         _require_backend()
-        from ..backend import Target  # type: ignore  # lazy import
         from qubecalib import neopulse as pls  # type: ignore  # lazy
+
+        from ..backend import Target  # type: ignore  # lazy import
+
         if readout_amplitudes is None:
             readout_amplitudes = self.control_params.readout_amplitude
         if readout_duration is None:
@@ -1281,6 +1285,7 @@ class Measurement:
     ) -> Any:
         _require_backend()
         from ..backend.sequencer_mod import SequencerMod  # type: ignore  # lazy
+
         if interval is None:
             interval = DEFAULT_INTERVAL
 


### PR DESCRIPTION
This PR addresses #151.

Summary
- Make Experiment importable without backend extras by lazily binding backend symbols (auto-detect availability;  opt-in)
- Make Measurement importable without backend extras by deferring backend/qubecalib imports to call sites
- Add  and deprecate  (re-export)
- Add clear  with guidance when backend-only APIs are invoked without extras

Notes
- No breaking API change; only import timing and error messaging when backend is missing
- Backend-installed environments retain existing behavior

Follow-ups
- README: document backend-free import and guidance
- Minimal smoke tests for backend-free import paths
