### PR TITLE
Refactring ConfigLoader 

### DIFF
--- a/src/qubex/backend/config_loader.py
+++ b/src/qubex/backend/config_loader.py
@@ -1,6 +1,9 @@
 from __future__ import annotations
 
+import math
+import warnings
 from collections import defaultdict
+from enum import Enum
 from logging import getLogger
 from pathlib import Path
 from typing import Final, Literal
@@ -18,11 +21,96 @@ DEFAULT_CONFIG_DIR: Final = "/home/shared/qubex-config"
 CHIP_FILE: Final = "chip.yaml"
 BOX_FILE: Final = "box.yaml"
 WIRING_FILE: Final = "wiring.yaml"
-PROPS_FILE: Final = "props.yaml"
-PARAMS_FILE: Final = "params.yaml"
+PROPS_FILE: Final = "props.yaml"  # legacy
+PARAMS_FILE: Final = "params.yaml"  # legacy
+
+
+class Param(Enum):
+    """
+    Canonical parameter names.
+
+    Each value encodes: (name, legacy_name, legacy_file)
+    """
+
+    QUBIT_FREQUENCY = ("qubit_frequency", None, "props")
+    QUBIT_ANHARMONICITY = ("qubit_anharmonicity", "anharmonicity", "props")
+    RESONATOR_FREQUENCY = ("resonator_frequency", None, "props")
+
+    CONTROL_FREQUENCY = ("control_frequency", "qubit_frequency", "props")
+    READOUT_FREQUENCY = ("readout_frequency", "resonator_frequency", "props")
+
+    CONTROL_AMPLITUDE = ("control_amplitude", None, "params")
+    READOUT_AMPLITUDE = ("readout_amplitude", None, "params")
+
+    CONTROL_VATT = ("control_vatt", None, "params")
+    READOUT_VATT = ("readout_vatt", None, "params")
+    PUMP_VATT = ("pump_vatt", None, "params")
+
+    CONTROL_FSC = ("control_fsc", None, "params")
+    READOUT_FSC = ("readout_fsc", None, "params")
+    PUMP_FSC = ("pump_fsc", None, "params")
+
+    CAPTURE_DELAY = ("capture_delay", None, "params")
+    CAPTURE_DELAY_WORD = ("capture_delay_word", None, "params")
+
+    JPA_PARAMS = ("jpa_params", None, "params")
 
 
 class ConfigLoader:
+    """
+    Single-chip configuration loader that builds an ExperimentSystem.
+
+    Summary
+    -------
+    ConfigLoader loads configuration and parameter YAML files for a specific
+    quantum chip and constructs the corresponding ExperimentSystem. It prefers
+    structured per-file parameter files under ``params/<name>.yaml`` with the
+    shape ``{"meta": ..., "data": ...}``, and falls back to the legacy
+    monolithic ``params.yaml`` when a per-file param name is absent. When
+    ``meta.unit`` is provided, numeric values in ``data`` are converted to the
+    internal base units (GHz for frequency-like quantities, ns for time-like
+    quantities). ``meta.unit`` must be a string and is applied uniformly to the
+    values in ``data``.
+
+    The loader passes through ``jpa_params`` as-is; it does not perform key
+    normalization. Downstream consumers should handle optional keys.
+
+    Parameters
+    ----------
+    chip_id : str
+        The quantum chip identifier (e.g., "64Q"). All configuration is loaded
+        for this specific chip.
+    config_dir : Path | str | None, optional
+        Directory containing configuration files (``chip.yaml``, ``box.yaml``,
+        ``wiring.yaml``). Defaults to ``DEFAULT_CONFIG_DIR/<chip_id>/config``.
+    params_dir : Path | str | None, optional
+        Directory containing parameter files (``params.yaml`` and per-section
+        files under ``params/``). Defaults to
+        ``DEFAULT_CONFIG_DIR/<chip_id>/params``.
+    chip_file, box_file, wiring_file, props_file, params_file : str, optional
+        Filenames for the respective YAMLs. Usually left as defaults.
+    targets_to_exclude : list[str] | None, optional
+        Qubit/resonator labels to exclude when assembling the ExperimentSystem.
+    configuration_mode : {"ge-ef-cr", "ge-cr-cr"} | None, optional
+        Control configuration style. Defaults to "ge-cr-cr" if not provided.
+
+    Notes
+    -----
+    - Per-file parameter YAML must be structured as ``{"meta": ..., "data": ...}``.
+        - ``meta.unit`` is a string (applied to all numeric values in ``data``).
+            Supported units are case-insensitive and include Hz/kHz/MHz/GHz (converted
+            to GHz) and s/ms/us/µs/ns (converted to ns).
+    - ``get_experiment_system(chip_id)`` accepts an optional argument for backward
+      compatibility, but the argument is deprecated and ignored; call
+      ``get_experiment_system()`` with no arguments.
+
+    Examples
+    --------
+    >>> from qubex.backend.config_loader import ConfigLoader
+    >>> cfg = ConfigLoader(chip_id="64Q")
+    >>> system = cfg.get_experiment_system()
+    """
+
     def __init__(
         self,
         *,
@@ -37,34 +125,6 @@ class ConfigLoader:
         targets_to_exclude: list[str] | None = None,
         configuration_mode: Literal["ge-ef-cr", "ge-cr-cr"] | None = None,
     ):
-        """
-        Initializes the ConfigLoader object.
-
-        Parameters
-        ----------
-        chip_id : str, optional
-            The quantum chip ID (e.g., "64Q"). If provided, the configuration will be loaded for this specific chip.
-        config_dir : Path | str, optional
-            The directory where the configuration files are stored.
-        params_dir : Path | str, optional
-            The directory where the parameter files are stored.
-        chip_file : str, optional
-            The name of the chip configuration file, by default "chip.yaml".
-        box_file : str, optional
-            The name of the box configuration file, by default "box.yaml".
-        wiring_file : str, optional
-            The name of the wiring configuration file, by default "wiring.yaml".
-        props_file : str, optional
-            The name of the properties configuration file, by default "props.yaml".
-        params_file : str, optional
-            The name of the parameters configuration file, by default "params.yaml".
-        targets_to_exclude : list[str], optional
-            The list of target labels to exclude, by default None.
-
-        Examples
-        --------
-        >>> config = ConfigLoader()
-        """
         if config_dir is None:
             config_dir = Path(DEFAULT_CONFIG_DIR) / chip_id / "config"
         if params_dir is None:
@@ -74,16 +134,18 @@ class ConfigLoader:
         self._chip_id = chip_id
         self._config_dir = config_dir
         self._params_dir = params_dir
+
         self._chip_dict = self._load_config_file(chip_file)
         self._box_dict = self._load_config_file(box_file)
         self._wiring_dict = self._load_config_file(wiring_file)
-        self._props_dict = self._load_params_file(props_file)
-        self._params_dict = self._load_params_file(params_file)
-        self._quantum_system_dict = self._load_quantum_system()
-        self._control_system_dict = self._load_control_system()
-        self._wiring_info_dict = self._load_wiring_info()
-        self._control_params_dict = self._load_control_params()
-        self._experiment_system_dict = self._load_experiment_system(
+        self._props_dict = self._load_legacy_params_file(props_file)  # legacy
+        self._params_dict = self._load_legacy_params_file(params_file)  # legacy
+
+        self._quantum_system = self._load_quantum_system()
+        self._control_system = self._load_control_system()
+        self._wiring_info = self._load_wiring_info()
+        self._control_params = self._load_control_params()
+        self._experiment_system = self._load_experiment_system(
             targets_to_exclude=targets_to_exclude,
             configuration_mode=configuration_mode,
         )
@@ -98,26 +160,43 @@ class ConfigLoader:
         """Returns the absolute path to the parameters directory."""
         return Path(self._params_dir).resolve()
 
-    def get_experiment_system(self, chip_id: str) -> ExperimentSystem:
+    def get_experiment_system(self, chip_id: str | None = None) -> ExperimentSystem:
         """
-        Returns the ExperimentSystem object for the given chip ID.
+        Return the ExperimentSystem for the configured chip.
 
         Parameters
         ----------
-        chip_id : str
-            The quantum chip ID (e.g., "64Q").
+        chip_id : str, optional
+            Deprecated and ignored. Use ``get_experiment_system()`` without
+            arguments. A ``DeprecationWarning`` is emitted when provided.
 
         Returns
         -------
         ExperimentSystem
-            The ExperimentSystem object for the given chip ID.
+            The ExperimentSystem for this loader's chip.
+
+        Notes
+        -----
+        The ``chip_id`` parameter is kept for backward compatibility and will be
+        removed in a future minor release.
 
         Examples
         --------
-        >>> config = ConfigLoader()
-        >>> config.get_experiment_system("64Q")
+        >>> cfg = ConfigLoader(chip_id="64Q")
+        >>> cfg.get_experiment_system()
         """
-        return self._experiment_system_dict[chip_id]
+        if chip_id is not None:
+            warnings.warn(
+                "get_experiment_system(chip_id) is deprecated; the argument is ignored. "
+                "Use get_experiment_system() instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if self._experiment_system is None:
+            raise RuntimeError(
+                "ExperimentSystem is not available for chip: %s" % self._chip_id
+            )
+        return self._experiment_system
 
     def _load_config_file(self, file_name) -> dict:
         path = Path(self._config_dir) / file_name
@@ -132,183 +211,308 @@ class ConfigLoader:
             raise e
         return result
 
-    def _load_params_file(self, file_name) -> dict:
+    def _load_legacy_params_file(self, file_name) -> dict:
         path = Path(self._params_dir) / file_name
         try:
             with open(path, "r") as file:
                 result = yaml.safe_load(file)
-        except FileNotFoundError as e:
-            print(f"Parameter file not found: {path}\n\n{e}")
-            raise e
+        except FileNotFoundError:
+            # Tolerate missing legacy params files (e.g., props.yaml, params.yaml)
+            # so that per-file structured params can be used without requiring
+            # the monolithic files. Return an empty mapping (no warning).
+            logger.debug("Legacy parameter file not found; treating as empty: %s", path)
+            return {}
         except yaml.YAMLError as e:
             print(f"Error loading parameter file: {path}\n\n{e}")
             raise e
         return result
 
-    def _load_quantum_system(self) -> dict[str, QuantumSystem]:
-        quantum_system_dict = {}
-        for chip_id, chip_info in self._chip_dict.items():
-            if self._chip_id is not None and chip_id != self._chip_id:
-                continue
-            chip = Chip.new(
-                id=chip_id,
-                name=chip_info["name"],
-                n_qubits=chip_info["n_qubits"],
-            )
-            props = self._props_dict.get(chip_id)
-            if props is None:
-                logger.warning(f"Chip `{chip_id}` is missing in `{PROPS_FILE}`. ")
-                continue
-            qubit_frequency_dict = props.get("qubit_frequency", {})
-            qubit_anharmonicity_dict = props.get("anharmonicity", {})
-            resonator_frequency_dict = props.get("resonator_frequency", {})
-            for qubit in chip.qubits:
-                qubit.frequency = qubit_frequency_dict.get(
-                    qubit.label, float("nan")
-                ) or float("nan")
-                anharmonicity = qubit_anharmonicity_dict.get(qubit.label)
-                if anharmonicity is None:
-                    factor = -1 / 19  # E_J / E_C = 50
-                    qubit.anharmonicity = qubit.frequency * factor
-                else:
-                    qubit.anharmonicity = anharmonicity
-            for resonator in chip.resonators:
-                resonator.frequency = resonator_frequency_dict.get(
-                    resonator.qubit, float("nan")
-                ) or float("nan")
-            quantum_system = QuantumSystem(chip=chip)
-            quantum_system_dict[chip_id] = quantum_system
-        return quantum_system_dict
+    def _load_structured_params_yaml(self, path: Path) -> dict[str, dict]:
+        """
+        Load a YAML file that may have a structured shape {"meta": ..., "data": ...}.
 
-    def _load_control_system(self) -> dict[str, ControlSystem]:
-        control_system_dict = {}
-        for chip_id in self._chip_dict:
-            if self._chip_id is not None and chip_id != self._chip_id:
-                continue
-            box_ports = defaultdict(list)
-            wirings = self._wiring_dict.get(chip_id)
-            if wirings is None:
-                logger.warning(f"Chip `{chip_id}` is missing in `{WIRING_FILE}`. ")
-                continue
-            for wiring in wirings:
-                box, port = wiring["read_out"].split("-")
-                box_ports[box].append(int(port))
-                box, port = wiring["read_in"].split("-")
-                box_ports[box].append(int(port))
-                for ctrl in wiring["ctrl"]:
-                    box, port = ctrl.split("-")
-                    box_ports[box].append(int(port))
-            boxes = [
-                Box.new(
-                    id=id,
-                    name=box["name"],
-                    type=box["type"],
-                    address=box["address"],
-                    adapter=box["adapter"],
-                    port_numbers=box_ports[id],
+        Returns
+        -------
+        dict[str, dict]
+            A mapping with keys "meta" and "data". Both are dicts (empty if absent).
+
+        Notes
+        -----
+        The on-disk format is preserved ("meta"/"data" keys). Downstream consumers
+        should typically use the returned["data"]. The "meta" is returned for
+        tooling/annotation but not merged into data.
+        """
+        try:
+            with open(path, "r") as f:
+                payload = yaml.safe_load(f)
+        except FileNotFoundError:
+            raise
+        except yaml.YAMLError as e:
+            print(f"Error loading parameter file: {path}\n\n{e}")
+            raise e
+
+        if payload is None:
+            return {"data": {}, "meta": {}}
+        if isinstance(payload, dict) and ("data" in payload or "meta" in payload):
+            data = payload.get("data") or {}
+            meta = payload.get("meta") or {}
+            if not isinstance(data, dict):
+                raise TypeError(f"'data' must be a mapping in {path}")
+            if not isinstance(meta, dict):
+                raise TypeError(f"'meta' must be a mapping in {path}")
+            return {"data": data, "meta": meta}
+        raise TypeError(
+            f"Per-file params must be structured with 'meta'/'data' mappings: {path}"
+        )
+
+    def _unit_scale_to_internal(self, unit: str) -> float:
+        """
+        Return a scale factor to convert values from the given unit to the internal base
+        units (GHz for frequency-like, ns for time-like). If unit is already base or
+        unrecognized/dimensionless, returns 1.0.
+
+        Supported units (case-insensitive):
+        - Frequency: Hz, kHz, MHz, GHz → internal GHz
+        - Time: s, ms, us/µs, ns → internal ns
+        """
+        if not unit:
+            return 1.0
+        u = unit.strip().lower()
+        # Frequency family → to GHz
+        if u in {"hz", "khz", "mhz", "ghz"}:
+            return {
+                "hz": 1e-9,
+                "khz": 1e-6,
+                "mhz": 1e-3,
+                "ghz": 1.0,
+            }[u]
+        # Time family → to ns
+        if u in {"s", "ms", "us", "µs", "ns"}:
+            return {
+                "s": 1e9,
+                "ms": 1e6,
+                "us": 1e3,
+                "µs": 1e3,
+                "ns": 1.0,
+            }[u]
+        return 1.0
+
+    def _convert_units_in_data(self, data: dict, unit: str | None) -> dict:
+        """
+        Convert numeric values in `data` according to `unit`.
+
+        Returns a new dict; does not mutate the input.
+        """
+
+        def apply(value, key: str | None = None):
+            if isinstance(unit, str):
+                scale = self._unit_scale_to_internal(unit)
+            else:
+                scale = 1.0
+
+            if isinstance(value, (int, float)) and scale != 1.0:
+                return float(value) * scale
+            else:
+                return value
+
+        if not isinstance(data, dict):
+            return data
+        return {k: apply(v, k) for k, v in data.items()}
+
+    def _load_param_data(self, param: Param, use_default: bool = True) -> dict:
+        """
+        Load a Param with per-file preference and legacy fallback.
+        """
+        name, legacy_name, legacy_file = param.value
+        file_path = Path(self._params_dir) / f"{name}.yaml"
+
+        legacy_root = self._params_dict if legacy_file == "params" else self._props_dict
+        legacy_map = legacy_root.get(self._chip_id, {}) or {}
+        legacy_key = legacy_name or name
+        legacy_data = legacy_map.get(legacy_key, {}) or {}
+
+        if file_path.exists():
+            payload = self._load_structured_params_yaml(file_path)
+            data = payload.get("data", {}) or {}
+            meta = payload.get("meta", {}) or {}
+            unit = meta.get("unit")
+            default = meta.get("default")
+            if use_default and default is not None:
+                data = {
+                    k: (
+                        default
+                        if (v is None or (isinstance(v, float) and math.isnan(v)))
+                        else v
+                    )
+                    for k, v in data.items()
+                }
+
+            converted_data = self._convert_units_in_data(data, unit)
+
+            if legacy_data and legacy_data != converted_data:
+                logger.info(
+                    "Param name `%s` for chip `%s` differs between %s and %s; using per-file (units converted).",
+                    name,
+                    self._chip_id,
+                    PARAMS_FILE if legacy_file == "params" else PROPS_FILE,
+                    file_path.name,
                 )
-                for id, box in self._box_dict.items()
-                if id in box_ports
-            ]
-            control_system_dict[chip_id] = ControlSystem(
-                boxes=boxes,
-                clock_master_address=self._chip_dict[chip_id].get("clock_master"),
+            else:
+                logger.info(
+                    "Param name `%s` for chip `%s` loaded from %s%s.",
+                    name,
+                    self._chip_id,
+                    file_path.name,
+                    f" with unit={unit!r}" if unit else "",
+                )
+            return converted_data
+        else:
+            return legacy_data
+
+    def _load_quantum_system(self) -> QuantumSystem | None:
+        chip_id = self._chip_id
+        chip_info = self._chip_dict.get(chip_id)
+        if chip_info is None:
+            logger.warning(f"Chip `{chip_id}` is missing in `{CHIP_FILE}`. ")
+            return None
+        chip = Chip.new(
+            id=chip_id,
+            name=chip_info["name"],
+            n_qubits=chip_info["n_qubits"],
+        )
+        qubit_frequency_dict = self._load_param_data(Param.QUBIT_FREQUENCY)
+        qubit_anharmonicity_dict = self._load_param_data(Param.QUBIT_ANHARMONICITY)
+        resonator_frequency_dict = self._load_param_data(Param.RESONATOR_FREQUENCY)
+        for qubit in chip.qubits:
+            qubit.frequency = qubit_frequency_dict.get(
+                qubit.label, float("nan")
+            ) or float("nan")
+            anharmonicity = qubit_anharmonicity_dict.get(qubit.label)
+            if anharmonicity is None:
+                factor = -1 / 19  # E_J / E_C = 50
+                qubit.anharmonicity = qubit.frequency * factor
+            else:
+                qubit.anharmonicity = anharmonicity
+        for resonator in chip.resonators:
+            resonator.frequency = resonator_frequency_dict.get(
+                resonator.qubit, float("nan")
+            ) or float("nan")
+        return QuantumSystem(chip=chip)
+
+    def _load_control_system(self) -> ControlSystem | None:
+        chip_id = self._chip_id
+        box_ports = defaultdict(list)
+        wirings = self._wiring_dict.get(chip_id)
+        if wirings is None:
+            logger.warning(f"Chip `{chip_id}` is missing in `{WIRING_FILE}`. ")
+            return None
+        for wiring in wirings:
+            box, port = wiring["read_out"].split("-")
+            box_ports[box].append(int(port))
+            box, port = wiring["read_in"].split("-")
+            box_ports[box].append(int(port))
+            for ctrl in wiring["ctrl"]:
+                box, port = ctrl.split("-")
+                box_ports[box].append(int(port))
+        boxes = [
+            Box.new(
+                id=id,
+                name=box["name"],
+                type=box["type"],
+                address=box["address"],
+                adapter=box["adapter"],
+                port_numbers=box_ports[id],
             )
-        return control_system_dict
+            for id, box in self._box_dict.items()
+            if id in box_ports
+        ]
+        return ControlSystem(
+            boxes=boxes,
+            clock_master_address=self._chip_dict[chip_id].get("clock_master"),
+        )
 
-    def _load_wiring_info(self) -> dict[str, WiringInfo]:
-        wiring_info_dict = {}
-        for chip_id in self._chip_dict:
-            if self._chip_id is not None and chip_id != self._chip_id:
-                continue
-            try:
-                wirings = self._wiring_dict[chip_id]
-                quantum_system = self._quantum_system_dict[chip_id]
-                control_system = self._control_system_dict[chip_id]
-            except KeyError:
-                continue
+    def _load_wiring_info(self) -> WiringInfo | None:
+        chip_id = self._chip_id
+        try:
+            wirings = self._wiring_dict[chip_id]
+            quantum_system = self._quantum_system
+            control_system = self._control_system
+        except KeyError:
+            return None
+        if quantum_system is None or control_system is None:
+            return None
 
-            def get_port(specifier: str | None):
-                if specifier is None:
-                    return None
-                box_id = specifier.split("-")[0]
-                port_num = int(specifier.split("-")[1])
-                port = control_system.get_port(box_id, port_num)
-                return port
+        def get_port(specifier: str | None):
+            if specifier is None:
+                return None
+            box_id = specifier.split("-")[0]
+            port_num = int(specifier.split("-")[1])
+            port = control_system.get_port(box_id, port_num)
+            return port
 
-            ctrl = []
-            read_out = []
-            read_in = []
-            pump = []
-            for wiring in wirings:
-                mux_num = int(wiring["mux"])
-                mux = quantum_system.get_mux(mux_num)
-                qubits = quantum_system.get_qubits_in_mux(mux_num)
-                for identifier, qubit in zip(wiring["ctrl"], qubits):
-                    ctrl_port: GenPort = get_port(identifier)  # type: ignore
-                    ctrl.append((qubit, ctrl_port))
-                read_out_port: GenPort = get_port(wiring["read_out"])  # type: ignore
-                read_out.append((mux, read_out_port))
-                read_in_port: CapPort = get_port(wiring["read_in"])  # type: ignore
-                read_in.append((mux, read_in_port))
-                pump_port: GenPort = get_port(wiring.get("pump"))  # type: ignore
-                if pump_port is not None:
-                    pump.append((mux, pump_port))
+        ctrl = []
+        read_out = []
+        read_in = []
+        pump = []
+        for wiring in wirings:
+            mux_num = int(wiring["mux"])
+            mux = quantum_system.get_mux(mux_num)
+            qubits = quantum_system.get_qubits_in_mux(mux_num)
+            for identifier, qubit in zip(wiring["ctrl"], qubits):
+                ctrl_port: GenPort = get_port(identifier)  # type: ignore
+                ctrl.append((qubit, ctrl_port))
+            read_out_port: GenPort = get_port(wiring["read_out"])  # type: ignore
+            read_out.append((mux, read_out_port))
+            read_in_port: CapPort = get_port(wiring["read_in"])  # type: ignore
+            read_in.append((mux, read_in_port))
+            pump_port: GenPort = get_port(wiring.get("pump"))  # type: ignore
+            if pump_port is not None:
+                pump.append((mux, pump_port))
 
-            wiring_info = WiringInfo(
-                ctrl=ctrl,
-                read_out=read_out,
-                read_in=read_in,
-                pump=pump,
-            )
-            wiring_info_dict[chip_id] = wiring_info
-        return wiring_info_dict
+        wiring_info = WiringInfo(
+            ctrl=ctrl,
+            read_out=read_out,
+            read_in=read_in,
+            pump=pump,
+        )
+        return wiring_info
 
-    def _load_control_params(self) -> dict[str, ControlParams]:
-        control_params_dict = {}
-        for chip_id in self._chip_dict:
-            if self._chip_id is not None and chip_id != self._chip_id:
-                continue
-            params = self._params_dict.get(chip_id)
-            if params is None:
-                logger.warning(f"Chip `{chip_id}` is missing in `{PARAMS_FILE}`. ")
-                continue
-            control_params = ControlParams(
-                control_amplitude=params.get("control_amplitude", {}),
-                readout_amplitude=params.get("readout_amplitude", {}),
-                control_vatt=params.get("control_vatt", {}),
-                readout_vatt=params.get("readout_vatt", {}),
-                pump_vatt=params.get("pump_vatt", {}),
-                control_fsc=params.get("control_fsc", {}),
-                readout_fsc=params.get("readout_fsc", {}),
-                pump_fsc=params.get("pump_fsc", {}),
-                capture_delay=params.get("capture_delay", {}),
-                capture_delay_word=params.get("capture_delay_word", {}),
-                jpa_params=params.get("jpa_params", {}),
-            )
-            control_params_dict[chip_id] = control_params
-        return control_params_dict
+    def _load_control_params(self) -> ControlParams | None:
+        # Build control params primarily from per-file param names when present;
+        # fall back to monolithic params.yaml where needed. Do not require the
+        # legacy monolithic file to exist.
+        control_params = ControlParams(
+            control_amplitude=self._load_param_data(Param.CONTROL_AMPLITUDE),
+            readout_amplitude=self._load_param_data(Param.READOUT_AMPLITUDE),
+            control_vatt=self._load_param_data(Param.CONTROL_VATT),
+            readout_vatt=self._load_param_data(Param.READOUT_VATT),
+            pump_vatt=self._load_param_data(Param.PUMP_VATT),
+            control_fsc=self._load_param_data(Param.CONTROL_FSC),
+            readout_fsc=self._load_param_data(Param.READOUT_FSC),
+            pump_fsc=self._load_param_data(Param.PUMP_FSC),
+            capture_delay=self._load_param_data(Param.CAPTURE_DELAY),
+            capture_delay_word=self._load_param_data(Param.CAPTURE_DELAY_WORD),
+            jpa_params=self._load_param_data(Param.JPA_PARAMS),
+        )
+        return control_params
 
     def _load_experiment_system(
         self,
         targets_to_exclude: list[str] | None = None,
         configuration_mode: Literal["ge-ef-cr", "ge-cr-cr"] = "ge-cr-cr",
-    ) -> dict[str, ExperimentSystem]:
-        experiment_system_dict = {}
-        for chip_id in self._chip_dict:
-            if self._chip_id is not None and chip_id != self._chip_id:
-                continue
-            quantum_system = self._quantum_system_dict[chip_id]
-            control_system = self._control_system_dict[chip_id]
-            wiring_info = self._wiring_info_dict[chip_id]
-            control_params = self._control_params_dict[chip_id]
-            experiment_system = ExperimentSystem(
-                quantum_system=quantum_system,
-                control_system=control_system,
-                wiring_info=wiring_info,
-                control_params=control_params,
-                targets_to_exclude=targets_to_exclude,
-                configuration_mode=configuration_mode,
-            )
-            experiment_system_dict[chip_id] = experiment_system
-        return experiment_system_dict
+    ) -> ExperimentSystem | None:
+        if (
+            self._quantum_system is None
+            or self._control_system is None
+            or self._wiring_info is None
+            or self._control_params is None
+        ):
+            return None
+        return ExperimentSystem(
+            quantum_system=self._quantum_system,
+            control_system=self._control_system,
+            wiring_info=self._wiring_info,
+            control_params=self._control_params,
+            targets_to_exclude=targets_to_exclude,
+            configuration_mode=configuration_mode,
+        )

--- a/tests/backend/test_config_loader.py
+++ b/tests/backend/test_config_loader.py
@@ -1,0 +1,198 @@
+from __future__ import annotations
+
+import math
+from pathlib import Path
+
+import pytest
+import yaml
+
+from qubex.backend.config_loader import ConfigLoader
+from qubex.backend.experiment_system import DEFAULT_PUMP_FREQUENCY
+
+
+def _write_yaml(path: Path, data: dict) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with open(path, "w") as f:
+        yaml.safe_dump(data, f, sort_keys=False)
+
+
+def _make_minimal_files(tmp_path: Path) -> tuple[Path, Path, str]:
+    chip_id = "TESTCHIP"
+    config_dir = tmp_path / "config"
+    params_dir = tmp_path / "params"
+
+    # chip.yaml
+    chip_yaml = {
+        chip_id: {"name": "Test Chip", "n_qubits": 4, "clock_master": "10.0.0.1"}
+    }
+    _write_yaml(config_dir / "chip.yaml", chip_yaml)
+
+    # box.yaml (one box sufficient)
+    box_yaml = {
+        "BOX1": {
+            "name": "Box One",
+            "type": "quel1-a",
+            "address": "10.0.0.2",
+            "adapter": "dummy",
+        }
+    }
+    _write_yaml(config_dir / "box.yaml", box_yaml)
+
+    # wiring.yaml — use ports compatible with QUEL1_A mapping
+    wiring_yaml = {
+        chip_id: [
+            {
+                "mux": 0,
+                "read_out": "BOX1-1",  # READ_OUT
+                "read_in": "BOX1-0",  # READ_IN
+                # 4 control ports for 4 qubits in mux 0
+                "ctrl": ["BOX1-2", "BOX1-4", "BOX1-9", "BOX1-11"],  # CTRL ports
+                "pump": "BOX1-3",  # PUMP
+            }
+        ]
+    }
+    _write_yaml(config_dir / "wiring.yaml", wiring_yaml)
+
+    # params per-file: qubit_frequency (MHz), resonator_frequency (MHz), control_amplitude (unitless)
+    _write_yaml(
+        params_dir / "qubit_frequency.yaml",
+        {
+            "meta": {"unit": "MHz", "default": 6000},
+            "data": {"Q0": 5000, "Q1": None},  # Q2, Q3 missing
+        },
+    )
+    _write_yaml(
+        params_dir / "resonator_frequency.yaml",
+        {
+            "meta": {"unit": "MHz"},
+            "data": {"Q0": 8000},
+        },
+    )
+    _write_yaml(
+        params_dir / "control_amplitude.yaml",
+        {
+            "meta": {},
+            "data": {"Q0": 0.05},
+        },
+    )
+
+    # jpa_params per-file: pass-through
+    _write_yaml(
+        params_dir / "jpa_params.yaml",
+        {
+            "meta": {},
+            "data": {
+                0: {"pump_frequency": 12.3, "pump_amplitude": 0.1, "dc_voltage": 0.2},
+                1: None,
+            },
+        },
+    )
+
+    # legacy params.yaml: readout_amplitude fallback only
+    _write_yaml(
+        params_dir / "params.yaml",
+        {
+            chip_id: {
+                "readout_amplitude": {"Q0": 0.02},
+            }
+        },
+    )
+
+    # legacy props.yaml may be empty
+    _write_yaml(params_dir / "props.yaml", {})
+
+    return config_dir, params_dir, chip_id
+
+
+def test_build_experiment_system_and_unit_conversion(tmp_path: Path):
+    config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)
+
+    loader = ConfigLoader(
+        chip_id=chip_id,
+        config_dir=config_dir,
+        params_dir=params_dir,
+    )
+    system = loader.get_experiment_system()
+
+    # Quantum system built
+    assert system is not None
+    qs = system.quantum_system
+    # Frequencies converted: 5000 MHz -> 5.0 GHz; default 6000 MHz -> 6.0 GHz
+    q0 = qs.get_qubit("Q0")
+    q1 = qs.get_qubit("Q1")
+    q2 = qs.get_qubit("Q2")
+    assert math.isclose(q0.frequency, 5.0, rel_tol=0, abs_tol=1e-9)
+    assert math.isclose(q1.frequency, 6.0, rel_tol=0, abs_tol=1e-9)
+    assert math.isnan(q2.frequency)
+
+    # Anharmonicity default when not specified: factor = -1/19 * frequency
+    assert math.isclose(q0.anharmonicity, -5.0 / 19.0, rel_tol=0, abs_tol=1e-9)
+    assert math.isclose(q1.anharmonicity, -6.0 / 19.0, rel_tol=0, abs_tol=1e-9)
+
+    # Resonator frequency for Q0 set from per-file (8000 MHz -> 8.0 GHz)
+    r0 = qs.get_resonator(0)
+    assert math.isclose(r0.frequency, 8.0, rel_tol=0, abs_tol=1e-9)
+
+    # Wiring is constructed and includes ctrl/read_out/read_in/pump
+    w = system.wiring_info
+    assert len(w.ctrl) == 4
+    assert len(w.read_out) == 1
+    assert len(w.read_in) == 1
+    assert len(w.pump) == 1
+
+    # Port numbers match wiring.yaml selections
+    # ctrl entries follow qubit order in mux; first corresponds to Q0 -> port 2
+    first_qubit, first_ctrl_port = w.ctrl[0]
+    assert first_qubit.label == "Q0"
+    assert first_ctrl_port.number == 2
+    (mux_ro, ro_port) = w.read_out[0]
+    (mux_ri, ri_port) = w.read_in[0]
+    assert (
+        ro_port.number == 1
+        and ri_port.number == 0
+        and mux_ro.index == mux_ri.index == 0
+    )
+
+
+def test_control_params_sources_and_jpa_passthrough(tmp_path: Path):
+    config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)
+
+    loader = ConfigLoader(
+        chip_id=chip_id,
+        config_dir=config_dir,
+        params_dir=params_dir,
+    )
+    system = loader.get_experiment_system()
+    cp = system.control_params
+
+    # Per-file control_amplitude overrides default for Q0; others fallback to DEFAULT_CONTROL_AMPLITUDE
+    assert math.isclose(cp.get_control_amplitude("Q0"), 0.05, rel_tol=0, abs_tol=1e-12)
+    assert math.isclose(cp.get_control_amplitude("Q3"), 0.03, rel_tol=0, abs_tol=1e-12)
+
+    # Legacy readout_amplitude used when per-file is absent
+    assert math.isclose(cp.get_readout_amplitude("Q0"), 0.02, rel_tol=0, abs_tol=1e-12)
+    assert math.isclose(cp.get_readout_amplitude("Q1"), 0.01, rel_tol=0, abs_tol=1e-12)
+
+    # jpa_params are passed through, getters reflect provided/None/default
+    assert cp.jpa_params.get(0) == {
+        "pump_frequency": 12.3,
+        "pump_amplitude": 0.1,
+        "dc_voltage": 0.2,
+    }
+    assert cp.jpa_params.get(1) is None
+    assert math.isclose(cp.get_pump_frequency(0), 12.3, rel_tol=0, abs_tol=1e-12)
+    assert math.isclose(
+        cp.get_pump_frequency(1), DEFAULT_PUMP_FREQUENCY, rel_tol=0, abs_tol=1e-12
+    )
+
+
+def test_get_experiment_system_deprecation_warning(tmp_path: Path):
+    config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)
+    loader = ConfigLoader(
+        chip_id=chip_id,
+        config_dir=config_dir,
+        params_dir=params_dir,
+    )
+    with pytest.warns(DeprecationWarning):
+        sys = loader.get_experiment_system(chip_id="IGNORED")
+    assert sys is not None


### PR DESCRIPTION
This pull request adds comprehensive new tests for the `ConfigLoader` and experiment system configuration logic. The tests verify correct construction of the quantum system, proper unit conversions, parameter sourcing, wiring setup, and handling of legacy and per-file parameter formats.

### New test coverage for configuration loading:

* Added helper functions to create minimal valid configuration and parameter files in YAML format, enabling isolated testing of config loading logic (`_write_yaml`, `_make_minimal_files`).
* Added `test_build_experiment_system_and_unit_conversion` to verify quantum system instantiation, MHz-to-GHz conversions, default value handling, wiring info construction, and port assignments.
* Added `test_control_params_sources_and_jpa_passthrough` to check correct sourcing of control/readout amplitudes, fallback behavior, and passthrough of JPA parameters.
* Added `test_get_experiment_system_deprecation_warning` to ensure a deprecation warning is raised when using the deprecated `chip_id` argument in `get_experiment_system`.sts for params loading, unit conversion, wiring, and deprecation