### PR TITLE
docs: Add MathJax support for rendering mathematical expressions in notebooks

### DIFF
--- a/docs/javascripts/mathjax.js
+++ b/docs/javascripts/mathjax.js
@@ -1,0 +1,17 @@
+window.MathJax = {
+  loader: { load: ["[tex]/physics"] },
+  tex: {
+    packages: { "[+]": ["physics"] },
+  },
+  options: {
+    ignoreHtmlClass: ".*|",
+    processHtmlClass: "arithmatex",
+  },
+};
+
+document$.subscribe(() => {
+  MathJax.startup.output.clearCache();
+  MathJax.typesetClear();
+  MathJax.texReset();
+  MathJax.typesetPromise();
+});

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,8 @@ plugins:
       execute: false
       include_source: true
       ignore_h1_titles: true
+      no_input: false
+      include_requirejs: false
   - mkdocstrings:
       handlers:
         python:
@@ -100,6 +102,8 @@ plugins:
 
 markdown_extensions:
   - admonition
+  - pymdownx.arithmatex:
+      generic: true
   - pymdownx.highlight
   - pymdownx.inlinehilite
   - pymdownx.superfences
@@ -111,6 +115,10 @@ extra:
 
 extra_css:
   - stylesheets/extra.css
+
+extra_javascript:
+  - javascripts/mathjax.js
+  - https://unpkg.com/mathjax@3/es5/tex-mml-chtml.js
 
 nav:
   - Home: index.md

--- a/scripts/mkdocs_hooks.py
+++ b/scripts/mkdocs_hooks.py
@@ -72,23 +72,22 @@ _INLINE_MATH_PATTERN = re.compile(r"(?<!\$)\$(?!\$)(.+?)(?<!\$)\$(?!\$)")
 
 
 def _wrap_notebook_math(html: str) -> str:
-    """Wrap $...$ and $$...$$ in notebook HTML with arithmatex spans.
+    """
+    Wrap $...$ and $$...$$ in notebook HTML with arithmatex spans.
 
     nbconvert emits bare $...$ delimiters that MathJax cannot find because
     the global ignoreHtmlClass pattern blocks classless elements. Wrapping
     them in <span class="arithmatex"> makes them visible to MathJax, just
     like pymdownx.arithmatex does for regular Markdown pages.
     """
-    html = _DISPLAY_MATH_PATTERN.sub(
-        r'<span class="arithmatex">\[\1\]</span>', html
-    )
-    html = _INLINE_MATH_PATTERN.sub(
-        r'<span class="arithmatex">\(\1\)</span>', html
-    )
+    html = _DISPLAY_MATH_PATTERN.sub(r'<span class="arithmatex">\[\1\]</span>', html)
+    html = _INLINE_MATH_PATTERN.sub(r'<span class="arithmatex">\(\1\)</span>', html)
     return html
 
 
-def on_page_content(html: str, *, page: Page, config: MkDocsConfig, files: Files) -> str:
+def on_page_content(
+    html: str, *, page: Page, config: MkDocsConfig, files: Files
+) -> str:
     """Post-process notebook HTML for MathJax v3 compatibility."""
     html = _MATHJAX_V2_PATTERN.sub("", html)
     if isinstance(page.file, NotebookFile):

--- a/scripts/mkdocs_hooks.py
+++ b/scripts/mkdocs_hooks.py
@@ -1,5 +1,6 @@
 """MkDocs build hooks for the Qubex documentation site."""
 
+import re
 from collections.abc import Callable
 from pathlib import Path
 
@@ -59,6 +60,40 @@ def _on_files_restore_notebooks(files: Files, config: MkDocsConfig) -> Files:
 
 
 on_files = CombinedEvent(_on_files_add_api_reference, _on_files_restore_notebooks)
+
+
+_MATHJAX_V2_PATTERN = re.compile(
+    r"<!-- Load mathjax -->.*?<!-- End of mathjax configuration -->",
+    re.DOTALL,
+)
+
+_DISPLAY_MATH_PATTERN = re.compile(r"\$\$(.+?)\$\$", re.DOTALL)
+_INLINE_MATH_PATTERN = re.compile(r"(?<!\$)\$(?!\$)(.+?)(?<!\$)\$(?!\$)")
+
+
+def _wrap_notebook_math(html: str) -> str:
+    """Wrap $...$ and $$...$$ in notebook HTML with arithmatex spans.
+
+    nbconvert emits bare $...$ delimiters that MathJax cannot find because
+    the global ignoreHtmlClass pattern blocks classless elements. Wrapping
+    them in <span class="arithmatex"> makes them visible to MathJax, just
+    like pymdownx.arithmatex does for regular Markdown pages.
+    """
+    html = _DISPLAY_MATH_PATTERN.sub(
+        r'<span class="arithmatex">\[\1\]</span>', html
+    )
+    html = _INLINE_MATH_PATTERN.sub(
+        r'<span class="arithmatex">\(\1\)</span>', html
+    )
+    return html
+
+
+def on_page_content(html: str, *, page: Page, config: MkDocsConfig, files: Files) -> str:
+    """Post-process notebook HTML for MathJax v3 compatibility."""
+    html = _MATHJAX_V2_PATTERN.sub("", html)
+    if isinstance(page.file, NotebookFile):
+        html = _wrap_notebook_math(html)
+    return html
 
 
 def on_page_read_source(*, page: Page, config: MkDocsConfig) -> str | None:


### PR DESCRIPTION
Introduce MathJax integration to enable rendering of mathematical expressions in notebooks, enhancing the documentation's capability to display complex formulas.

left: after

<img width="1128" height="409" alt="CleanShot 2026-04-03 at 13 30 52" src="https://github.com/user-attachments/assets/b7f0dce3-cb3f-4a5b-b0d9-a3a49629f627" />
