### PR TITLE
contrib: add superconducting-gap and resistance-charge helpers

### DIFF
--- a/src/qubex/contrib/__init__.py
+++ b/src/qubex/contrib/__init__.py
@@ -48,6 +48,10 @@ from .experiment.stark_characterization import (
     stark_ramsey_experiment,
     stark_t1_experiment,
 )
+from .experiment.superconducting_gap import (
+    get_resistance_charge,
+    get_superconducting_gap,
+)
 
 __all__ = [
     "cr_crosstalk_hamiltonian_tomography",
@@ -64,6 +68,8 @@ __all__ = [
     "create_measurement_rounds",
     "create_mqc_sequence",
     "fourier_analysis",
+    "get_resistance_charge",
+    "get_superconducting_gap",
     "ghz_state_tomography",
     "interleaved_purity_benchmarking",
     "ipb_experiment",

--- a/src/qubex/contrib/experiment/__init__.py
+++ b/src/qubex/contrib/experiment/__init__.py
@@ -41,6 +41,7 @@ from .purity_benchmarking import (
 from .rzx_gate import rzx, rzx_gate_property
 from .simultaneous_coherence_measurement import simultaneous_coherence_measurement
 from .stark_characterization import stark_ramsey_experiment, stark_t1_experiment
+from .superconducting_gap import get_resistance_charge, get_superconducting_gap
 
 __all__ = [
     "cr_crosstalk_hamiltonian_tomography",
@@ -57,6 +58,8 @@ __all__ = [
     "create_measurement_rounds",
     "create_mqc_sequence",
     "fourier_analysis",
+    "get_resistance_charge",
+    "get_superconducting_gap",
     "ghz_state_tomography",
     "interleaved_purity_benchmarking",
     "ipb_experiment",

--- a/src/qubex/contrib/experiment/superconducting_gap.py
+++ b/src/qubex/contrib/experiment/superconducting_gap.py
@@ -1,0 +1,583 @@
+"""Contributed superconducting-gap estimation helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from pathlib import Path
+from typing import Any
+
+import numpy as np
+import plotly.graph_objects as go
+import yaml
+
+import qubex.visualization as viz
+from qubex.experiment import Experiment
+from qubex.experiment.models import Result
+from qubex.system.lattice_graph import NODE_SIZE, TEXT_SIZE, LatticeGraph
+from qubex.visualization import save_figure
+
+_ELECTRON_CHARGE_C = 1.602176634e-19
+_DEFAULT_DESCRIPTION = (
+    "The minimum energy required to break an electron pair in a superconductor"
+)
+_DEFAULT_UNIT = "ueV"
+_DEFAULT_RESISTANCE_DESCRIPTION = "Resistance charge after annealing"
+_DEFAULT_RESISTANCE_UNIT = "ohms"
+
+
+def _infer_all_qubit_labels(exp: Experiment) -> list[str]:
+    chip_qubit_count_text = exp.chip_id.split("Q", maxsplit=1)[0]
+    if not chip_qubit_count_text.isdigit():
+        return list(exp.ctx.qubit_labels)
+
+    chip_qubit_count = int(chip_qubit_count_text)
+    label_width = max((len(label) - 1 for label in exp.ctx.qubit_labels), default=0)
+    if label_width <= 0:
+        label_width = len(str(chip_qubit_count - 1))
+    return [f"Q{index:0{label_width}d}" for index in range(chip_qubit_count)]
+
+
+def _load_resistance_map_from_file(path: Path) -> dict[str, float | None]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError("resistance yaml must contain a mapping payload.")
+
+    data = payload.get("data")
+    if not isinstance(data, dict):
+        raise TypeError("resistance yaml must contain a `data` mapping.")
+
+    resistance_map: dict[str, float | None] = {}
+    for key, value in data.items():
+        key_text = str(key)
+        if value is None:
+            resistance_map[key_text] = None
+            continue
+        resistance_map[key_text] = float(value)
+    return resistance_map
+
+
+def _load_resistance_payload(path: Path) -> dict[str, object]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError("resistance yaml must contain a mapping payload.")
+
+    data_obj = payload.get("data")
+    if not isinstance(data_obj, dict):
+        raise TypeError("resistance yaml must contain a `data` mapping.")
+
+    meta_obj = payload.get("meta")
+    if meta_obj is None:
+        meta_obj = {}
+    if not isinstance(meta_obj, dict):
+        raise TypeError("resistance yaml `meta` must be a mapping.")
+
+    parsed_data: dict[str, float | None] = {}
+    for key, value in data_obj.items():
+        key_text = str(key)
+        if value is None:
+            parsed_data[key_text] = None
+            continue
+        parsed_data[key_text] = float(value)
+
+    description = meta_obj.get("description", _DEFAULT_RESISTANCE_DESCRIPTION)
+    unit = meta_obj.get("unit", _DEFAULT_RESISTANCE_UNIT)
+    if not isinstance(description, str):
+        raise TypeError("resistance yaml `meta.description` must be a string.")
+    if not isinstance(unit, str):
+        raise TypeError("resistance yaml `meta.unit` must be a string.")
+
+    return {
+        "meta": {
+            "description": description,
+            "unit": unit,
+        },
+        "data": parsed_data,
+    }
+
+
+def _load_superconducting_gap_payload(path: Path) -> dict[str, object]:
+    payload = yaml.safe_load(path.read_text(encoding="utf-8"))
+    if not isinstance(payload, dict):
+        raise TypeError("superconducting gap yaml must contain a mapping payload.")
+
+    data_obj = payload.get("data")
+    if not isinstance(data_obj, dict):
+        raise TypeError("superconducting gap yaml must contain a `data` mapping.")
+
+    meta_obj = payload.get("meta")
+    if meta_obj is None:
+        meta_obj = {}
+    if not isinstance(meta_obj, dict):
+        raise TypeError("superconducting gap yaml `meta` must be a mapping.")
+
+    parsed_data: dict[str, float | None] = {}
+    for key, value in data_obj.items():
+        key_text = str(key)
+        if value is None:
+            parsed_data[key_text] = None
+            continue
+        parsed_data[key_text] = float(value)
+
+    description = meta_obj.get("description", _DEFAULT_DESCRIPTION)
+    unit = meta_obj.get("unit", _DEFAULT_UNIT)
+    if not isinstance(description, str):
+        raise TypeError("superconducting gap yaml `meta.description` must be a string.")
+    if not isinstance(unit, str):
+        raise TypeError("superconducting gap yaml `meta.unit` must be a string.")
+
+    return {
+        "meta": {
+            "description": description,
+            "unit": unit,
+        },
+        "data": parsed_data,
+    }
+
+
+def _resolve_params_path(exp: Experiment) -> Path | None:
+    config_loader = getattr(exp, "config_loader", None)
+    if config_loader is None:
+        return None
+    params_path = getattr(config_loader, "params_path", None)
+    if params_path is None:
+        return None
+    return Path(params_path)
+
+
+def _normalize_qubit_keyed_values(
+    raw_values: Mapping[str, float | None],
+    *,
+    all_labels: list[str],
+) -> dict[str, float | None]:
+    normalized: dict[str, float | None] = {}
+    label_set = set(all_labels)
+    index_to_label = dict(enumerate(all_labels))
+
+    for key, value in raw_values.items():
+        if key in label_set:
+            normalized[key] = value
+            continue
+
+        index: int | None = None
+        if key.isdigit():
+            index = int(key)
+        elif key.startswith("Q") and key[1:].isdigit():
+            index = int(key[1:])
+
+        if index is not None and index in index_to_label:
+            normalized[index_to_label[index]] = value
+
+    return normalized
+
+
+def dump_superconducting_gap_yaml(
+    superconducting_gap: Mapping[str, Any],
+    output_path: str | Path,
+) -> None:
+    """
+    Serialize a superconducting-gap payload to YAML.
+
+    Parameters
+    ----------
+    superconducting_gap
+        Superconducting-gap payload returned by `get_superconducting_gap`.
+    output_path
+        Destination path for the YAML file.
+    """
+    path = Path(output_path)
+    serialized = yaml.safe_dump(
+        dict(superconducting_gap),
+        sort_keys=False,
+        allow_unicode=False,
+    )
+    path.write_text(serialized, encoding="utf-8")
+
+
+def _build_superconducting_gap_figure(
+    *,
+    all_labels: list[str],
+    values_by_label: Mapping[str, float | None],
+    title: str,
+    unit_label: str,
+) -> go.Figure:
+    graph = LatticeGraph(len(all_labels))
+    ordered_labels = all_labels
+    plot_values = [
+        np.nan if values_by_label.get(label) is None else values_by_label[label]
+        for label in ordered_labels
+    ]
+    plot_texts: list[str] = []
+    plot_hovertexts: list[str] = []
+    for label in ordered_labels:
+        value = values_by_label.get(label)
+        if value is None:
+            plot_texts.append("N/A")
+            plot_hovertexts.append(f"{label}: N/A")
+            continue
+        plot_texts.append(f"{label}<br>{value:.1f}<br>{unit_label}")
+        plot_hovertexts.append(f"{label}: {value:.3f} {unit_label}")
+
+    fig = viz.make_figure()
+    fig.add_trace(
+        go.Heatmap(
+            z=graph.create_data_matrix(plot_values),
+            text=graph.create_data_matrix(plot_texts),
+            colorscale="Viridis",
+            hoverinfo="text",
+            hovertext=graph.create_data_matrix(plot_hovertexts),
+            texttemplate="%{text}",
+            showscale=False,
+            textfont=dict(
+                family="monospace",
+                size=TEXT_SIZE,
+                weight="bold",
+            ),
+        )
+    )
+
+    width = 3 * NODE_SIZE * graph.n_qubit_cols
+    height = 3 * NODE_SIZE * graph.n_qubit_rows
+    fig.update_layout(
+        title=title,
+        showlegend=False,
+        margin=dict(b=30, l=30, r=30, t=60),
+        xaxis=dict(
+            ticks="",
+            linewidth=1,
+            showgrid=False,
+            zeroline=False,
+            showticklabels=False,
+        ),
+        yaxis=dict(
+            ticks="",
+            autorange="reversed",
+            linewidth=1,
+            showgrid=False,
+            zeroline=False,
+            showticklabels=False,
+        ),
+        width=width,
+        height=height,
+    )
+    return fig
+
+
+def get_superconducting_gap(
+    exp: Experiment,
+    resistance_charge: Mapping[str, float | None] | str | Path | None = None,
+    *,
+    plot: bool | None = None,
+    save_image: bool | None = None,
+    image_name: str | None = None,
+    output_path: str | Path | None = None,
+) -> Result:
+    """
+    Estimate superconducting-gap parameters from qubit and resistance data.
+
+    Parameters
+    ----------
+    exp
+        Experiment instance that provides per-qubit frequency and anharmonicity.
+    resistance_charge
+        Resistance values in ohms keyed by qubit label, a yaml path with
+        `{"meta": ..., "data": {...}}` payload, or `None`.
+        When `None`, this function loads
+        `<exp.config_loader.params_path>/resistance_charge.yaml`.
+    plot
+        Whether to render a chip-layout heatmap similarly to
+        `qubex.experiment.experiment_tool.print_chip_info`.
+    save_image
+        Whether to save the rendered heatmap image.
+    image_name
+        Image name used when `save_image=True`.
+    output_path
+        Optional yaml path. When provided, the result is serialized to this path.
+
+    Returns
+    -------
+    Result
+        Result container with payload keys `meta` and `data`, and optional
+        `figure` when plotting is requested.
+
+    Raises
+    ------
+    FileNotFoundError
+        If `resistance_charge` is not provided and the default params file is
+        missing, or when a provided path does not exist.
+    ValueError
+        If required resistance data is missing, resistance is non-positive,
+        or anharmonicity is zero for an available qubit.
+
+    Notes
+    -----
+    This function is cache-first.
+    If `<params_path>/superconducting_gap.yaml` exists, it is loaded and used.
+    Otherwise the value is computed from resistance and then saved to that path.
+
+    This helper uses the same empirical formula as the superconducting-gap
+    notebook prototype:
+    `gap = 1e15 * e * R_n * (f + |alpha|)^2 / |alpha|`.
+    """
+    if plot is None:
+        plot = False
+    if save_image is None:
+        save_image = False
+    if image_name is None:
+        image_name = "superconducting_gap"
+
+    params_path = _resolve_params_path(exp)
+    inferred_all_labels = _infer_all_qubit_labels(exp)
+
+    default_gap_path = (
+        params_path / "superconducting_gap.yaml" if params_path is not None else None
+    )
+    if default_gap_path is not None and default_gap_path.exists():
+        superconducting_gap = _load_superconducting_gap_payload(default_gap_path)
+        loaded_data = superconducting_gap["data"]
+        if not isinstance(loaded_data, dict):
+            raise TypeError("superconducting gap payload `data` must be a mapping.")
+        data = loaded_data
+    else:
+        if resistance_charge is None:
+            if params_path is None:
+                raise FileNotFoundError(
+                    "No `resistance_charge` source was provided and params path "
+                    "is unavailable from `exp.config_loader.params_path`."
+                )
+            default_path = params_path / "resistance_charge.yaml"
+            if not default_path.exists():
+                raise FileNotFoundError(
+                    "No `resistance_charge` source was provided, and default file "
+                    f"`{default_path}` was not found."
+                )
+            resistance_map = _load_resistance_map_from_file(default_path)
+        elif isinstance(resistance_charge, (str, Path)):
+            resistance_path = Path(resistance_charge)
+            if not resistance_path.exists():
+                raise FileNotFoundError(
+                    f"`resistance_charge` file was not found: {resistance_path}"
+                )
+            resistance_map = _load_resistance_map_from_file(resistance_path)
+        else:
+            resistance_map = {
+                str(key): (None if value is None else float(value))
+                for key, value in resistance_charge.items()
+            }
+        resistance_map = _normalize_qubit_keyed_values(
+            resistance_map,
+            all_labels=inferred_all_labels,
+        )
+
+        available_labels = set(exp.ctx.qubit_labels)
+        data = {}
+        for qubit_label in inferred_all_labels:
+            qubit_param = exp.ctx.qubits.get(qubit_label)
+            if qubit_label not in available_labels or qubit_param is None:
+                data[qubit_label] = None
+                continue
+
+            if qubit_label not in resistance_map:
+                raise ValueError(f"`resistance_charge` is missing target `{qubit_label}`.")
+
+            resistance_ohm = resistance_map[qubit_label]
+            if resistance_ohm is None:
+                data[qubit_label] = None
+                continue
+            if resistance_ohm <= 0:
+                raise ValueError(
+                    f"`resistance_charge[{qubit_label}]` must be positive: {resistance_ohm}."
+                )
+
+            anharmonicity_ghz = abs(float(qubit_param.anharmonicity))
+            if anharmonicity_ghz == 0:
+                raise ValueError(
+                    f"Anharmonicity for `{qubit_label}` must not be zero to estimate gap."
+                )
+
+            frequency_ghz = float(qubit_param.frequency)
+            gap_uev = (
+                1e15
+                * _ELECTRON_CHARGE_C
+                * resistance_ohm
+                * (frequency_ghz + anharmonicity_ghz) ** 2
+                / anharmonicity_ghz
+            )
+            data[qubit_label] = gap_uev
+
+        superconducting_gap = {
+            "meta": {
+                "description": _DEFAULT_DESCRIPTION,
+                "unit": _DEFAULT_UNIT,
+            },
+            "data": data,
+        }
+
+        if default_gap_path is not None:
+            default_gap_path.parent.mkdir(parents=True, exist_ok=True)
+            dump_superconducting_gap_yaml(
+                superconducting_gap=superconducting_gap,
+                output_path=default_gap_path,
+            )
+
+    if output_path is not None:
+        dump_superconducting_gap_yaml(
+            superconducting_gap=superconducting_gap,
+            output_path=output_path,
+        )
+
+    figure: go.Figure | None = None
+    if plot:
+        figure = _build_superconducting_gap_figure(
+            all_labels=inferred_all_labels,
+            values_by_label=data,
+            title="Superconducting gap (ueV)",
+            unit_label="ueV",
+        )
+        figure.show()
+        if save_image:
+            figure_width = int(figure.layout.width) if figure.layout.width is not None else None
+            figure_height = (
+                int(figure.layout.height) if figure.layout.height is not None else None
+            )
+            save_figure(
+                figure,
+                name=image_name,
+                format="png",
+                width=figure_width,
+                height=figure_height,
+                scale=3,
+            )
+
+    return Result(data=superconducting_gap, figure=figure)
+
+
+def get_resistance_charge(
+    exp: Experiment,
+    resistance_charge: Mapping[str, float | None] | str | Path | None = None,
+    *,
+    plot: bool | None = None,
+    save_image: bool | None = None,
+    image_name: str | None = None,
+) -> Result:
+    """
+    Load resistance-charge data and optionally plot it on chip layout.
+
+    Parameters
+    ----------
+    exp
+        Experiment instance used to resolve chip labels and params path.
+    resistance_charge
+        Resistance values in ohms keyed by qubit label, a yaml path with
+        `{"meta": ..., "data": {...}}` payload, or `None`.
+        When `None`, this function loads
+        `<exp.config_loader.params_path>/resistance_charge.yaml`.
+    plot
+        Whether to render a chip-layout heatmap.
+    save_image
+        Whether to save the rendered heatmap image.
+    image_name
+        Image name used when `save_image=True`.
+
+    Returns
+    -------
+    Result
+        Result container with payload keys `meta` and `data`, and optional
+        `figure` when plotting is requested.
+
+    Raises
+    ------
+    FileNotFoundError
+        If no resistance source is provided and the default params file is
+        missing, or when a provided path does not exist.
+    """
+    if plot is None:
+        plot = False
+    if save_image is None:
+        save_image = False
+    if image_name is None:
+        image_name = "resistance_charge"
+
+    params_path = _resolve_params_path(exp)
+    inferred_all_labels = _infer_all_qubit_labels(exp)
+
+    if resistance_charge is None:
+        if params_path is None:
+            raise FileNotFoundError(
+                "No `resistance_charge` source was provided and params path "
+                "is unavailable from `exp.config_loader.params_path`."
+            )
+        default_path = params_path / "resistance_charge.yaml"
+        if not default_path.exists():
+            raise FileNotFoundError(
+                "No `resistance_charge` source was provided, and default file "
+                f"`{default_path}` was not found."
+            )
+        resistance_payload = _load_resistance_payload(default_path)
+    elif isinstance(resistance_charge, (str, Path)):
+        resistance_path = Path(resistance_charge)
+        if not resistance_path.exists():
+            raise FileNotFoundError(
+                f"`resistance_charge` file was not found: {resistance_path}"
+            )
+        resistance_payload = _load_resistance_payload(resistance_path)
+    else:
+        resistance_payload = {
+            "meta": {
+                "description": _DEFAULT_RESISTANCE_DESCRIPTION,
+                "unit": _DEFAULT_RESISTANCE_UNIT,
+            },
+            "data": {
+                str(key): (None if value is None else float(value))
+                for key, value in resistance_charge.items()
+            },
+        }
+
+    payload_data_obj = resistance_payload["data"]
+    if not isinstance(payload_data_obj, dict):
+        raise TypeError("resistance payload `data` must be a mapping.")
+
+    normalized_payload_data = _normalize_qubit_keyed_values(
+        payload_data_obj,  # type: ignore[arg-type]
+        all_labels=inferred_all_labels,
+    )
+    full_data: dict[str, float | None] = {}
+    for qubit_label in inferred_all_labels:
+        value = normalized_payload_data.get(qubit_label)
+        full_data[qubit_label] = None if value is None else float(value)
+
+    result_payload: dict[str, object] = {
+        "meta": resistance_payload["meta"],
+        "data": full_data,
+    }
+
+    figure: go.Figure | None = None
+    if plot:
+        figure = _build_superconducting_gap_figure(
+            all_labels=inferred_all_labels,
+            values_by_label=full_data,
+            title="Resistance charge (ohms)",
+            unit_label="ohms",
+        )
+        figure.show()
+        if save_image:
+            figure_width = int(figure.layout.width) if figure.layout.width is not None else None
+            figure_height = (
+                int(figure.layout.height) if figure.layout.height is not None else None
+            )
+            save_figure(
+                figure,
+                name=image_name,
+                format="png",
+                width=figure_width,
+                height=figure_height,
+                scale=3,
+            )
+
+    return Result(data=result_payload, figure=figure)
+
+
+__all__ = [
+    "dump_superconducting_gap_yaml",
+    "get_resistance_charge",
+    "get_superconducting_gap",
+]

--- a/src/qubex/contrib/experiment/superconducting_gap.py
+++ b/src/qubex/contrib/experiment/superconducting_gap.py
@@ -378,7 +378,9 @@ def get_superconducting_gap(
                 continue
 
             if qubit_label not in resistance_map:
-                raise ValueError(f"`resistance_charge` is missing target `{qubit_label}`.")
+                raise ValueError(
+                    f"`resistance_charge` is missing target `{qubit_label}`."
+                )
 
             resistance_ohm = resistance_map[qubit_label]
             if resistance_ohm is None:
@@ -436,7 +438,9 @@ def get_superconducting_gap(
         )
         figure.show()
         if save_image:
-            figure_width = int(figure.layout.width) if figure.layout.width is not None else None
+            figure_width = (
+                int(figure.layout.width) if figure.layout.width is not None else None
+            )
             figure_height = (
                 int(figure.layout.height) if figure.layout.height is not None else None
             )
@@ -574,7 +578,9 @@ def get_resistance_charge(
         )
         figure.show()
         if save_image:
-            figure_width = int(figure.layout.width) if figure.layout.width is not None else None
+            figure_width = (
+                int(figure.layout.width) if figure.layout.width is not None else None
+            )
             figure_height = (
                 int(figure.layout.height) if figure.layout.height is not None else None
             )

--- a/src/qubex/contrib/experiment/superconducting_gap.py
+++ b/src/qubex/contrib/experiment/superconducting_gap.py
@@ -73,11 +73,12 @@ def _load_resistance_payload(path: Path) -> dict[str, object]:
 
     parsed_data: dict[str, float | None] = {}
     for key, value in data_obj.items():
-        key_text = str(key)
+        if not isinstance(key, str):
+            raise TypeError("resistance yaml keys must be qubit-label strings.")
         if value is None:
-            parsed_data[key_text] = None
+            parsed_data[key] = None
             continue
-        parsed_data[key_text] = float(value)
+        parsed_data[key] = float(value)
 
     description = meta_obj.get("description", _DEFAULT_RESISTANCE_DESCRIPTION)
     unit = meta_obj.get("unit", _DEFAULT_RESISTANCE_UNIT)
@@ -264,7 +265,7 @@ def _build_superconducting_gap_figure(
 
 def get_superconducting_gap(
     exp: Experiment,
-    resistance_charge: Mapping[str, float | None] | str | Path | None = None,
+    resistance_charge: Mapping[str | int, float | None] | str | Path | None = None,
     *,
     plot: bool | None = None,
     save_image: bool | None = None,
@@ -453,11 +454,12 @@ def get_superconducting_gap(
 
 def get_resistance_charge(
     exp: Experiment,
-    resistance_charge: Mapping[str, float | None] | str | Path | None = None,
+    resistance_charge: Mapping[str | int, float | None] | str | Path | None = None,
     *,
     plot: bool | None = None,
     save_image: bool | None = None,
     image_name: str | None = None,
+    output_path: str | Path | None = None,
 ) -> Result:
     """
     Load resistance-charge data and optionally plot it on chip layout.
@@ -477,6 +479,8 @@ def get_resistance_charge(
         Whether to save the rendered heatmap image.
     image_name
         Image name used when `save_image=True`.
+    output_path
+        Optional yaml path. When provided, the payload is serialized to this path.
 
     Returns
     -------
@@ -536,12 +540,16 @@ def get_resistance_charge(
     if not isinstance(payload_data_obj, dict):
         raise TypeError("resistance payload `data` must be a mapping.")
 
+    available_labels = set(exp.ctx.qubit_labels)
     normalized_payload_data = _normalize_qubit_keyed_values(
         payload_data_obj,  # type: ignore[arg-type]
         all_labels=inferred_all_labels,
     )
     full_data: dict[str, float | None] = {}
     for qubit_label in inferred_all_labels:
+        if qubit_label not in available_labels:
+            full_data[qubit_label] = None
+            continue
         value = normalized_payload_data.get(qubit_label)
         full_data[qubit_label] = None if value is None else float(value)
 
@@ -549,6 +557,12 @@ def get_resistance_charge(
         "meta": resistance_payload["meta"],
         "data": full_data,
     }
+
+    if output_path is not None:
+        dump_superconducting_gap_yaml(
+            superconducting_gap=result_payload,
+            output_path=output_path,
+        )
 
     figure: go.Figure | None = None
     if plot:

--- a/tests/contrib/superconducting_gap/test_function_api.py
+++ b/tests/contrib/superconducting_gap/test_function_api.py
@@ -1,0 +1,11 @@
+"""Tests for functional APIs in `qubex.contrib.experiment.superconducting_gap`."""
+
+from __future__ import annotations
+
+from qubex.contrib import get_resistance_charge, get_superconducting_gap
+
+
+def test_superconducting_gap_function_is_exported_from_contrib() -> None:
+    """Given contrib package, when imported, then superconducting-gap helper is available."""
+    assert callable(get_superconducting_gap)
+    assert callable(get_resistance_charge)

--- a/tests/contrib/superconducting_gap/test_superconducting_gap.py
+++ b/tests/contrib/superconducting_gap/test_superconducting_gap.py
@@ -1,0 +1,235 @@
+"""Tests for superconducting-gap estimation helper behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from types import SimpleNamespace
+
+import pytest
+import yaml
+
+from qubex.contrib.experiment.superconducting_gap import (
+    get_resistance_charge,
+    get_superconducting_gap,
+)
+
+
+def test_superconducting_gap_fills_unavailable_qubits_with_none() -> None:
+    """Given unavailable qubit slots, when estimating gap, then result data stores None."""
+    exp = SimpleNamespace(
+        chip_id="4Qv1",
+        ctx=SimpleNamespace(
+            qubit_labels=["Q00", "Q01", "Q03"],
+            qubits={
+                "Q00": SimpleNamespace(frequency=6.0, anharmonicity=-0.3),
+                "Q01": SimpleNamespace(frequency=5.5, anharmonicity=-0.25),
+                "Q03": SimpleNamespace(frequency=5.2, anharmonicity=-0.2),
+            },
+        ),
+    )
+
+    result = get_superconducting_gap(
+        exp,  # type: ignore[arg-type]
+        resistance_charge={"Q00": 4700.0, "Q01": 4710.0, "Q03": 4720.0},
+    )
+
+    data = result.data["data"]
+    assert isinstance(data, dict)
+    assert set(data) == {"Q00", "Q01", "Q02", "Q03"}
+    assert data["Q02"] is None
+    assert data["Q00"] is not None
+    assert data["Q01"] is not None
+    assert data["Q03"] is not None
+
+
+
+def test_superconducting_gap_raises_when_resistance_is_missing() -> None:
+    """Given missing resistance, when estimating gap, then helper raises a descriptive ValueError."""
+    exp = SimpleNamespace(
+        chip_id="2Qv1",
+        ctx=SimpleNamespace(
+            qubit_labels=["Q00", "Q01"],
+            qubits={
+                "Q00": SimpleNamespace(frequency=6.0, anharmonicity=-0.3),
+                "Q01": SimpleNamespace(frequency=5.5, anharmonicity=-0.25),
+            },
+        ),
+    )
+
+    with pytest.raises(ValueError, match="missing target `Q01`"):
+        get_superconducting_gap(
+            exp,  # type: ignore[arg-type]
+            resistance_charge={"Q00": 4700.0},
+        )
+
+
+def test_superconducting_gap_raises_when_default_resistance_file_is_missing() -> None:
+    """Given no resistance source, when default params file is absent, then helper raises FileNotFoundError."""
+    missing_params_path = (
+        "/home/nilton/work/work_experiments_2026_04/.tmp/nonexistent-qubex-params"
+    )
+    exp = SimpleNamespace(
+        chip_id="2Qv1",
+        config_loader=SimpleNamespace(params_path=missing_params_path),
+        ctx=SimpleNamespace(
+            qubit_labels=["Q00", "Q01"],
+            qubits={
+                "Q00": SimpleNamespace(frequency=6.0, anharmonicity=-0.3),
+                "Q01": SimpleNamespace(frequency=5.5, anharmonicity=-0.25),
+            },
+        ),
+    )
+
+    with pytest.raises(FileNotFoundError, match="resistance_charge"):
+        get_superconducting_gap(
+            exp,  # type: ignore[arg-type]
+            resistance_charge=None,
+        )
+
+
+def test_superconducting_gap_loads_cached_file_from_params() -> None:
+    """Given cached superconducting gap yaml, when helper runs, then it loads cache without resistance input."""
+    params_path = "/home/nilton/work/work_experiments_2026_04/.tmp/test-gap-cache-load"
+    exp = SimpleNamespace(
+        chip_id="4Qv1",
+        config_loader=SimpleNamespace(params_path=params_path),
+        ctx=SimpleNamespace(
+            qubit_labels=["Q00", "Q01", "Q03"],
+            qubits={
+                "Q00": SimpleNamespace(frequency=6.0, anharmonicity=-0.3),
+                "Q01": SimpleNamespace(frequency=5.5, anharmonicity=-0.25),
+                "Q03": SimpleNamespace(frequency=5.2, anharmonicity=-0.2),
+            },
+        ),
+    )
+
+    cache_path = Path(params_path) / "superconducting_gap.yaml"
+    cache_path.parent.mkdir(parents=True, exist_ok=True)
+    payload = {
+        "meta": {"description": "cached", "unit": "ueV"},
+        "data": {"Q00": 1.0, "Q01": 2.0, "Q02": None, "Q03": 3.0},
+    }
+    cache_path.write_text(yaml.safe_dump(payload, sort_keys=False), encoding="utf-8")
+
+    result = get_superconducting_gap(
+        exp,  # type: ignore[arg-type]
+        resistance_charge=None,
+    )
+
+    assert result.data["meta"]["description"] == "cached"
+    assert result.data["data"]["Q01"] == 2.0
+
+
+def test_superconducting_gap_saves_computed_file_to_params(tmp_path: Path) -> None:
+    """Given no cached superconducting gap, when helper computes, then it saves superconducting_gap.yaml to params."""
+    params_dir = tmp_path / "gap-save-params"
+    params_dir.mkdir(parents=True, exist_ok=True)
+    exp = SimpleNamespace(
+        chip_id="4Qv1",
+        config_loader=SimpleNamespace(params_path=str(params_dir)),
+        ctx=SimpleNamespace(
+            qubit_labels=["Q00", "Q01", "Q03"],
+            qubits={
+                "Q00": SimpleNamespace(frequency=6.0, anharmonicity=-0.3),
+                "Q01": SimpleNamespace(frequency=5.5, anharmonicity=-0.25),
+                "Q03": SimpleNamespace(frequency=5.2, anharmonicity=-0.2),
+            },
+        ),
+    )
+
+    get_superconducting_gap(
+        exp,  # type: ignore[arg-type]
+        resistance_charge={"Q00": 4700.0, "Q01": 4710.0, "Q03": 4720.0},
+    )
+
+    saved_path = params_dir / "superconducting_gap.yaml"
+    assert saved_path.exists()
+
+
+def test_resistance_charge_loads_from_default_params_file(tmp_path: Path) -> None:
+    """Given default params resistance file, when helper runs, then it loads and pads unavailable slots."""
+    params_dir = tmp_path / "resistance-default-params"
+    params_dir.mkdir(parents=True, exist_ok=True)
+    resistance_path = params_dir / "resistance_charge.yaml"
+    payload = {
+        "meta": {"description": "Resistance charge after annealing", "unit": "ohms"},
+        "data": {"Q00": 4700.0, "Q01": 4710.0, "Q03": 4720.0},
+    }
+    resistance_path.write_text(
+        yaml.safe_dump(payload, sort_keys=False),
+        encoding="utf-8",
+    )
+
+    exp = SimpleNamespace(
+        chip_id="4Qv1",
+        config_loader=SimpleNamespace(params_path=str(params_dir)),
+        ctx=SimpleNamespace(
+            qubit_labels=["Q00", "Q01", "Q03"],
+            qubits={
+                "Q00": SimpleNamespace(frequency=6.0, anharmonicity=-0.3),
+                "Q01": SimpleNamespace(frequency=5.5, anharmonicity=-0.25),
+                "Q03": SimpleNamespace(frequency=5.2, anharmonicity=-0.2),
+            },
+        ),
+    )
+
+    result = get_resistance_charge(
+        exp,  # type: ignore[arg-type]
+        resistance_charge=None,
+    )
+    data = result.data["data"]
+    assert isinstance(data, dict)
+    assert set(data) == {"Q00", "Q01", "Q02", "Q03"}
+    assert data["Q02"] is None
+    assert data["Q00"] == 4700.0
+
+
+def test_resistance_charge_raises_when_default_file_is_missing() -> None:
+    """Given no source and missing default file, when helper runs, then FileNotFoundError is raised."""
+    missing_params_path = (
+        "/home/nilton/work/work_experiments_2026_04/.tmp/nonexistent-resistance-params"
+    )
+    exp = SimpleNamespace(
+        chip_id="2Qv1",
+        config_loader=SimpleNamespace(params_path=missing_params_path),
+        ctx=SimpleNamespace(
+            qubit_labels=["Q00", "Q01"],
+            qubits={
+                "Q00": SimpleNamespace(frequency=6.0, anharmonicity=-0.3),
+                "Q01": SimpleNamespace(frequency=5.5, anharmonicity=-0.25),
+            },
+        ),
+    )
+
+    with pytest.raises(FileNotFoundError, match="resistance_charge"):
+        get_resistance_charge(
+            exp,  # type: ignore[arg-type]
+            resistance_charge=None,
+        )
+
+
+def test_resistance_charge_accepts_numeric_index_keys() -> None:
+    """Given numeric index keys, when loading resistance values, then helper maps them to qubit labels."""
+    exp = SimpleNamespace(
+        chip_id="4Qv1",
+        ctx=SimpleNamespace(
+            qubit_labels=["Q00", "Q01", "Q03"],
+            qubits={
+                "Q00": SimpleNamespace(frequency=6.0, anharmonicity=-0.3),
+                "Q01": SimpleNamespace(frequency=5.5, anharmonicity=-0.25),
+                "Q03": SimpleNamespace(frequency=5.2, anharmonicity=-0.2),
+            },
+        ),
+    )
+
+    result = get_resistance_charge(
+        exp,  # type: ignore[arg-type]
+        resistance_charge={0: 4700.0, "1": 4710.0, 3: 4720.0},
+    )
+
+    data = result.data["data"]
+    assert isinstance(data, dict)
+    assert data["Q00"] == 4700.0
+    assert data["Q01"] == 4710.0
+    assert data["Q02"] is None
+    assert data["Q03"] == 4720.0

--- a/tests/contrib/superconducting_gap/test_superconducting_gap.py
+++ b/tests/contrib/superconducting_gap/test_superconducting_gap.py
@@ -86,12 +86,13 @@ def test_superconducting_gap_raises_when_default_resistance_file_is_missing() ->
         )
 
 
-def test_superconducting_gap_loads_cached_file_from_params() -> None:
+def test_superconducting_gap_loads_cached_file_from_params(tmp_path: Path) -> None:
     """Given cached superconducting gap yaml, when helper runs, then it loads cache without resistance input."""
-    params_path = "/home/nilton/work/work_experiments_2026_04/.tmp/test-gap-cache-load"
+    params_dir = tmp_path / "test-gap-cache-load"
+    params_dir.mkdir(parents=True, exist_ok=True)
     exp = SimpleNamespace(
         chip_id="4Qv1",
-        config_loader=SimpleNamespace(params_path=params_path),
+        config_loader=SimpleNamespace(params_path=str(params_dir)),
         ctx=SimpleNamespace(
             qubit_labels=["Q00", "Q01", "Q03"],
             qubits={
@@ -102,7 +103,7 @@ def test_superconducting_gap_loads_cached_file_from_params() -> None:
         ),
     )
 
-    cache_path = Path(params_path) / "superconducting_gap.yaml"
+    cache_path = params_dir / "superconducting_gap.yaml"
     cache_path.parent.mkdir(parents=True, exist_ok=True)
     payload = {
         "meta": {"description": "cached", "unit": "ueV"},

--- a/tests/contrib/superconducting_gap/test_superconducting_gap.py
+++ b/tests/contrib/superconducting_gap/test_superconducting_gap.py
@@ -42,7 +42,6 @@ def test_superconducting_gap_fills_unavailable_qubits_with_none() -> None:
     assert data["Q03"] is not None
 
 
-
 def test_superconducting_gap_raises_when_resistance_is_missing() -> None:
     """Given missing resistance, when estimating gap, then helper raises a descriptive ValueError."""
     exp = SimpleNamespace(

--- a/tests/contrib/test_top_level_module_export.py
+++ b/tests/contrib/test_top_level_module_export.py
@@ -10,3 +10,5 @@ def test_contrib_module_is_exported_from_qubex() -> None:
     assert callable(contrib.measure_cr_crosstalk)
     assert callable(contrib.simultaneous_coherence_measurement)
     assert callable(contrib.purity_benchmarking)
+    assert callable(contrib.get_superconducting_gap)
+    assert callable(contrib.get_resistance_charge)


### PR DESCRIPTION
## Summary

This PR adds contrib helpers for resistance/superconducting-gap workflows:

- `get_resistance_charge(...)`
- `get_superconducting_gap(...)`

Both return `Result` and support chip-layout plotting.

## Physics model used

The implementation uses standard transmon + Josephson-junction relations.

Transmon approximation:

- `f01 ≈ (sqrt(8*EJ*EC) - EC) / h`
- `|alpha| ≈ EC / h`

So:

- `EJ / h ≈ (f01 + |alpha|)^2 / (8*|alpha|)`

Ambegaokar–Baratoff + Josephson energy:

- `Ic * Rn = pi * Delta / (2*e)`
- `EJ = hbar * Ic / (2*e) = h * Ic / (4*pi*e)`
- therefore `Delta = 2*e*EJ*Rn / hbar`

Substituting `EJ/h` gives:

- `Delta ≈ e^2 * Rn * (f01 + |alpha|)^2 / |alpha|`  (frequencies in Hz)

When `f01` and `|alpha|` are in GHz and output is in `ueV`, this is implemented as:

- `gap_uev = 1e15 * _ELECTRON_CHARGE_C * resistance_ohm * (frequency_ghz + anharmonicity_ghz) ** 2 / anharmonicity_ghz`
- file/line: [superconducting_gap.py:398](/home/nilton/work/work_experiments_2026_04/qubex/src/qubex/contrib/experiment/superconducting_gap.py:398)

## Behavior

- Cache-first for superconducting gap:
  - load `params/superconducting_gap.yaml` if present
  - otherwise compute from resistance and save it
- Resistance helper loads/plots `resistance_charge` directly
- Plot style/size follows the same lattice format used by Qubex chip-info plots

## References

- Koch et al., Phys. Rev. A 76, 042319 (2007)
- Ambegaokar & Baratoff, Phys. Rev. Lett. 10, 486 (1963)
