### PR TITLE
fix: increase QuEL-1 compat min time offset to 150 ms

### DIFF
--- a/src/qubex/backend/quel1/compat/parallel_action_builder.py
+++ b/src/qubex/backend/quel1/compat/parallel_action_builder.py
@@ -512,7 +512,7 @@ class QubexMultiAction:
 
     SYSREF_PERIOD: Final[int] = 2_000  # 2e3 ticks = 2e3 * 8 ns = 16 us = 62.5 kHz
     TIMING_OFFSET: Final[int] = 0
-    MIN_TIME_OFFSET: Final[int] = 12_500_000  # 12.5e6 ticks = 12.5e6 * 8 ns = 100 ms
+    MIN_TIME_OFFSET: Final[int] = 18_750_000  # 18.75e6 ticks = 18.75e6 * 8 ns = 150 ms
 
     @classmethod
     def _mod_by_sysref(cls, t: int) -> int:

--- a/tests/backend/test_parallel_action_builder.py
+++ b/tests/backend/test_parallel_action_builder.py
@@ -713,6 +713,47 @@ def test_qxdriver_action_arms_triggered_boxes_at_shared_time() -> None:
     assert data == {("MON", "P0", 0): "data"}
 
 
+def test_qxdriver_action_uses_150ms_default_min_time_offset() -> None:
+    """Qxdriver compatibility should schedule the default shared time 150 ms ahead."""
+    monitor_box = _FakeWavegenBox()
+    target_box = _FakeWavegenBox()
+    monitor_action = _TimedTriggeredAction(
+        box=monitor_box,
+        _wseqs=[SimpleNamespace(port="MON", channel=0)],
+        _triggers={"P0": SimpleNamespace(port="MON", channel=0)},
+    )
+    target_action = _TimedAwgOnlyAction(
+        box=target_box,
+        _wseqs=[SimpleNamespace(port="GEN", channel=1)],
+    )
+    multi_action = QubexMultiAction(
+        _system=cast(
+            Any,
+            SimpleNamespace(
+                box={"MON": monitor_box, "GEN": target_box},
+                timing_shift={"MON": 0, "GEN": 0},
+                displacement=0,
+            ),
+        ),
+        _actions=cast(
+            Any,
+            MappingProxyType({"MON": monitor_action, "GEN": target_action}),
+        ),
+        _estimated_timediff=MappingProxyType({"MON": 0, "GEN": 0}),
+        _reference_box_name="MON",
+        _ref_sysref_time_offset=0,
+        _clock_options=ClockHealthCheckOptions(),
+        _logger=logging.getLogger(__name__),
+        _emit_triggered_boxes=False,
+        _arm_triggered_boxes_at_capture_start=True,
+    )
+
+    multi_action.action()
+
+    assert monitor_action.capture_start_timecounter == 18_750_112
+    assert target_box.reservations == [({("GEN", 1)}, 18_750_112)]
+
+
 def test_qubex_multi_action_capture_start_runs_box_calls_in_parallel() -> None:
     """Given multiple boxes, when starting capture, then per-box starts should overlap."""
     # Arrange


### PR DESCRIPTION
## Summary
- increase `QubexMultiAction.MIN_TIME_OFFSET` from 100 ms to 150 ms in the QuEL-1 compat parallel action builder
- add a regression test that fixes the default shared schedule at the new 150 ms offset

## Verification
- `uv run pytest tests/backend/test_parallel_action_builder.py`
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`