### PR TITLE
feat: add in_same_mux option to 2q characterization

### DIFF
--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -5055,6 +5055,7 @@ class Experiment:
         self,
         targets: Collection[str] | str | None = None,
         *,
+        in_same_mux: bool = True,
         n_shots: int | None = None,
         shot_interval: int | None = None,
         plot: bool | None = None,
@@ -5063,6 +5064,7 @@ class Experiment:
         """Run basic two-qubit characterization routines."""
         return self.characterization_service.characterize_2q(
             targets=targets,
+            in_same_mux=in_same_mux,
             shots=n_shots,
             interval=shot_interval,
             plot=plot,

--- a/src/qubex/experiment/experiment_context.py
+++ b/src/qubex/experiment/experiment_context.py
@@ -802,11 +802,13 @@ class ExperimentContext:
 
     def get_edge_pairs(
         self,
+        *,
+        in_same_mux: bool = True,
     ) -> list[tuple[str, str]]:
         """Get the qubit edge pairs."""
         edge_pairs = []
         for qubit in self.qubit_labels:
-            spectators = self.get_spectators(qubit, in_same_mux=True)
+            spectators = self.get_spectators(qubit, in_same_mux=in_same_mux)
             for spectator in spectators:
                 pair = (qubit, spectator.label)
                 edge_pairs.append(pair)
@@ -814,9 +816,14 @@ class ExperimentContext:
 
     def get_edge_labels(
         self,
+        *,
+        in_same_mux: bool = True,
     ) -> list[str]:
         """Get the qubit edge labels."""
-        return [f"{pair[0]}-{pair[1]}" for pair in self.get_edge_pairs()]
+        return [
+            f"{pair[0]}-{pair[1]}"
+            for pair in self.get_edge_pairs(in_same_mux=in_same_mux)
+        ]
 
     def cr_pair(self, cr_label: str) -> tuple[str, str]:
         """Return the control/target qubit pair for a CR label."""

--- a/src/qubex/experiment/services/characterization_service.py
+++ b/src/qubex/experiment/services/characterization_service.py
@@ -4141,6 +4141,7 @@ class CharacterizationService:
         self,
         targets: Collection[str] | str | None = None,
         *,
+        in_same_mux: bool = True,
         shots: int | None = None,
         interval: float | None = None,
         plot: bool | None = None,
@@ -4153,6 +4154,8 @@ class CharacterizationService:
         ----------
         targets
             Target edges to characterize.
+        in_same_mux
+            Whether to restrict default target edges to the same mux.
         shots
             Number of shots per experiment.
         plot
@@ -4167,7 +4170,7 @@ class CharacterizationService:
         if save_image is None:
             save_image = True
         if targets is None:
-            targets = self.ctx.edge_labels
+            targets = self.ctx.get_edge_labels(in_same_mux=in_same_mux)
         elif isinstance(targets, str):
             targets = [targets]
         else:

--- a/tests/experiment/test_experiment_context_targets.py
+++ b/tests/experiment/test_experiment_context_targets.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Literal
 
 from qubex.experiment.experiment_context import ExperimentContext
@@ -110,3 +111,43 @@ def test_targets_keep_cr_pair_with_active_spectator(monkeypatch) -> None:
     )
 
     assert set(context.targets) == {"Q00-Q01"}
+
+
+def test_get_edge_labels_filters_to_same_mux_by_default(monkeypatch) -> None:
+    """Given mux-mixed spectators, when getting edge labels, then only same-mux edges are returned by default."""
+    context = object.__new__(ExperimentContext)
+    context.__dict__["_qubits"] = ["Q00"]
+
+    def _get_spectators(
+        qubit: str, *, in_same_mux: bool = True
+    ) -> list[SimpleNamespace]:
+        assert qubit == "Q00"
+        if in_same_mux:
+            return [SimpleNamespace(label="Q01")]
+        return [SimpleNamespace(label="Q01"), SimpleNamespace(label="Q02")]
+
+    monkeypatch.setattr(context, "get_spectators", _get_spectators)
+
+    assert context.get_edge_labels() == ["Q00-Q01"]
+
+
+def test_get_edge_labels_can_include_cross_mux_edges(monkeypatch) -> None:
+    """Given mux-mixed spectators, when in_same_mux is false, then cross-mux edges are included."""
+    context = object.__new__(ExperimentContext)
+    context.__dict__["_qubits"] = ["Q00"]
+
+    recorded: list[bool] = []
+
+    def _get_spectators(
+        qubit: str, *, in_same_mux: bool = True
+    ) -> list[SimpleNamespace]:
+        assert qubit == "Q00"
+        recorded.append(in_same_mux)
+        if in_same_mux:
+            return [SimpleNamespace(label="Q01")]
+        return [SimpleNamespace(label="Q01"), SimpleNamespace(label="Q02")]
+
+    monkeypatch.setattr(context, "get_spectators", _get_spectators)
+
+    assert context.get_edge_labels(in_same_mux=False) == ["Q00-Q01", "Q00-Q02"]
+    assert recorded == [False]

--- a/tests/experiment/test_experiment_facade_delegation.py
+++ b/tests/experiment/test_experiment_facade_delegation.py
@@ -293,7 +293,7 @@ def test_characterize_2q_delegates_in_same_mux_to_characterization_service() -> 
         targets=None,
         in_same_mux=False,
         n_shots=512,
-        shot_interval=240.0,
+        shot_interval=240,
         plot=False,
         save_image=True,
     )
@@ -306,7 +306,7 @@ def test_characterize_2q_delegates_in_same_mux_to_characterization_service() -> 
                 "targets": None,
                 "in_same_mux": False,
                 "shots": 512,
-                "interval": 240.0,
+                "interval": 240,
                 "plot": False,
                 "save_image": True,
             },

--- a/tests/experiment/test_experiment_facade_delegation.py
+++ b/tests/experiment/test_experiment_facade_delegation.py
@@ -34,6 +34,15 @@ class _BenchmarkingServiceStub:
         self.calls.append(("benchmark_2q", kwargs))
 
 
+class _CharacterizationServiceStub:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def characterize_2q(self, **kwargs: Any) -> str:
+        self.calls.append(("characterize_2q", kwargs))
+        return "characterize_2q_result"
+
+
 class _MeasurementServiceStub:
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict[str, Any]]] = []
@@ -269,6 +278,37 @@ def test_benchmark_2q_delegates_to_benchmarking_service() -> None:
                 "interval": 240.0,
                 "plot": True,
                 "save_image": False,
+            },
+        )
+    ]
+
+
+def test_characterize_2q_delegates_in_same_mux_to_characterization_service() -> None:
+    """Given in_same_mux, when characterize_2q is called, then it delegates to characterization service."""
+    exp = object.__new__(Experiment)
+    characterization_stub = _CharacterizationServiceStub()
+    exp.__dict__["_characterization_service"] = characterization_stub
+
+    result = exp.characterize_2q(
+        targets=None,
+        in_same_mux=False,
+        n_shots=512,
+        shot_interval=240.0,
+        plot=False,
+        save_image=True,
+    )
+
+    assert result == "characterize_2q_result"
+    assert characterization_stub.calls == [
+        (
+            "characterize_2q",
+            {
+                "targets": None,
+                "in_same_mux": False,
+                "shots": 512,
+                "interval": 240.0,
+                "plot": False,
+                "save_image": True,
             },
         )
     ]


### PR DESCRIPTION
Closes #221 

## Summary

Add an `in_same_mux` option to 2q characterization target selection.

When `targets` is omitted, `characterize_2q()` now uses `ctx.get_edge_labels(in_same_mux=in_same_mux)`.

## Impact

- Backward compatible
- Default behavior is unchanged (`in_same_mux=True`)
- `in_same_mux=False` allows cross-MUX edges within the available experiment resources

## Changes

- Add `in_same_mux` to `Experiment.characterize_2q()`
- Add `in_same_mux` to `CharacterizationService.characterize_2q()`
- Add `in_same_mux` to `ExperimentContext.get_edge_pairs()` / `get_edge_labels()`

## Tests

- Add `ExperimentContext` coverage for same-MUX vs cross-MUX edge selection
- Add `Experiment` facade delegation coverage for `in_same_mux`

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`
