### PR TITLE
fix: honor experiment readout timing defaults

### DIFF
--- a/src/qubex/experiment/services/measurement_service.py
+++ b/src/qubex/experiment/services/measurement_service.py
@@ -174,6 +174,13 @@ class MeasurementService:
         """Return measurement schedule, building only when pulse schedule is provided."""
         if isinstance(schedule, MeasurementSchedule):
             return schedule
+        readout_duration, readout_pre_margin, readout_post_margin = (
+            self._resolve_readout_timing_defaults(
+                readout_duration=readout_duration,
+                readout_pre_margin=readout_pre_margin,
+                readout_post_margin=readout_post_margin,
+            )
+        )
         return self.ctx.measurement.build_measurement_schedule(
             pulse_schedule=schedule,
             frequencies=frequencies,
@@ -187,6 +194,22 @@ class MeasurementService:
             readout_amplification=readout_amplification,
             final_measurement=final_measurement,
         )
+
+    def _resolve_readout_timing_defaults(
+        self,
+        *,
+        readout_duration: float | None,
+        readout_pre_margin: float | None,
+        readout_post_margin: float | None,
+    ) -> tuple[float, float, float]:
+        """Return Experiment readout timing defaults for omitted measurement options."""
+        if readout_duration is None:
+            readout_duration = self.pulse.readout_duration
+        if readout_pre_margin is None:
+            readout_pre_margin = self.pulse.readout_pre_margin
+        if readout_post_margin is None:
+            readout_post_margin = self.pulse.readout_post_margin
+        return readout_duration, readout_pre_margin, readout_post_margin
 
     @classmethod
     def resolve_deprecated_option(
@@ -260,6 +283,13 @@ class MeasurementService:
         plot: bool | None = None,
     ) -> MeasurementSchedule:
         """Build a measurement schedule through the measurement facade."""
+        readout_duration, readout_pre_margin, readout_post_margin = (
+            self._resolve_readout_timing_defaults(
+                readout_duration=readout_duration,
+                readout_pre_margin=readout_pre_margin,
+                readout_post_margin=readout_post_margin,
+            )
+        )
         return self.ctx.measurement.build_measurement_schedule(
             pulse_schedule=pulse_schedule,
             frequencies=frequencies,
@@ -638,6 +668,13 @@ class MeasurementService:
             }
             self.ctx.reset_awg_and_capunits(qubits=qubits)
 
+        readout_duration, readout_pre_margin, readout_post_margin = (
+            self._resolve_readout_timing_defaults(
+                readout_duration=readout_duration,
+                readout_pre_margin=readout_pre_margin,
+                readout_post_margin=readout_post_margin,
+            )
+        )
         with self.ctx.modified_frequencies(frequencies):
             result = self.ctx.measurement.execute(
                 schedule=schedule,
@@ -807,6 +844,13 @@ class MeasurementService:
             qubits = {self.ctx.resolve_qubit_label(target) for target in waveforms}
             self.ctx.reset_awg_and_capunits(qubits=qubits)
 
+        readout_duration, readout_pre_margin, readout_post_margin = (
+            self._resolve_readout_timing_defaults(
+                readout_duration=readout_duration,
+                readout_pre_margin=readout_pre_margin,
+                readout_post_margin=readout_post_margin,
+            )
+        )
         with self.ctx.modified_frequencies(frequencies):
             result = self.ctx.measurement.measure(
                 waveforms=waveforms,

--- a/tests/experiment/test_measurement_service_async_delegation.py
+++ b/tests/experiment/test_measurement_service_async_delegation.py
@@ -90,7 +90,11 @@ def _make_service() -> tuple[MeasurementService, dict[str, Any]]:
     service.__dict__["_ctx"] = SimpleNamespace(
         measurement=measurement,
     )
-    service.__dict__["_pulse_service"] = SimpleNamespace()
+    service.__dict__["_pulse_service"] = SimpleNamespace(
+        readout_duration=512.0,
+        readout_pre_margin=16.0,
+        readout_post_margin=96.0,
+    )
     return cast(MeasurementService, service), calls
 
 
@@ -104,7 +108,7 @@ def _measurement_schedule() -> MeasurementSchedule:
 
 
 def test_build_measurement_schedule_delegates_none_values() -> None:
-    """Given omitted optional flags, when building schedule, then None values are delegated downstream."""
+    """Given omitted options, when building schedule, then timing defaults and optional flags are delegated."""
     service, calls = _make_service()
     pulse_schedule = object()
 
@@ -113,10 +117,27 @@ def test_build_measurement_schedule_delegates_none_values() -> None:
     assert cast(SimpleNamespace, result).tag == "built"
     kwargs = calls["build_schedule"][0]
     assert kwargs["pulse_schedule"] is pulse_schedule
+    assert kwargs["readout_duration"] == 512.0
+    assert kwargs["readout_pre_margin"] == 16.0
+    assert kwargs["readout_post_margin"] == 96.0
     assert kwargs["readout_amplification"] is None
     assert kwargs["final_measurement"] is None
     assert kwargs["capture_placement"] is None
     assert kwargs["plot"] is None
+
+
+def test_run_measurement_uses_experiment_readout_timing_defaults() -> None:
+    """Given no per-call timing, when running async measurement, then Experiment defaults are delegated."""
+    service, calls = _make_service()
+    pulse_schedule = cast(Any, object())
+
+    result = asyncio.run(service.run_measurement(pulse_schedule))
+
+    assert result == "measurement_result"
+    build_kwargs = calls["build_schedule"][0]
+    assert build_kwargs["readout_duration"] == 512.0
+    assert build_kwargs["readout_pre_margin"] == 16.0
+    assert build_kwargs["readout_post_margin"] == 96.0
 
 
 def test_run_measurement_builds_schedule_and_delegates() -> None:

--- a/tests/experiment/test_measurement_service_registry_resolution.py
+++ b/tests/experiment/test_measurement_service_registry_resolution.py
@@ -215,6 +215,21 @@ def test_execute_does_not_reset_awg_by_default() -> None:
     assert captured["reset_calls"] == []
 
 
+def test_execute_uses_experiment_readout_timing_defaults() -> None:
+    """Given omitted readout timing, when executing, then Experiment defaults are delegated."""
+    service, captured = _make_service()
+
+    with PulseSchedule(["custom-target"]) as schedule:
+        pass
+
+    service.execute(schedule, plot=False)
+
+    execute_calls = cast(list[dict[str, object]], captured["execute_calls"])
+    assert execute_calls[0]["readout_duration"] == 1024.0
+    assert execute_calls[0]["readout_pre_margin"] == 8.0
+    assert execute_calls[0]["readout_post_margin"] == 16.0
+
+
 def test_measure_does_not_reset_awg_by_default() -> None:
     """Given measure call without reset flag, when measured, then AWG reset is skipped by default."""
     service, captured = _make_service()
@@ -225,6 +240,21 @@ def test_measure_does_not_reset_awg_by_default() -> None:
     )
 
     assert captured["reset_calls"] == []
+
+
+def test_measure_uses_experiment_readout_timing_defaults() -> None:
+    """Given omitted readout timing, when measuring, then Experiment defaults are delegated."""
+    service, captured = _make_service()
+
+    service.measure(
+        sequence={"custom-target": np.array([0.0 + 0.0j], dtype=np.complex128)},
+        plot=False,
+    )
+
+    measure_calls = cast(list[dict[str, object]], captured["measure_calls"])
+    assert measure_calls[0]["readout_duration"] == 1024.0
+    assert measure_calls[0]["readout_pre_margin"] == 8.0
+    assert measure_calls[0]["readout_post_margin"] == 16.0
 
 
 def test_check_waveform_resolves_read_labels_via_target_registry() -> None:


### PR DESCRIPTION
## Background

`Experiment(readout_duration=...)` stored the override in `ExperimentContext`, but measurement execution paths delegated `None` readout timing values to the measurement layer. That caused measurement schedule generation to fall back to system `measurement_defaults` instead of the Experiment-level defaults.

## Summary

- Resolve omitted readout duration/pre-margin/post-margin from `PulseService` before delegating measurement schedule construction.
- Apply the same default resolution to async measurement schedule builds and legacy `execute` / `measure` paths.
- Add regression coverage for schedule building, async measurement, `execute`, and `measure` delegation.

## Impact

Explicit per-call readout timing arguments still take precedence. When omitted, `Experiment(..., readout_duration=512, ...)` now consistently affects readout pulse generation through Experiment measurement APIs.

## Compatibility

This restores the expected released `Experiment` behavior and does not change public signatures or require migration.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`