### PR TITLE
Fix readout amplitude keyword in Ramsey fringe measurement

### DIFF
--- a/src/qubex/contrib/experiment/quantum_efficiency_measurement.py
+++ b/src/qubex/contrib/experiment/quantum_efficiency_measurement.py
@@ -297,7 +297,7 @@ def _measure_ramsey_fringe(
             schedule.barrier()
             schedule.add(
                 readout_target,
-                exp.pulse.readout(readout_target, readout_amplitude=readout_amplitude),
+                exp.pulse.readout(readout_target, amplitude=readout_amplitude),
             )
             schedule.barrier()
             schedule.add(target, exp.pulse.x90(target).shifted(float(phase_shift)))


### PR DESCRIPTION
## Background
`_measure_ramsey_fringe` builds a weak-readout pulse through `exp.pulse.readout()`, but it was passing `readout_amplitude=` instead of the supported `amplitude=` keyword.

Because the readout pulse builder accepts `amplitude` as the public keyword, this mismatch can break the Ramsey fringe measurement step used in the quantum efficiency measurement flow.

## Summary of changes
- replace `readout_amplitude=readout_amplitude` with `amplitude=readout_amplitude` in `_measure_ramsey_fringe`
- align the weak-readout pulse construction with the current `exp.pulse.readout()` API

## User-facing / API impact
- fixes a bug in the quantum efficiency measurement path when `_measure_ramsey_fringe` constructs the intermediate weak readout pulse
- no public API change
- no behavior change outside this incorrect keyword usage

## Risks / compatibility
- low risk
- the change only updates the keyword name passed to the existing readout pulse API
- no documentation update is required because this does not introduce a new API or behavior

## Validation
Executed local validation in the project environment:

### `make check`
- `uv run python scripts/check_release_version.py`
  - Release version is synchronized at `1.5.0b4`
- `uv run pyright`
  - `0 errors, 0 warnings, 0 informations`
- `uv run ruff check`
  - `All checks passed!`
- `uv run ruff format --check`
  - `464 files already formatted`

### `make test`
- `uv run pytest`
  - `965 passed in 9.49s`
