### PR TITLE
Include fitting figures in readout results

### DIFF
--- a/src/qubex/experiment/mixin/characterization_mixin.py
+++ b/src/qubex/experiment/mixin/characterization_mixin.py
@@ -798,7 +798,7 @@ class CharacterizationMixin(
             )
             if "f0" in fit_result:
                 fit_data[target] = fit_result["f0"]
-            
+
             if "fig" in fit_result:
                 figs[target] = fit_result["fig"]
 
@@ -816,7 +816,7 @@ class CharacterizationMixin(
         for target, freq in fit_data.items():
             print(f"{target}: {freq:.6f}")
 
-        return Result(data={"data":fit_data,"fig":figs})
+        return Result(data={"data": fit_data, "fig": figs})
 
     def t1_experiment(
         self,


### PR DESCRIPTION
Enhance the readout results by including fitting figures alongside the frequency data. This change allows for better visualization and analysis of the fitting process.