### PR TITLE
fix: avoid chevron heatmap saturation when Rabi amplitude is invalid

### DIFF
--- a/src/qubex/experiment/services/characterization_service.py
+++ b/src/qubex/experiment/services/characterization_service.py
@@ -6,7 +6,7 @@ import logging
 from collections import defaultdict
 from collections.abc import Callable, Collection
 from copy import deepcopy
-from typing import Literal
+from typing import Any, Literal
 
 import numpy as np
 import plotly.graph_objects as go
@@ -57,6 +57,7 @@ from .measurement_service import MeasurementService
 from .pulse_service import PulseService
 
 logger = logging.getLogger(__name__)
+_CHEVRON_RABI_AMPLITUDE_EPS = 1e-12
 
 
 def _build_ramsey_sequence(
@@ -166,6 +167,29 @@ class CharacterizationService:
     def calibration_service(self) -> CalibrationService:
         """Return the calibration service."""
         return self._calibration_service
+
+    @staticmethod
+    def _is_valid_chevron_rabi_param(param: Any) -> bool:
+        """Return whether a shared Rabi parameter is safe for chevron normalization."""
+        if param is None:
+            return False
+        amplitude = getattr(param, "amplitude", np.nan)
+        return bool(
+            np.isfinite(amplitude) and abs(amplitude) > _CHEVRON_RABI_AMPLITUDE_EPS
+        )
+
+    @staticmethod
+    def _get_chevron_plot_values(
+        data: Any,
+        *,
+        use_fallback: bool,
+    ) -> NDArray[np.float64]:
+        """Return heatmap values for chevron plotting."""
+        if not use_fallback:
+            return np.asarray(data.normalized, dtype=np.float64)
+        # When normalization is invalid, use one fixed raw quadrature.
+        # Real/imag are equivalent here because link-up resets the phase basis.
+        return np.asarray(np.real(data.data), dtype=np.float64)
 
     def measure_readout_snr(
         self,
@@ -543,6 +567,12 @@ class CharacterizationService:
         rabi_rates: dict[str, NDArray] = {}
         chevron_data: dict[str, NDArray] = {}
         resonant_frequencies: dict[str, float] = {}
+        use_fallback_by_target = {
+            target: not self._is_valid_chevron_rabi_param(
+                shared_rabi_params.get(target)
+            )
+            for target in targets
+        }
 
         print(f"Targets : {targets}")
         subgroups = self.ctx.util.create_qubit_subgroups(targets)
@@ -585,7 +615,12 @@ class CharacterizationService:
                             fit_result.get("frequency", np.nan)
                         )
                         data.rabi_param = shared_rabi_params[target]
-                        chevron_data_buffer[target].append(data.normalized)
+                        chevron_data_buffer[target].append(
+                            self._get_chevron_plot_values(
+                                data,
+                                use_fallback=use_fallback_by_target[target],
+                            )
+                        )
 
             for target in subgroup:
                 rabi_rates[target] = np.array(rabi_rates_buffer[target])
@@ -604,7 +639,14 @@ class CharacterizationService:
                     title=dict(
                         text=f"Chevron pattern : {target}",
                         subtitle=dict(
-                            text=f"control_amplitude={amplitudes[target]:.6g}",
+                            text=(
+                                f"control_amplitude={amplitudes[target]:.6g}"
+                                if not use_fallback_by_target[target]
+                                else (
+                                    f"control_amplitude={amplitudes[target]:.6g}, "
+                                    "fallback=data.real"
+                                )
+                            ),
                             font=dict(
                                 size=13,
                                 family="monospace",

--- a/tests/experiment/test_chevron_pattern_logging.py
+++ b/tests/experiment/test_chevron_pattern_logging.py
@@ -76,3 +76,83 @@ def test_chevron_pattern_suppresses_low_r2_fit_warning(monkeypatch) -> None:
     assert fit_rabi_calls
     assert all(call["warn_low_r2"] is False for call in fit_rabi_calls)
     assert result.data["resonant_frequencies"] == {"Q00": 5.0}
+
+
+def test_chevron_pattern_falls_back_to_real_signal_when_rabi_amplitude_is_zero(
+    monkeypatch,
+) -> None:
+    """Given zero Rabi amplitude, when plotting chevron data, then it falls back to the real signal."""
+
+    @contextmanager
+    def _no_output() -> Any:
+        yield
+
+    def _fit_rabi(**_kwargs: Any) -> dict[str, float]:
+        return {"frequency": 0.25}
+
+    def _fit_detuned_rabi(**kwargs: Any) -> dict[str, float]:
+        return {"f_resonance": kwargs["control_frequencies"][0]}
+
+    service = cast(Any, object.__new__(CharacterizationService))
+    service.__dict__["_experiment_context"] = SimpleNamespace(
+        qubit_labels=["Q00"],
+        targets={"Q00": SimpleNamespace(frequency=5.0)},
+        params=SimpleNamespace(control_amplitude={"Q00": 0.1}),
+        util=SimpleNamespace(
+            create_qubit_subgroups=lambda targets: [list(targets)],
+            no_output=_no_output,
+        ),
+    )
+    service.__dict__["_measurement_service"] = SimpleNamespace(
+        obtain_rabi_params=lambda **_kwargs: SimpleNamespace(
+            rabi_params={
+                "Q00": SimpleNamespace(
+                    target="Q00",
+                    amplitude=0.0,
+                    frequency=0.25,
+                    phase=0.0,
+                    offset=0.0,
+                    noise=0.01,
+                    angle=0.0,
+                    distance=0.0,
+                    r2=1.0,
+                    reference_phase=0.0,
+                )
+            }
+        ),
+        sweep_parameter=lambda **_kwargs: Result(
+            data={
+                "Q00": SimpleNamespace(
+                    target="Q00",
+                    sweep_range=np.array([0.0, 4.0, 8.0]),
+                    data=np.array([1.0 + 4.0j, 2.0 + 5.0j, 3.0 + 6.0j]),
+                    rabi_param=None,
+                )
+            }
+        ),
+    )
+    service.__dict__["_calibration_service"] = SimpleNamespace()
+    service.__dict__["_pulse_service"] = SimpleNamespace()
+
+    monkeypatch.setattr(
+        "qubex.experiment.services.characterization_service.fitting.fit_rabi",
+        _fit_rabi,
+    )
+    monkeypatch.setattr(
+        "qubex.experiment.services.characterization_service.fitting.fit_detuned_rabi",
+        _fit_detuned_rabi,
+    )
+
+    result = service.chevron_pattern(
+        targets=["Q00"],
+        detuning_range=np.array([0.0]),
+        time_range=np.array([0.0, 4.0, 8.0]),
+        plot=False,
+        save_image=False,
+    )
+
+    assert result.figures is not None
+    figure = result.figures["Q00"]
+    heatmap_z = np.asarray(figure.data[0]["z"], dtype=np.float64)
+    np.testing.assert_allclose(heatmap_z[:, 0], np.array([1.0, 2.0, 3.0]))
+    assert "fallback=data.real" in figure.layout.title.subtitle.text


### PR DESCRIPTION
## Summary

Avoid white-out in `chevron_pattern()` when the shared Rabi amplitude is invalid.

When the shared Rabi parameter is not safe for normalization, `chevron_pattern()` now falls back to plotting `data.real` and marks the figure subtitle with `fallback=data.real`.

<img width="600" height="400" alt="image" src="https://github.com/user-attachments/assets/6ee3db40-f1c5-4185-8c89-7c87fbcc03b3" />

## Impact

- Backward compatible
- Normalized chevron plotting is unchanged when the shared Rabi amplitude is valid
- Invalid shared Rabi amplitudes no longer produce unusable chevron heatmaps

## Changes

- Add shared-Rabi validity checking in `CharacterizationService.chevron_pattern()`
- Fall back to `data.real` for chevron heatmap values when normalization is unsafe
- Update chevron subtitles to indicate `fallback=data.real`

## Tests

- Add chevron regression coverage for zero shared Rabi amplitude fallback
- Verify fallback heatmap values use the real component of the measured signal
- Verify fallback figures annotate the subtitle with `fallback=data.real`

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`
