### PR TITLE
fix: update default rotation_frequency in CharacterizationMixin methods

### DIFF
--- a/src/qubex/experiment/mixin/characterization_mixin.py
+++ b/src/qubex/experiment/mixin/characterization_mixin.py
@@ -1266,7 +1266,7 @@ class CharacterizationMixin(
         second_rotation_axis: Literal["X", "Y"] = "Y",
         shots: int = DEFAULT_SHOTS,
         interval: float = DEFAULT_INTERVAL,
-        rotation_frequency: float = 0.001, 
+        rotation_frequency: float = 0.0002, 
         plot: bool = True,
     ) -> Result:
         if time_range is None:
@@ -1364,7 +1364,7 @@ class CharacterizationMixin(
         second_rotation_axis: Literal["X", "Y"] = "Y",
         shots: int = CALIBRATION_SHOTS,
         interval: float = DEFAULT_INTERVAL,
-        rotation_frequency: float = 0.001,
+        rotation_frequency: float = 0.0002,
         plot: bool = True,
     ) -> Result:
         qubit_1 = target_qubit


### PR DESCRIPTION
obtain_coupling_strengthとjazz_experimentにおけるrotation_frequency引数のデフォルト値を、0.001から0.0002に変更しました。
0.001だとtime_rangeのデフォルト値で掃引すると振動のエイリアスが見えてしまい誤った振動周波数を検知してしまうため、振動数を落としました。
レビューをよろしくお願いいたします。