### PR TITLE
feat / Add quantum efficiency to chip info

### DIFF
--- a/src/qubex/experiment/experiment_tool.py
+++ b/src/qubex/experiment/experiment_tool.py
@@ -267,6 +267,7 @@ def print_chip_info(
         "static_zz_interaction",
         "qubit_qubit_coupling_strength",
         "average_readout_fidelity",
+        "quantum_efficiency",
         "average_gate_fidelity",
         "x90_gate_fidelity",
         "x180_gate_fidelity",
@@ -313,6 +314,7 @@ def print_chip_info(
             "static_zz_interaction",
             "qubit_qubit_coupling_strength",
             "average_readout_fidelity",
+            "quantum_efficiency",
             "x90_gate_fidelity",
             "x180_gate_fidelity",
             "zx90_gate_fidelity",
@@ -566,6 +568,23 @@ def print_chip_info(
                     ],
                     save_image=save_image,
                     image_name="average_readout_fidelity",
+                )
+
+        if "quantum_efficiency" in info_type:
+            if values := loader.load_param_data("quantum_efficiency"):
+                graph.plot_lattice_data(
+                    title="Quantum efficiency (%)",
+                    values=list(values.values()),
+                    texts=[
+                        f"{qubit}<br>{value:.2%}" if _is_valid(value) else "N/A"
+                        for qubit, value in values.items()
+                    ],
+                    hovertexts=[
+                        f"{qubit}: {value:.2%}" if _is_valid(value) else f"{qubit}: N/A"
+                        for qubit, value in values.items()
+                    ],
+                    save_image=save_image,
+                    image_name="quantum_efficiency",
                 )
 
         if "x90_gate_fidelity" in info_type:

--- a/src/qubex/system/config_loader.py
+++ b/src/qubex/system/config_loader.py
@@ -71,6 +71,7 @@ PARAMS_MAP = {
     "t2_echo": ("t2_echo", "props"),
     "t2_star": ("t2_star", "props"),
     "average_readout_fidelity": ("average_readout_fidelity", "props"),
+    "quantum_efficiency": ("quantum_efficiency", "props"),
     "x90_gate_fidelity": ("x90_gate_fidelity", "props"),
     "x180_gate_fidelity": ("x180_gate_fidelity", "props"),
     "zx90_gate_fidelity": ("zx90_gate_fidelity", "props"),
@@ -96,6 +97,7 @@ QUBIT_KEYED_PARAMS = frozenset(
         "t2_echo",
         "t2_star",
         "average_readout_fidelity",
+        "quantum_efficiency",
         "x90_gate_fidelity",
         "x180_gate_fidelity",
     }


### PR DESCRIPTION
## Background

`quantum_efficiency` is stored as a chip property, but it was not exposed through the chip-info loading and visualization flow.

As a result, QE data could exist in `props` while remaining unavailable from `print_chip_info()`.

## Summary of changes

- add `quantum_efficiency` to the config-loader parameter map
- treat `quantum_efficiency` as qubit-keyed chip property data
- add `quantum_efficiency` to the supported chip-info items in `print_chip_info()`
- render quantum efficiency on the lattice view with percent-formatted labels and hover text

## User-facing / API impact

- `print_chip_info(..., info_type="quantum_efficiency")` can now load and visualize quantum efficiency from chip properties
- quantum efficiency is displayed in percent format on the chip lattice view
- no existing API is removed or changed for other chip-info items

## Risks / compatibility

- low risk
- the change is limited to chip-info parameter loading and visualization
- this assumes `quantum_efficiency` is stored in `props` as qubit-keyed data, consistent with the existing chip property layout

## Validation

Executed local validation in the project environment:

### `make check`
- `uv run python scripts/check_release_version.py`
  - `Release version is synchronized at 1.5.0b4`
- `uv run pyright`
  - `0 errors, 0 warnings, 0 informations`
- `uv run ruff check`
  - `All checks passed!`
- `uv run ruff format --check`
  - `467 files already formatted`

### `make test`
- `uv run pytest`
  - `969 passed in 6.00s`
