### PR TITLE
feat: add VertRamp class for vertical ramp pulse representation

### DIFF
--- a/src/qubex/pulse/library/flat_top.py
+++ b/src/qubex/pulse/library/flat_top.py
@@ -8,6 +8,7 @@ from typing_extensions import TypeAlias
 
 from ..pulse import Pulse
 from .drag import Drag
+from .vert_ramp import VertRamp
 
 RampType: TypeAlias = Literal["Gaussian", "RaisedCosine", "Sintegral", "Bump"]
 
@@ -109,21 +110,34 @@ class FlatTop(Pulse):
 
         beta = beta or 0.0
 
-        v_rise = Drag.func(
-            t=t,
-            duration=T,
-            amplitude=amplitude,
-            beta=beta,
-            type=type,
-        )
-        v_flat = amplitude * np.ones_like(t)
-        v_fall = Drag.func(
-            t=t - flattime,
-            duration=T,
-            amplitude=amplitude,
-            beta=beta,
-            type=type,
-        )
+        if type == "VertRamp":
+            v_rise = VertRamp.func(
+                t=t,
+                duration=tau,
+                amplitude=amplitude,
+            )
+            v_flat = amplitude * np.ones_like(t)
+            v_fall = VertRamp.func(
+                t=-(t - duration),
+                duration=tau,
+                amplitude=amplitude,
+            )
+        else:
+            v_rise = Drag.func(
+                t=t,
+                duration=T,
+                amplitude=amplitude,
+                beta=beta,
+                type=type,
+            )
+            v_flat = amplitude * np.ones_like(t)
+            v_fall = Drag.func(
+                t=t - flattime,
+                duration=T,
+                amplitude=amplitude,
+                beta=beta,
+                type=type,
+            )
 
         return np.where(
             (t >= 0) & (t <= duration),

--- a/src/qubex/pulse/library/vert_ramp.py
+++ b/src/qubex/pulse/library/vert_ramp.py
@@ -1,0 +1,85 @@
+from __future__ import annotations
+
+from typing import Final
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+
+from ..pulse import Pulse
+
+
+class VertRamp(Pulse):
+    """
+    A class to represent a vertical ramp pulse.
+
+    Parameters
+    ----------
+    duration : float
+        Duration of the pulse in ns.
+    amplitude : float
+        Amplitude of the pulse.
+
+    Examples
+    --------
+    >>> pulse = VertRamp(
+    ...     duration=100,
+    ...     amplitude=1.0,
+    ... )
+    """
+
+    def __init__(
+        self,
+        *,
+        duration: float,
+        amplitude: float,
+        beta: float | None = None,
+        **kwargs,
+    ):
+        self.amplitude: Final = amplitude
+        self.beta: Final = beta
+
+        if duration == 0:
+            values = np.array([], dtype=np.complex128)
+        else:
+            values = self.func(
+                t=self._sampling_points(duration),
+                duration=duration,
+                amplitude=amplitude,
+            )
+
+        super().__init__(values, **kwargs)
+
+    @staticmethod
+    def func(
+        t: ArrayLike,
+        *,
+        duration: float,
+        amplitude: float,
+    ) -> NDArray:
+        """
+        Vertical ramp pulse function.
+
+        Parameters
+        ----------
+        t : ArrayLike
+            Time points at which to evaluate the pulse.
+        duration : float
+            Duration of the pulse in ns.
+        amplitude : float
+            Amplitude of the pulse.
+        """
+        t = np.asarray(t)
+
+        if duration == 0:
+            return np.zeros_like(t, dtype=np.complex128)
+
+        # Compute only on the valid domain to avoid sqrt of negative numbers
+        mask = (t >= 0) & (t <= duration)
+        out = np.zeros_like(t, dtype=np.float64)
+        if np.any(mask):
+            u = t[mask] / duration
+            # Clip for numerical stability at the boundary (e.g., u ~ 1 +/- eps)
+            arg = np.clip(1.0 - u**2, 0.0, 1.0)
+            out[mask] = amplitude * (1.0 - np.sqrt(arg))
+
+        return out.astype(np.complex128)


### PR DESCRIPTION
This pull request introduces a new pulse type called `VertRamp` and integrates it into the existing `flat_top` pulse logic. The main focus is on expanding the library's pulse shape capabilities by adding and supporting the vertical ramp pulse.

**New pulse shape support and integration:**

* Added a new `VertRamp` class in `vert_ramp.py` that implements a vertical ramp pulse shape, including its evaluation function and documentation.
* Updated `flat_top.py` to import the new `VertRamp` class and support a `"VertRamp"` type in the `func` method, allowing the use of vertical ramp pulses in `flat_top` constructions. [[1]](diffhunk://#diff-dc518bbf3fae29009eccdc3a57e5ae68c73ce2211e38ec8da4b61b7ff9aef656R11) [[2]](diffhunk://#diff-dc518bbf3fae29009eccdc3a57e5ae68c73ce2211e38ec8da4b61b7ff9aef656R113-R125)