### PR TITLE
Update qube-calib to avoid indirect Cairo dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,7 +38,7 @@ dependencies = [
 
 [project.optional-dependencies]
 backend = [
-    "qubecalib @ git+https://github.com/alecandido/qube-calib.git@main",
+    "qubecalib @ git+https://github.com/qiqb-osaka/qube-calib.git@3.1.16beta1",
 ]
 dev = ["pyinstrument", "pytest", "pytest-cov", "ruff"]
 


### PR DESCRIPTION
This PR is used to update to the latest https://github.com/qiqb-osaka/qube-calib/releases/tag/3.1.16beta1

This was published since the `pycairo` dependency was initially introduced because of a `quelware` compatibility request. By now, `quelware` itself is not using it any longer, and neither `pycairo` nor `PyGObject` is using it directly.

I confirm that the updated tag lift the dependency.

However, being a beta tag, I leave up to you @amachino the decision about merging this to `develop` or not. 