### PR TITLE
Feat/ef measurement for qubits with single channel

### DIFF
--- a/src/qubex/contrib/__init__.py
+++ b/src/qubex/contrib/__init__.py
@@ -19,8 +19,7 @@ from .experiment.crosstalk_cross_resonance import (
 )
 from .experiment.ef_measurement_with_one_channel import (
     calibrate_cr_pi_pulse,
-    ef_chevron_pattern,
-    ef_rabi_experiment,
+    obtain_anharmonicity_with_cr,
 )
 from .experiment.gf_calibration import (
     calibrate_gf_hpi_pulse,
@@ -116,8 +115,6 @@ __all__ = [
     "decompose_cr_crosstalk",
     "estimate_qubit_frequency_from_chevron",
     "estimate_qubit_frequency_from_chevron_adaptive",
-    "ef_chevron_pattern",
-    "ef_rabi_experiment",
     "filtered_ckp_experiment",
     "fit_readout_parameters",
     "fourier_analysis",
@@ -139,6 +136,7 @@ __all__ = [
     "measurement_induced_dephasing",
     "measurement_induced_dephasing_experiment",
     "mqc_experiment",
+    "obtain_anharmonicity_with_cr",
     "obtain_gf_rabi_params",
     "parity_oscillation",
     "partial_transpose",

--- a/src/qubex/contrib/__init__.py
+++ b/src/qubex/contrib/__init__.py
@@ -86,9 +86,15 @@ from .experiment.superconducting_gap import (
 from .experiment.thermal_excitation_characterization import (
     thermal_excitation_via_rabi,
 )
+from .experiment.ef_measurement_with_one_channel import (
+    calibrate_cr_pi_pulse,
+    ef_chevron_pattern,
+    ef_rabi_experiment,
+)
 
 __all__ = [
     "analyze_chevron_matched_transform",
+    "calibrate_cr_pi_pulse",
     "calibrate_gf_hpi_pulse",
     "calibrate_gf_pi_pulse",
     "calibrate_gf_pulse",
@@ -110,6 +116,8 @@ __all__ = [
     "decompose_cr_crosstalk",
     "estimate_qubit_frequency_from_chevron",
     "estimate_qubit_frequency_from_chevron_adaptive",
+    "ef_chevron_pattern",
+    "ef_rabi_experiment",
     "filtered_ckp_experiment",
     "fit_readout_parameters",
     "fourier_analysis",

--- a/src/qubex/contrib/__init__.py
+++ b/src/qubex/contrib/__init__.py
@@ -17,6 +17,11 @@ from .experiment.crosstalk_cross_resonance import (
     cr_crosstalk_hamiltonian_tomography,
     measure_cr_crosstalk,
 )
+from .experiment.ef_measurement_with_one_channel import (
+    calibrate_cr_pi_pulse,
+    ef_chevron_pattern,
+    ef_rabi_experiment,
+)
 from .experiment.gf_calibration import (
     calibrate_gf_hpi_pulse,
     calibrate_gf_pi_pulse,
@@ -85,11 +90,6 @@ from .experiment.superconducting_gap import (
 )
 from .experiment.thermal_excitation_characterization import (
     thermal_excitation_via_rabi,
-)
-from .experiment.ef_measurement_with_one_channel import (
-    calibrate_cr_pi_pulse,
-    ef_chevron_pattern,
-    ef_rabi_experiment,
 )
 
 __all__ = [

--- a/src/qubex/contrib/experiment/__init__.py
+++ b/src/qubex/contrib/experiment/__init__.py
@@ -17,8 +17,7 @@ from .crosstalk_cross_resonance import (
 )
 from .ef_measurement_with_one_channel import (
     calibrate_cr_pi_pulse,
-    ef_chevron_pattern,
-    ef_rabi_experiment,
+    obtain_anharmonicity_with_cr,
 )
 from .gf_calibration import (
     calibrate_gf_hpi_pulse,
@@ -103,8 +102,6 @@ __all__ = [
     "decompose_cr_crosstalk",
     "estimate_qubit_frequency_from_chevron",
     "estimate_qubit_frequency_from_chevron_adaptive",
-    "ef_chevron_pattern",
-    "ef_rabi_experiment",
     "filtered_ckp_experiment",
     "fourier_analysis",
     "get_resistance_charge",
@@ -125,6 +122,7 @@ __all__ = [
     "measurement_induced_dephasing",
     "measurement_induced_dephasing_experiment",
     "mqc_experiment",
+    "obtain_anharmonicity_with_cr",
     "obtain_gf_rabi_params",
     "parity_oscillation",
     "partial_transpose",

--- a/src/qubex/contrib/experiment/__init__.py
+++ b/src/qubex/contrib/experiment/__init__.py
@@ -73,9 +73,15 @@ from .superconducting_gap import get_resistance_charge, get_superconducting_gap
 from .thermal_excitation_characterization import (
     thermal_excitation_via_rabi,
 )
+from .ef_measurement_with_one_channel import (
+    calibrate_cr_pi_pulse,
+    ef_chevron_pattern,
+    ef_rabi_experiment,
+)
 
 __all__ = [
     "analyze_chevron_matched_transform",
+    "calibrate_cr_pi_pulse",
     "calibrate_gf_hpi_pulse",
     "calibrate_gf_pi_pulse",
     "calibrate_gf_pulse",
@@ -97,6 +103,8 @@ __all__ = [
     "decompose_cr_crosstalk",
     "estimate_qubit_frequency_from_chevron",
     "estimate_qubit_frequency_from_chevron_adaptive",
+    "ef_chevron_pattern",
+    "ef_rabi_experiment",
     "filtered_ckp_experiment",
     "fourier_analysis",
     "get_resistance_charge",

--- a/src/qubex/contrib/experiment/__init__.py
+++ b/src/qubex/contrib/experiment/__init__.py
@@ -15,6 +15,11 @@ from .crosstalk_cross_resonance import (
     cr_crosstalk_hamiltonian_tomography,
     measure_cr_crosstalk,
 )
+from .ef_measurement_with_one_channel import (
+    calibrate_cr_pi_pulse,
+    ef_chevron_pattern,
+    ef_rabi_experiment,
+)
 from .gf_calibration import (
     calibrate_gf_hpi_pulse,
     calibrate_gf_pi_pulse,
@@ -72,11 +77,6 @@ from .stark_characterization import stark_ramsey_experiment, stark_t1_experiment
 from .superconducting_gap import get_resistance_charge, get_superconducting_gap
 from .thermal_excitation_characterization import (
     thermal_excitation_via_rabi,
-)
-from .ef_measurement_with_one_channel import (
-    calibrate_cr_pi_pulse,
-    ef_chevron_pattern,
-    ef_rabi_experiment,
 )
 
 __all__ = [

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -1,16 +1,18 @@
+"""ef measurement helper functions for qubits with single control channel."""
+
 from __future__ import annotations
 
-from contextlib import ExitStack
 from collections.abc import Collection
+from contextlib import ExitStack
 from typing import Any
 
 import numpy as np
 from numpy.typing import ArrayLike
 from plotly import graph_objects as go
+from qxpulse import Blank, FlatTop, PulseSchedule
 from tqdm import tqdm
 
 import qubex as qx
-from qxpulse import Blank, FlatTop, PulseSchedule
 from qubex import visualization as viz
 from qubex.analysis import FitStatus, fitting
 from qubex.experiment.experiment_constants import (
@@ -28,31 +30,30 @@ from qubex.experiment.models.experiment_result import (
 from qubex.experiment.models.rabi_param import RabiParam
 from qubex.system import MixingUtil
 
-
 # Public API exported from this module (contrib-style utilities)
 __all__ = [
-    'calibrate_cr_pi_pulse',
-    'ef_rabi_experiment',
-    'ef_chevron_pattern',
+    "calibrate_cr_pi_pulse",
+    "ef_chevron_pattern",
+    "ef_rabi_experiment",
 ]
 
 
 def calibrate_cr_pi_pulse(
-        ex: qx.Experiment,
-        control_qubit: str,
-        target_qubit: str,
-        duration_range: Collection[float],
-        amplitude_range: Collection[float] | None = None,
-        ramptime: float | None = None,
-        n_points: int | None = None,
-        n_rotations: int | None = None,
-        n_iterations: int | None = None,
-        ratio: float | None = None,
-        r2_threshold: float | None = None,
-        plot: bool | None = None,
-        shots: int | None = None,
-        interval: float | None = None,
-    ) -> tuple[ExperimentResult[AmplCalibData], int, qx.PulseSchedule]:
+    ex: qx.Experiment,
+    control_qubit: str,
+    target_qubit: str,
+    duration_range: Collection[float],
+    amplitude_range: Collection[float] | None = None,
+    ramptime: float | None = None,
+    n_points: int | None = None,
+    n_rotations: int | None = None,
+    n_iterations: int | None = None,
+    ratio: float | None = None,
+    r2_threshold: float | None = None,
+    plot: bool | None = None,
+    shots: int | None = None,
+    interval: float | None = None,
+) -> tuple[ExperimentResult[AmplCalibData], int, qx.PulseSchedule]:
     """
     Calibrate CR pi pulse by fitting duration first, then amplitude.
 
@@ -124,13 +125,10 @@ def calibrate_cr_pi_pulse(
                     duration=duration,
                     amplitude=amplitude,
                     tau=ramptime,
-                    type='RaisedCosine',
+                    type="RaisedCosine",
                 ),
             )
-            ps.add(
-                target_qubit,
-                Blank(duration=duration)
-            )
+            ps.add(target_qubit, Blank(duration=duration))
         return ps
 
     def _plot_raw_calibration(
@@ -151,9 +149,9 @@ def calibrate_cr_pi_pulse(
         fig.update_layout(
             title=title,
             xaxis_title=xlabel,
-            yaxis_title='Normalized signal',
-            xaxis_type='linear',
-            yaxis_type='linear',
+            yaxis_title="Normalized signal",
+            xaxis_type="linear",
+            yaxis_type="linear",
         )
         fig.show()
 
@@ -173,7 +171,7 @@ def calibrate_cr_pi_pulse(
             x_values=duration_range,
             y_values=sweep_data.normalized,
             title=f"CR pi pulse duration calibration : {target_qubit}",
-            xlabel='duration',
+            xlabel="duration",
         )
 
         fit_result = fitting.fit_ampl_calib_data(
@@ -181,22 +179,26 @@ def calibrate_cr_pi_pulse(
             amplitude_range=duration_range,
             data=sweep_data.normalized,
             plot=plot,
-            title='CR pi pulse duration calibration',
-            xlabel='duration',
-            ylabel='Normalized signal',
+            title="CR pi pulse duration calibration",
+            xlabel="duration",
+            ylabel="Normalized signal",
         )
 
-        duration_r2 = fit_result['r2']
+        duration_r2 = fit_result["r2"]
         if duration_r2 < r2_threshold:
             print(f"Error: duration fit R² value is too low ({duration_r2:.3f})")
 
-        return fit_result['amplitude']
+        return fit_result["amplitude"]
 
-    def calibrate_amplitude(amplitude_range: Collection[float], fixed_duration: float) -> AmplCalibData:
+    def calibrate_amplitude(
+        amplitude_range: Collection[float], fixed_duration: float
+    ) -> AmplCalibData:
         n_per_rotation = 2
 
         sweep_data = ex.sweep_parameter(
-            sequence=lambda amplitude: seq(duration=fixed_duration, amplitude=amplitude),
+            sequence=lambda amplitude: seq(
+                duration=fixed_duration, amplitude=amplitude
+            ),
             sweep_range=amplitude_range,
             repetitions=n_per_rotation * n_rotations,
             shots=shots,
@@ -208,7 +210,7 @@ def calibrate_cr_pi_pulse(
             x_values=amplitude_range,
             y_values=sweep_data.normalized,
             title=f"CR pi pulse amplitude calibration : {target_qubit}",
-            xlabel='amplitude',
+            xlabel="amplitude",
         )
 
         fit_result = fitting.fit_ampl_calib_data(
@@ -216,18 +218,18 @@ def calibrate_cr_pi_pulse(
             amplitude_range=amplitude_range,
             data=sweep_data.normalized,
             plot=plot,
-            title='CR pi pulse amplitude calibration',
-            xlabel='amplitude',
-            ylabel='Normalized signal',
+            title="CR pi pulse amplitude calibration",
+            xlabel="amplitude",
+            ylabel="Normalized signal",
         )
 
-        r2 = fit_result['r2']
+        r2 = fit_result["r2"]
         if r2 < r2_threshold:
             print(f"Error: R² value is too low ({r2:.3f})")
 
         return AmplCalibData.new(
             sweep_data=sweep_data,
-            calib_value=fit_result['amplitude'],
+            calib_value=fit_result["amplitude"],
             r2=r2,
         )
 
@@ -250,32 +252,36 @@ def calibrate_cr_pi_pulse(
     # print(f"Optimal duration (fit): {opt_duration}")
     # print(f"Duration used for amplitude sweep (rounded up to even): {opt_duration_fixed}")
 
-    for i in range(n_iterations):
+    for _ in range(n_iterations):
         # print(f"Amplitude iteration {i+1}/{n_iterations}")
         data[target_qubit] = calibrate_amplitude(
             amplitude_range=_amplitude_range,
             fixed_duration=opt_duration_fixed,
         )
-        _amplitude_range = _update_amplitude_range(center=data[target_qubit].calib_value, ratio=ratio)
+        _amplitude_range = _update_amplitude_range(
+            center=data[target_qubit].calib_value, ratio=ratio
+        )
 
     print("")
-    print(f"Calibration results for CR pi pulse:")
+    print("Calibration results for CR pi pulse:")
     print(f"  duration: {opt_duration} -> {opt_duration_fixed} [ns]")
     for target, calib_data in data.items():
         print(f"  {target}: {calib_data.calib_value} [arb. units]")
 
-    ps_result = seq(duration=opt_duration_fixed, amplitude=data[target_qubit].calib_value)
+    ps_result = seq(
+        duration=opt_duration_fixed, amplitude=data[target_qubit].calib_value
+    )
 
     return ExperimentResult(data=data), opt_duration_fixed, ps_result
 
 
 def _calc_fnco_settings(
-        ex: qx.Experiment,
-        channel_label: str,
-        drive_frequency: float,
-        force_retune: bool = False,
-        print_info: bool = False,
-    )-> tuple[bool, dict[str, float]]:
+    ex: qx.Experiment,
+    channel_label: str,
+    drive_frequency: float,
+    force_retune: bool = False,
+    print_info: bool = False,
+) -> tuple[bool, dict[str, float]]:
     """
     Return device settings kwargs when an FNCO retune is needed.
 
@@ -298,9 +304,8 @@ def _calc_fnco_settings(
     tuple
         (retune_needed, params) where `params` can be passed to backend settings.
     """
-
-    FINE_FREQ_TOL_GHZ = 0.150 # 150 MHz
-    FNCO_MAX = 600_000_000 # 600 MHz
+    FINE_FREQ_TOL_GHZ = 0.150  # 150 MHz
+    FNCO_MAX = 600_000_000  # 600 MHz
 
     target = ex.ctx.experiment_system.get_target(channel_label)
     port = target.channel.port
@@ -314,14 +319,20 @@ def _calc_fnco_settings(
     current_cnco = target.channel.cnco_freq
 
     if current_lo is not None:
-        current_diff_ghz = abs(drive_frequency - (current_lo - current_cnco - current_fnco) * 1e-9)
+        current_diff_ghz = abs(
+            drive_frequency - (current_lo - current_cnco - current_fnco) * 1e-9
+        )
         if print_info:
-            print(f"current lo: {current_lo*1e-9} GHz, current cnco: {current_cnco*1e-9} GHz, fnco: {current_fnco*1e-9} GHz")
+            print(
+                f"current lo: {current_lo * 1e-9} GHz, current cnco: {current_cnco * 1e-9} GHz, fnco: {current_fnco * 1e-9} GHz"
+            )
 
-    else: 
+    else:
         current_diff_ghz = abs(drive_frequency - (current_cnco + current_fnco) * 1e-9)
         if print_info:
-            print(f"current cnco: {current_cnco*1e-9} GHz, fnco: {current_fnco*1e-9} GHz")
+            print(
+                f"current cnco: {current_cnco * 1e-9} GHz, fnco: {current_fnco * 1e-9} GHz"
+            )
 
     current_fnco_ok = abs(current_fnco) <= FNCO_MAX
     if not force_retune and current_diff_ghz <= FINE_FREQ_TOL_GHZ and current_fnco_ok:
@@ -329,10 +340,10 @@ def _calc_fnco_settings(
             print("No FNCO retune needed")
         retune_needed = False
         params = {
-            'label': channel_label,
-            'lo_freq': current_lo,
-            'cnco_freq': current_cnco,
-            'fnco_freq': current_fnco,
+            "label": channel_label,
+            "lo_freq": current_lo,
+            "cnco_freq": current_cnco,
+            "fnco_freq": current_fnco,
         }
         return retune_needed, params
 
@@ -357,34 +368,36 @@ def _calc_fnco_settings(
         )
 
     if print_info:
-        print(f"new fnco: {new_fnco*1e-9} GHz, projected fine frequency delta: {diff_ghz:.6f} GHz")
+        print(
+            f"new fnco: {new_fnco * 1e-9} GHz, projected fine frequency delta: {diff_ghz:.6f} GHz"
+        )
 
     retune_needed = True
     params = {
-        'label': channel_label,
-        'lo_freq': current_lo,
-        'cnco_freq': current_cnco,
-        'fnco_freq': new_fnco,
+        "label": channel_label,
+        "lo_freq": current_lo,
+        "cnco_freq": current_cnco,
+        "fnco_freq": new_fnco,
     }
     return retune_needed, params
 
 
 def ef_rabi_experiment(
-        ex: qx.Experiment,
-        target_qubit: str,
-        control_qubit: str,
-        cr_amplitude: float,
-        cr_duration: int,
-        cr_ramptime: float,
-        time_range: ArrayLike,
-        ef_amplitude: float | None = None,
-        ef_ramptime: float | None = None,
-        is_damped: bool | None = None,
-        n_shots: int | None = None,
-        shot_interval: float | None = None,
-        plot: bool | None = None,
-        **deprecated_options: Any,
-    ) -> ExperimentResult[RabiData]:
+    ex: qx.Experiment,
+    target_qubit: str,
+    control_qubit: str,
+    cr_amplitude: float,
+    cr_duration: int,
+    cr_ramptime: float,
+    time_range: ArrayLike,
+    ef_amplitude: float | None = None,
+    ef_ramptime: float | None = None,
+    is_damped: bool | None = None,
+    n_shots: int | None = None,
+    shot_interval: float | None = None,
+    plot: bool | None = None,
+    **deprecated_options: Any,
+) -> ExperimentResult[RabiData]:
     """
     Run an EF Rabi experiment and fit parameters.
 
@@ -421,22 +434,23 @@ def ef_rabi_experiment(
         # print(f"Using default ef_amplitude {ef_amplitude} for {target_qubit}")
     if ef_ramptime is None:
         ef_ramptime = 0.0
-    
-    n_shots, shot_interval, deprecated_options = ex.measurement_service.resolve_shot_options(
-        n_shots=n_shots,
-        shot_interval=shot_interval,
-        deprecated_options=deprecated_options,
-        n_shots_default=DEFAULT_SHOTS,
-        shot_interval_default=DEFAULT_INTERVAL,
+
+    n_shots, shot_interval, deprecated_options = (
+        ex.measurement_service.resolve_shot_options(
+            n_shots=n_shots,
+            shot_interval=shot_interval,
+            deprecated_options=deprecated_options,
+            n_shots_default=DEFAULT_SHOTS,
+            shot_interval_default=DEFAULT_INTERVAL,
+        )
     )
     if plot is None:
         plot = True
-        
+
     time_range = np.array(time_range, dtype=np.float64)
 
     effective_time_range = time_range + ef_ramptime
     control_sampling_period = ex.measurement_service.ctx.measurement.sampling_period
-
 
     def cr_pi_pulse() -> qx.PulseSchedule:
         with qx.PulseSchedule() as ps:
@@ -446,15 +460,11 @@ def ef_rabi_experiment(
                     duration=cr_duration,
                     amplitude=cr_amplitude,
                     tau=cr_ramptime,
-                    type='RaisedCosine',
+                    type="RaisedCosine",
                 ),
             )
-            ps.add(
-                target_qubit,
-                Blank(duration=cr_duration)
-            )
+            ps.add(target_qubit, Blank(duration=cr_duration))
         return ps
-
 
     # ef rabi sequence with rect pulses of duration T
     def ef_rabi_sequence(T: int) -> PulseSchedule:
@@ -531,23 +541,23 @@ def ef_rabi_experiment(
 
 
 def ef_chevron_pattern(
-        ex: qx.Experiment,
-        target_qubit: str,
-        control_qubit: str,
-        cr_amplitude: float,
-        cr_duration: int,
-        cr_ramptime: float,
-        time_range: ArrayLike,
-        ef_frequency: float | None = None,
-        ef_amplitude: float | None = None,
-        ef_ramptime: float | None = None,
-        detuning_range: ArrayLike | None = None,
-        is_damped: bool | None = None,
-        n_shots: int | None = None,
-        shot_interval: float | None = None,
-        plot: bool | None = None,
-        **deprecated_options: Any,
-    ) -> ExperimentResult[FreqRabiData]:
+    ex: qx.Experiment,
+    target_qubit: str,
+    control_qubit: str,
+    cr_amplitude: float,
+    cr_duration: int,
+    cr_ramptime: float,
+    time_range: ArrayLike,
+    ef_frequency: float | None = None,
+    ef_amplitude: float | None = None,
+    ef_ramptime: float | None = None,
+    detuning_range: ArrayLike | None = None,
+    is_damped: bool | None = None,
+    n_shots: int | None = None,
+    shot_interval: float | None = None,
+    plot: bool | None = None,
+    **deprecated_options: Any,
+) -> ExperimentResult[FreqRabiData]:
     """
     Measure an EF chevron (frequency-versus-Rabi) pattern by sweeping detuning.
 
@@ -572,7 +582,9 @@ def ef_chevron_pattern(
         Container with `FreqRabiData` over the detuning sweep.
     """
     if ef_frequency is None:
-        ef_frequency = ex.qubits[target_qubit].frequency + ex.qubits[target_qubit].anharmonicity
+        ef_frequency = (
+            ex.qubits[target_qubit].frequency + ex.qubits[target_qubit].anharmonicity
+        )
     if detuning_range is None:
         detuning_range = np.linspace(-0.01, 0.01, 21)
 
@@ -580,19 +592,21 @@ def ef_chevron_pattern(
     rabi_rates: list[float] = []
 
     with ExitStack() as stack:
-        retune_needed, backend_settings = _calc_fnco_settings(ex, channel_label=target_qubit, drive_frequency=ef_frequency)
+        retune_needed, backend_settings = _calc_fnco_settings(
+            ex, channel_label=target_qubit, drive_frequency=ef_frequency
+        )
         if retune_needed:
             stack.enter_context(
-                ex.system_manager.modified_backend_settings(
-                    **backend_settings
-                )
+                ex.system_manager.modified_backend_settings(**backend_settings)
             )
-        
+
         # ex.obtain_rabi_params()
         for detuning in tqdm(detuning_range):
-            with ex.modified_frequencies({
-                    target_qubit: ef_frequency+detuning,
-                }):
+            with ex.modified_frequencies(
+                {
+                    target_qubit: ef_frequency + detuning,
+                }
+            ):
                 rabi_result = ef_rabi_experiment(
                     ex=ex,
                     target_qubit=target_qubit,
@@ -609,10 +623,10 @@ def ef_chevron_pattern(
                     plot=plot,
                     **deprecated_options,
                 )
-            
+
             ef_label = ex.measurement_service.ctx.resolve_ef_label(target_qubit)
             rabi_params = rabi_result.rabi_params.get(ef_label, None)
-            rabi_datum  = rabi_result.data.get(ef_label, None)
+            rabi_datum = rabi_result.data.get(ef_label, None)
             if rabi_params is None:
                 raise ValueError("Rabi parameters are not stored.")
                 # print("Rabi parameters are not stored.")

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -589,7 +589,7 @@ def obtain_anharmonicity_with_cr(
     result = ExperimentResult(data={target_qubit: data})
     fit_result = data.fit(plot=plot)
     if fit_result.status is FitStatus.SUCCESS:
-        ef_frequency = fit_result.data.get("resonance_frequency", None)
+        ef_frequency = fit_result.data.get("f_resonance", None)
         if ef_frequency is None:
             raise ValueError("Resonance frequency is not available in fit result.")
         anharmonicity = ef_frequency - ex.qubits[target_qubit].frequency

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -138,30 +138,6 @@ def calibrate_cr_pi_pulse(
             ps.add(target_qubit, Blank(duration=duration))
         return ps
 
-    def _plot_raw_calibration(
-        x_values: Collection[float],
-        y_values: Collection[float],
-        title: str,
-        xlabel: str,
-    ) -> None:
-        fig = viz.make_figure()
-        fig.add_trace(
-            go.Scatter(
-                x=x_values,
-                y=-y_values,
-                mode="markers",
-                name="Data",
-            )
-        )
-        fig.update_layout(
-            title=title,
-            xaxis_title=xlabel,
-            yaxis_title="Normalized signal",
-            xaxis_type="linear",
-            yaxis_type="linear",
-        )
-        fig.show()
-
     def calibrate_duration(duration_range: Collection[float]) -> float:
         n_per_rotation = 2
 
@@ -173,13 +149,6 @@ def calibrate_cr_pi_pulse(
             interval=interval,
             plot=True,
         ).data[target_qubit]
-
-        _plot_raw_calibration(
-            x_values=duration_range,
-            y_values=sweep_data.normalized,
-            title=f"CR pi pulse duration calibration : {target_qubit}",
-            xlabel="duration",
-        )
 
         fit_result = fitting.fit_ampl_calib_data(
             target=target_qubit,
@@ -212,13 +181,6 @@ def calibrate_cr_pi_pulse(
             interval=interval,
             plot=True,
         ).data[target_qubit]
-
-        _plot_raw_calibration(
-            x_values=amplitude_range,
-            y_values=sweep_data.normalized,
-            title=f"CR pi pulse amplitude calibration : {target_qubit}",
-            xlabel="amplitude",
-        )
 
         fit_result = fitting.fit_ampl_calib_data(
             target=target_qubit,

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -280,7 +280,6 @@ def _calc_fnco_settings(
     channel_label: str,
     drive_frequency: float,
     force_retune: bool = False,
-    print_info: bool = False,
 ) -> tuple[bool, dict[str, float]]:
     """
     Return device settings kwargs when an FNCO retune is needed.
@@ -304,6 +303,9 @@ def _calc_fnco_settings(
     tuple
         (retune_needed, params) where `params` can be passed to backend settings.
     """
+    # Normally FINE_FREQ_TOL_GHZ could be 0.250 (250 MHz) and FNCO_MAX
+    # could be as high as 750 MHz, but we choose smaller values here to
+    # avoid spurious signals.
     FINE_FREQ_TOL_GHZ = 0.150  # 150 MHz
     FNCO_MAX = 600_000_000  # 600 MHz
 
@@ -318,26 +320,10 @@ def _calc_fnco_settings(
     current_fnco = target.channel.fnco_freq
     current_cnco = target.channel.cnco_freq
 
-    if current_lo is not None:
-        current_diff_ghz = abs(
-            drive_frequency - (current_lo - current_cnco - current_fnco) * 1e-9
-        )
-        if print_info:
-            print(
-                f"current lo: {current_lo * 1e-9} GHz, current cnco: {current_cnco * 1e-9} GHz, fnco: {current_fnco * 1e-9} GHz"
-            )
-
-    else:
-        current_diff_ghz = abs(drive_frequency - (current_cnco + current_fnco) * 1e-9)
-        if print_info:
-            print(
-                f"current cnco: {current_cnco * 1e-9} GHz, fnco: {current_fnco * 1e-9} GHz"
-            )
-
+    current_diff_ghz = abs(drive_frequency - target.fine_frequency)
     current_fnco_ok = abs(current_fnco) <= FNCO_MAX
+
     if not force_retune and current_diff_ghz <= FINE_FREQ_TOL_GHZ and current_fnco_ok:
-        if print_info:
-            print("No FNCO retune needed")
         retune_needed = False
         params = {
             "label": channel_label,
@@ -354,30 +340,24 @@ def _calc_fnco_settings(
         cnco=current_cnco,
     )
 
-    new_fnco = int(np.min((new_fnco, FNCO_MAX)))
-    new_fnco = int(np.max((-FNCO_MAX, new_fnco)))
-
-    # Residual fine-frequency error after applying the rounded FNCO
-    if current_lo is not None:
-        diff_ghz = abs(drive_frequency - (current_lo - current_cnco - new_fnco) * 1e-9)
-    else:
-        diff_ghz = abs(drive_frequency - (current_cnco + new_fnco) * 1e-9)
-    if diff_ghz > FINE_FREQ_TOL_GHZ:
+    # Compare the desired FNCO magnitude with the FNCO limit (upper/lower bound)
+    diff = abs(new_fnco) - FNCO_MAX
+    print(diff)
+    if diff > FINE_FREQ_TOL_GHZ * 1e9:
+        # The required FNCO is outside the allowable range and cannot be compensated by the AWG
         raise RuntimeError(
-            f"{channel_label}: No feasible FNCO within tolerance: residual delta {diff_ghz:.6f} GHz > {FINE_FREQ_TOL_GHZ} GHz"
+            f"{channel_label}: Calculated FNCO {new_fnco} Hz is below min {-FNCO_MAX} Hz by {diff} Hz, which exceeds tolerance {FINE_FREQ_TOL_GHZ * 1e9:.2f} Hz"
         )
-
-    if print_info:
-        print(
-            f"new fnco: {new_fnco * 1e-9} GHz, projected fine frequency delta: {diff_ghz:.6f} GHz"
-        )
+    else:
+        # The difference can be compensated by the AWG, so clip FNCO to the allowable range.
+        new_fnco = np.clip(new_fnco, -FNCO_MAX, FNCO_MAX)
 
     retune_needed = True
     params = {
         "label": channel_label,
         "lo_freq": current_lo,
         "cnco_freq": current_cnco,
-        "fnco_freq": new_fnco,
+        "fnco_freq": int(new_fnco),
     }
     return retune_needed, params
 

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -1,0 +1,643 @@
+from __future__ import annotations
+
+from contextlib import ExitStack
+from collections.abc import Collection
+from typing import Any
+
+import numpy as np
+from numpy.typing import ArrayLike
+from plotly import graph_objects as go
+from tqdm import tqdm
+
+import qubex as qx
+from qxpulse import Blank, FlatTop, PulseSchedule
+from qubex import visualization as viz
+from qubex.analysis import FitStatus, fitting
+from qubex.experiment.experiment_constants import (
+    CALIBRATION_SHOTS,
+    DEFAULT_INTERVAL,
+    DEFAULT_SHOTS,
+    PI_RAMPTIME,
+)
+from qubex.experiment.models.experiment_result import (
+    AmplCalibData,
+    ExperimentResult,
+    FreqRabiData,
+    RabiData,
+)
+from qubex.experiment.models.rabi_param import RabiParam
+from qubex.system import MixingUtil
+
+
+# Public API exported from this module (contrib-style utilities)
+__all__ = [
+    'calibrate_cr_pi_pulse',
+    'ef_rabi_experiment',
+    'ef_chevron_pattern',
+]
+
+
+def calibrate_cr_pi_pulse(
+        ex: qx.Experiment,
+        control_qubit: str,
+        target_qubit: str,
+        duration_range: Collection[float],
+        amplitude_range: Collection[float] | None = None,
+        ramptime: float | None = None,
+        n_points: int | None = None,
+        n_rotations: int | None = None,
+        n_iterations: int | None = None,
+        ratio: float | None = None,
+        r2_threshold: float | None = None,
+        plot: bool | None = None,
+        shots: int | None = None,
+        interval: float | None = None,
+    ) -> tuple[ExperimentResult[AmplCalibData], int, qx.PulseSchedule]:
+    """
+    Calibrate CR pi pulse by fitting duration first, then amplitude.
+
+    Parameters
+    ----------
+    ex
+        Experiment context providing measurement and device access.
+    control_qubit, target_qubit
+        Qubit labels used for control and target channels.
+    duration_range
+        Sequence of durations to sweep when fitting the pi pulse duration.
+    amplitude_range
+        Optional amplitude sweep range for amplitude calibration.
+    ramptime
+        Pulse ramp time.
+    n_points
+        Number of points used when generating an amplitude range if not provided.
+    n_rotations, n_iterations, ratio, r2_threshold
+        Calibration control parameters.
+    update_params
+        If True, update experiment calibration parameters (no-op here).
+    plot
+        If True, plotting is enabled.
+    shots, interval
+        Measurement shot options.
+
+    Returns
+    -------
+    tuple
+        A tuple of (ExperimentResult[data], fixed_duration, pulse_schedule).
+
+    Notes
+    -----
+    This function preserves argument list and behavior; only docstring and
+    return type annotation were adjusted to match contrib guidelines.
+    """
+    if n_points is None:
+        if amplitude_range is not None:
+            n_points = len(amplitude_range)
+        else:
+            n_points = 20
+    if n_rotations is None:
+        n_rotations = 1
+    if n_iterations is None:
+        n_iterations = 2
+    if r2_threshold is None:
+        r2_threshold = 0.5
+    if ratio is None:
+        ratio = 0.2
+    if ramptime is None:
+        ramptime = PI_RAMPTIME
+    if amplitude_range is None:
+        amplitude_range = np.linspace(0.9, 1, n_points)
+    if plot is None:
+        plot = True
+    if shots is None:
+        shots = CALIBRATION_SHOTS
+    if interval is None:
+        interval = DEFAULT_INTERVAL
+
+    if target_qubit not in ex.ctx.calib_note.rabi_params:
+        raise ValueError(f"Rabi parameters are not stored for {target_qubit}.")
+
+    def seq(duration: float, amplitude: float = 1.0) -> qx.PulseSchedule:
+        with qx.PulseSchedule() as ps:
+            ps.add(
+                control_qubit,
+                FlatTop(
+                    duration=duration,
+                    amplitude=amplitude,
+                    tau=ramptime,
+                    type='RaisedCosine',
+                ),
+            )
+            ps.add(
+                target_qubit,
+                Blank(duration=duration)
+            )
+        return ps
+
+    def _plot_raw_calibration(
+        x_values: Collection[float],
+        y_values: Collection[float],
+        title: str,
+        xlabel: str,
+    ) -> None:
+        fig = viz.make_figure()
+        fig.add_trace(
+            go.Scatter(
+                x=x_values,
+                y=-y_values,
+                mode="markers",
+                name="Data",
+            )
+        )
+        fig.update_layout(
+            title=title,
+            xaxis_title=xlabel,
+            yaxis_title='Normalized signal',
+            xaxis_type='linear',
+            yaxis_type='linear',
+        )
+        fig.show()
+
+    def calibrate_duration(duration_range: Collection[float]) -> float:
+        n_per_rotation = 2
+
+        sweep_data = ex.sweep_parameter(
+            sequence=lambda sweep_duration: seq(duration=sweep_duration, amplitude=1.0),
+            sweep_range=duration_range,
+            repetitions=n_per_rotation * n_rotations,
+            shots=shots,
+            interval=interval,
+            plot=True,
+        ).data[target_qubit]
+
+        _plot_raw_calibration(
+            x_values=duration_range,
+            y_values=sweep_data.normalized,
+            title=f"CR pi pulse duration calibration : {target_qubit}",
+            xlabel='duration',
+        )
+
+        fit_result = fitting.fit_ampl_calib_data(
+            target=target_qubit,
+            amplitude_range=duration_range,
+            data=sweep_data.normalized,
+            plot=plot,
+            title='CR pi pulse duration calibration',
+            xlabel='duration',
+            ylabel='Normalized signal',
+        )
+
+        duration_r2 = fit_result['r2']
+        if duration_r2 < r2_threshold:
+            print(f"Error: duration fit R² value is too low ({duration_r2:.3f})")
+
+        return fit_result['amplitude']
+
+    def calibrate_amplitude(amplitude_range: Collection[float], fixed_duration: float) -> AmplCalibData:
+        n_per_rotation = 2
+
+        sweep_data = ex.sweep_parameter(
+            sequence=lambda amplitude: seq(duration=fixed_duration, amplitude=amplitude),
+            sweep_range=amplitude_range,
+            repetitions=n_per_rotation * n_rotations,
+            shots=shots,
+            interval=interval,
+            plot=True,
+        ).data[target_qubit]
+
+        _plot_raw_calibration(
+            x_values=amplitude_range,
+            y_values=sweep_data.normalized,
+            title=f"CR pi pulse amplitude calibration : {target_qubit}",
+            xlabel='amplitude',
+        )
+
+        fit_result = fitting.fit_ampl_calib_data(
+            target=target_qubit,
+            amplitude_range=amplitude_range,
+            data=sweep_data.normalized,
+            plot=plot,
+            title='CR pi pulse amplitude calibration',
+            xlabel='amplitude',
+            ylabel='Normalized signal',
+        )
+
+        r2 = fit_result['r2']
+        if r2 < r2_threshold:
+            print(f"Error: R² value is too low ({r2:.3f})")
+
+        return AmplCalibData.new(
+            sweep_data=sweep_data,
+            calib_value=fit_result['amplitude'],
+            r2=r2,
+        )
+
+    def _update_amplitude_range(center: float, ratio: float = 0.2) -> Collection[float]:
+        if ratio <= 0 or ratio >= 1:
+            raise ValueError("Ratio must be between 0 and 1.")
+        new_range = np.linspace(
+            np.max((0, center * (1 - ratio))),
+            np.min((1, center * (1 + ratio))),
+            n_points,
+        )
+        return new_range
+
+    data: dict[str, AmplCalibData] = {}
+    _amplitude_range = amplitude_range
+    # print(f"Calibrating CR pi pulse for {target_qubit}...")
+
+    opt_duration = calibrate_duration(duration_range=duration_range)
+    opt_duration_fixed = int(np.ceil(opt_duration / 2.0) * 2)
+    # print(f"Optimal duration (fit): {opt_duration}")
+    # print(f"Duration used for amplitude sweep (rounded up to even): {opt_duration_fixed}")
+
+    for i in range(n_iterations):
+        # print(f"Amplitude iteration {i+1}/{n_iterations}")
+        data[target_qubit] = calibrate_amplitude(
+            amplitude_range=_amplitude_range,
+            fixed_duration=opt_duration_fixed,
+        )
+        _amplitude_range = _update_amplitude_range(center=data[target_qubit].calib_value, ratio=ratio)
+
+    print("")
+    print(f"Calibration results for CR pi pulse:")
+    print(f"  duration: {opt_duration} -> {opt_duration_fixed} [ns]")
+    for target, calib_data in data.items():
+        print(f"  {target}: {calib_data.calib_value} [arb. units]")
+
+    ps_result = seq(duration=opt_duration_fixed, amplitude=data[target_qubit].calib_value)
+
+    return ExperimentResult(data=data), opt_duration_fixed, ps_result
+
+
+def _calc_fnco_settings(
+        ex: qx.Experiment,
+        channel_label: str,
+        drive_frequency: float,
+        force_retune: bool = False,
+        print_info: bool = False,
+    )-> tuple[bool, dict[str, float]]:
+    """
+    Return device settings kwargs when an FNCO retune is needed.
+
+    Parameters
+    ----------
+    ex
+        Experiment providing system and channel information.
+    channel_label
+        Channel label to inspect and (optionally) retune.
+    drive_frequency
+        Desired drive frequency in GHz.
+    force_retune
+        If True, force recalculation of FNCO even if current settings are within
+        tolerance.
+    print_info
+        If True, print informational messages about decisions.
+
+    Returns
+    -------
+    tuple
+        (retune_needed, params) where `params` can be passed to backend settings.
+    """
+
+    FINE_FREQ_TOL_GHZ = 0.150 # 150 MHz
+    FNCO_MAX = 600_000_000 # 600 MHz
+
+    target = ex.ctx.experiment_system.get_target(channel_label)
+    port = target.channel.port
+
+    try:
+        current_lo = target.channel.lo_freq
+    except ValueError:
+        current_lo = None
+
+    current_fnco = target.channel.fnco_freq
+    current_cnco = target.channel.cnco_freq
+
+    if current_lo is not None:
+        current_diff_ghz = abs(drive_frequency - (current_lo - current_cnco - current_fnco) * 1e-9)
+        if print_info:
+            print(f"current lo: {current_lo*1e-9} GHz, current cnco: {current_cnco*1e-9} GHz, fnco: {current_fnco*1e-9} GHz")
+
+    else: 
+        current_diff_ghz = abs(drive_frequency - (current_cnco + current_fnco) * 1e-9)
+        if print_info:
+            print(f"current cnco: {current_cnco*1e-9} GHz, fnco: {current_fnco*1e-9} GHz")
+
+    current_fnco_ok = abs(current_fnco) <= FNCO_MAX
+    if not force_retune and current_diff_ghz <= FINE_FREQ_TOL_GHZ and current_fnco_ok:
+        if print_info:
+            print("No FNCO retune needed")
+        retune_needed = False
+        params = {
+            'label': channel_label,
+            'lo_freq': current_lo,
+            'cnco_freq': current_cnco,
+            'fnco_freq': current_fnco,
+        }
+        return retune_needed, params
+
+    new_fnco, _ = MixingUtil.calc_fnco(
+        f=drive_frequency * 1e9,
+        ssb=port.sideband,
+        lo=current_lo,
+        cnco=current_cnco,
+    )
+
+    new_fnco = int(np.min((new_fnco, FNCO_MAX)))
+    new_fnco = int(np.max((-FNCO_MAX, new_fnco)))
+
+    # Residual fine-frequency error after applying the rounded FNCO
+    if current_lo is not None:
+        diff_ghz = abs(drive_frequency - (current_lo - current_cnco - new_fnco) * 1e-9)
+    else:
+        diff_ghz = abs(drive_frequency - (current_cnco + new_fnco) * 1e-9)
+    if diff_ghz > FINE_FREQ_TOL_GHZ:
+        raise RuntimeError(
+            f"{channel_label}: No feasible FNCO within tolerance: residual delta {diff_ghz:.6f} GHz > {FINE_FREQ_TOL_GHZ} GHz"
+        )
+
+    if print_info:
+        print(f"new fnco: {new_fnco*1e-9} GHz, projected fine frequency delta: {diff_ghz:.6f} GHz")
+
+    retune_needed = True
+    params = {
+        'label': channel_label,
+        'lo_freq': current_lo,
+        'cnco_freq': current_cnco,
+        'fnco_freq': new_fnco,
+    }
+    return retune_needed, params
+
+
+def ef_rabi_experiment(
+        ex: qx.Experiment,
+        target_qubit: str,
+        control_qubit: str,
+        cr_amplitude: float,
+        cr_duration: int,
+        cr_ramptime: float,
+        time_range: ArrayLike,
+        ef_amplitude: float | None = None,
+        ef_ramptime: float | None = None,
+        is_damped: bool | None = None,
+        n_shots: int | None = None,
+        shot_interval: float | None = None,
+        plot: bool | None = None,
+        **deprecated_options: Any,
+    ) -> ExperimentResult[RabiData]:
+    """
+    Run an EF Rabi experiment and fit parameters.
+
+    Parameters
+    ----------
+    ex
+        Experiment context with measurement and pulse configuration.
+    target_qubit, control_qubit
+        Qubit labels for the experiment.
+    cr_amplitude, cr_duration, cr_ramptime
+        Parameters for the CR pi pulse used to prepare the `e` state.
+    time_range
+        Durations swept for the EF drive.
+    ef_amplitude, ef_ramptime
+        EF drive amplitude and ramp time. Defaults are taken from `ex` when
+        not provided.
+    is_damped
+        Whether to use a damped Rabi fit.
+    n_shots, shot_interval
+        Measurement shot options.
+    plot
+        If True, plotting is enabled.
+
+    Returns
+    -------
+    ExperimentResult
+        Result object containing fitted `RabiData` and parameters.
+    """
+    # TODO: Integrate with rabi_experiment
+    if is_damped is None:
+        is_damped = True
+    if ef_amplitude is None:
+        ef_amplitude = ex.params.get_ef_control_amplitude(target_qubit)
+        # print(f"Using default ef_amplitude {ef_amplitude} for {target_qubit}")
+    if ef_ramptime is None:
+        ef_ramptime = 0.0
+    
+    n_shots, shot_interval, deprecated_options = ex.measurement_service.resolve_shot_options(
+        n_shots=n_shots,
+        shot_interval=shot_interval,
+        deprecated_options=deprecated_options,
+        n_shots_default=DEFAULT_SHOTS,
+        shot_interval_default=DEFAULT_INTERVAL,
+    )
+    if plot is None:
+        plot = True
+        
+    time_range = np.array(time_range, dtype=np.float64)
+
+    effective_time_range = time_range + ef_ramptime
+    control_sampling_period = ex.measurement_service.ctx.measurement.sampling_period
+
+
+    def cr_pi_pulse() -> qx.PulseSchedule:
+        with qx.PulseSchedule() as ps:
+            ps.add(
+                control_qubit,
+                FlatTop(
+                    duration=cr_duration,
+                    amplitude=cr_amplitude,
+                    tau=cr_ramptime,
+                    type='RaisedCosine',
+                ),
+            )
+            ps.add(
+                target_qubit,
+                Blank(duration=cr_duration)
+            )
+        return ps
+
+
+    # ef rabi sequence with rect pulses of duration T
+    def ef_rabi_sequence(T: int) -> PulseSchedule:
+        with PulseSchedule() as ps:
+            ps.call(cr_pi_pulse())
+            ps.barrier()
+            # apply the ef drive to induce the ef Rabi oscillation
+            ps.add(
+                target_qubit,
+                FlatTop(
+                    duration=T + 2 * ef_ramptime,
+                    amplitude=ef_amplitude,
+                    tau=ef_ramptime,
+                    sampling_period=control_sampling_period,
+                ),
+            )
+        return ps
+
+    # run the Rabi experiment by sweeping the drive time
+    sweep_result = ex.measurement_service.sweep_parameter(
+        sequence=ef_rabi_sequence,
+        sweep_range=time_range,
+        n_shots=n_shots,
+        shot_interval=shot_interval,
+        plot=plot,
+        **deprecated_options,
+    )
+
+    # fit the Rabi oscillation
+    ef_rabi_params = {}
+    ef_rabi_data = {}
+    data = sweep_result.data[target_qubit]
+    ef_label = ex.measurement_service.ctx.resolve_ef_label(target_qubit)
+    ge_rabi_param = ex.measurement_service.pulse.ge_rabi_params[target_qubit]
+    iq_e = ge_rabi_param.endpoints[1]
+    # print(f"Fitting EF Rabi for {target_qubit} with iq_e={iq_e}, is_damped={is_damped}")
+    fit_result = fitting.fit_rabi(
+        target=target_qubit,
+        times=effective_time_range,
+        data=data.data,
+        reference_point=iq_e,
+        plot=plot,
+        is_damped=is_damped,
+    )
+    if fit_result.status is not FitStatus.SUCCESS:
+        ef_rabi_params[ef_label] = RabiParam.nan(target=ef_label)
+    else:
+        ef_rabi_params[ef_label] = RabiParam(
+            target=ef_label,
+            amplitude=fit_result["amplitude"],
+            frequency=fit_result["frequency"],
+            phase=fit_result["phase"],
+            offset=fit_result["offset"],
+            noise=fit_result["noise"],
+            angle=fit_result["angle"],
+            distance=fit_result["distance"],
+            r2=fit_result["r2"],
+            reference_phase=fit_result["reference_phase"],
+        )
+    ef_rabi_data[ef_label] = RabiData(
+        target=ef_label,
+        data=data.data,
+        time_range=effective_time_range,
+        rabi_param=ef_rabi_params[ef_label],
+    )
+
+    # create the experiment result
+    result = ExperimentResult(
+        data=ef_rabi_data,
+        rabi_params=ef_rabi_params,
+    )
+
+    return result
+
+
+def ef_chevron_pattern(
+        ex: qx.Experiment,
+        target_qubit: str,
+        control_qubit: str,
+        cr_amplitude: float,
+        cr_duration: int,
+        cr_ramptime: float,
+        time_range: ArrayLike,
+        ef_frequency: float | None = None,
+        ef_amplitude: float | None = None,
+        ef_ramptime: float | None = None,
+        detuning_range: ArrayLike | None = None,
+        is_damped: bool | None = None,
+        n_shots: int | None = None,
+        shot_interval: float | None = None,
+        plot: bool | None = None,
+        **deprecated_options: Any,
+    ) -> ExperimentResult[FreqRabiData]:
+    """
+    Measure an EF chevron (frequency-versus-Rabi) pattern by sweeping detuning.
+
+    Parameters
+    ----------
+    ex
+        Experiment context used to run measurements and manage backend settings.
+    target_qubit, control_qubit
+        Qubit labels.
+    cr_amplitude, cr_duration, cr_ramptime
+        CR pi pulse parameters used to prepare the `e` state before EF drive.
+    time_range
+        Time sweep used for each Rabi experiment.
+    ef_frequency, detuning_range
+        Center EF drive frequency and detuning sweep (in GHz).
+    ef_amplitude, ef_ramptime, is_damped, n_shots, shot_interval, plot
+        Measurement control options.
+
+    Returns
+    -------
+    ExperimentResult
+        Container with `FreqRabiData` over the detuning sweep.
+    """
+    if ef_frequency is None:
+        ef_frequency = ex.qubits[target_qubit].frequency + ex.qubits[target_qubit].anharmonicity
+    if detuning_range is None:
+        detuning_range = np.linspace(-0.01, 0.01, 21)
+
+    rabi_data: list[RabiData] = []
+    rabi_rates: list[float] = []
+
+    with ExitStack() as stack:
+        retune_needed, backend_settings = _calc_fnco_settings(ex, channel_label=target_qubit, drive_frequency=ef_frequency)
+        if retune_needed:
+            stack.enter_context(
+                ex.system_manager.modified_backend_settings(
+                    **backend_settings
+                )
+            )
+        
+        # ex.obtain_rabi_params()
+        for detuning in tqdm(detuning_range):
+            with ex.modified_frequencies({
+                    target_qubit: ef_frequency+detuning,
+                }):
+                rabi_result = ef_rabi_experiment(
+                    ex=ex,
+                    target_qubit=target_qubit,
+                    control_qubit=control_qubit,
+                    cr_amplitude=cr_amplitude,
+                    cr_duration=cr_duration,
+                    cr_ramptime=cr_ramptime,
+                    time_range=time_range,
+                    ef_amplitude=ef_amplitude,
+                    ef_ramptime=ef_ramptime,
+                    is_damped=is_damped,
+                    n_shots=n_shots,
+                    shot_interval=shot_interval,
+                    plot=plot,
+                    **deprecated_options,
+                )
+            
+            ef_label = ex.measurement_service.ctx.resolve_ef_label(target_qubit)
+            rabi_params = rabi_result.rabi_params.get(ef_label, None)
+            rabi_datum  = rabi_result.data.get(ef_label, None)
+            if rabi_params is None:
+                raise ValueError("Rabi parameters are not stored.")
+                # print("Rabi parameters are not stored.")
+                # rabi_rates.append(None)
+            else:
+                rabi_rates.append(rabi_params.frequency)
+            if rabi_datum is None:
+                raise ValueError("Rabi data are not stored.")
+                # print("Rabi data are not stored.")
+                # rabi_data.append(None)
+            else:
+                rabi_data.append(rabi_datum)
+
+    frequency_range = detuning_range + ef_frequency
+
+    data = {
+        target_qubit: FreqRabiData(
+            target=target_qubit,
+            data=np.array(rabi_rates, dtype=np.float64),
+            sweep_range=detuning_range,
+            frequency_range=frequency_range,
+            rabi_data=rabi_data,
+        )
+    }
+    result = ExperimentResult(data=data)
+    if plot:
+        result.fit()
+    return result

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -245,15 +245,11 @@ def calibrate_cr_pi_pulse(
 
     data: dict[str, AmplCalibData] = {}
     _amplitude_range = amplitude_range
-    # print(f"Calibrating CR pi pulse for {target_qubit}...")
 
     opt_duration = calibrate_duration(duration_range=duration_range)
     opt_duration_fixed = int(np.ceil(opt_duration / 2.0) * 2)
-    # print(f"Optimal duration (fit): {opt_duration}")
-    # print(f"Duration used for amplitude sweep (rounded up to even): {opt_duration_fixed}")
 
     for _ in range(n_iterations):
-        # print(f"Amplitude iteration {i+1}/{n_iterations}")
         data[target_qubit] = calibrate_amplitude(
             amplitude_range=_amplitude_range,
             fixed_duration=opt_duration_fixed,
@@ -342,7 +338,6 @@ def _calc_fnco_settings(
 
     # Compare the desired FNCO magnitude with the FNCO limit (upper/lower bound)
     diff = abs(new_fnco) - FNCO_MAX
-    print(diff)
     if diff > FINE_FREQ_TOL_GHZ * 1e9:
         # The required FNCO is outside the allowable range and cannot be compensated by the AWG
         raise RuntimeError(
@@ -411,7 +406,6 @@ def ef_rabi_experiment(
         is_damped = True
     if ef_amplitude is None:
         ef_amplitude = ex.params.get_ef_control_amplitude(target_qubit)
-        # print(f"Using default ef_amplitude {ef_amplitude} for {target_qubit}")
     if ef_ramptime is None:
         ef_ramptime = 0.0
 
@@ -480,7 +474,6 @@ def ef_rabi_experiment(
     ef_label = ex.measurement_service.ctx.resolve_ef_label(target_qubit)
     ge_rabi_param = ex.measurement_service.pulse.ge_rabi_params[target_qubit]
     iq_e = ge_rabi_param.endpoints[1]
-    # print(f"Fitting EF Rabi for {target_qubit} with iq_e={iq_e}, is_damped={is_damped}")
     fit_result = fitting.fit_rabi(
         target=target_qubit,
         times=effective_time_range,
@@ -609,14 +602,10 @@ def ef_chevron_pattern(
             rabi_datum = rabi_result.data.get(ef_label, None)
             if rabi_params is None:
                 raise ValueError("Rabi parameters are not stored.")
-                # print("Rabi parameters are not stored.")
-                # rabi_rates.append(None)
             else:
                 rabi_rates.append(rabi_params.frequency)
             if rabi_datum is None:
                 raise ValueError("Rabi data are not stored.")
-                # print("Rabi data are not stored.")
-                # rabi_data.append(None)
             else:
                 rabi_data.append(rabi_datum)
     detuning_range = np.asarray(detuning_range, dtype=np.float64)

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -98,7 +98,7 @@ def calibrate_cr_pi_pulse(
     if n_rotations is None:
         n_rotations = 1
     if n_iterations is None:
-        n_iterations = 2
+        n_iterations = 1
     if r2_threshold is None:
         r2_threshold = 0.5
     if ratio is None:
@@ -106,7 +106,7 @@ def calibrate_cr_pi_pulse(
     if ramptime is None:
         ramptime = PI_RAMPTIME
     if amplitude_range is None:
-        amplitude_range = np.linspace(0.9, 1, n_points)
+        amplitude_range = np.linspace(0.5, 1, n_points)
     if plot is None:
         plot = True
     if shots is None:
@@ -117,10 +117,19 @@ def calibrate_cr_pi_pulse(
     if target_qubit not in ex.ctx.calib_note.rabi_params:
         raise ValueError(f"Rabi parameters are not stored for {target_qubit}.")
 
+    cr_label = control_qubit + "-" + target_qubit
+    control_labels = [
+        target.label
+        for target in ex.ctx.experiment_system.targets
+        if target.is_related_to_qubits(ex.qubit_labels) and target.is_cr
+    ]
+    if cr_label not in control_labels:
+        raise ValueError(f"CR target label `{cr_label}` is not found in the system.")
+
     def seq(duration: float, amplitude: float = 1.0) -> qx.PulseSchedule:
         with qx.PulseSchedule() as ps:
             ps.add(
-                control_qubit,
+                cr_label,
                 FlatTop(
                     duration=duration,
                     amplitude=amplitude,
@@ -233,7 +242,7 @@ def calibrate_cr_pi_pulse(
             r2=r2,
         )
 
-    def _update_amplitude_range(center: float, ratio: float = 0.2) -> Collection[float]:
+    def _update_amplitude_range(center: float, ratio: float = 0.4) -> Collection[float]:
         if ratio <= 0 or ratio >= 1:
             raise ValueError("Ratio must be between 0 and 1.")
         new_range = np.linspace(
@@ -268,7 +277,7 @@ def calibrate_cr_pi_pulse(
         duration=opt_duration_fixed, amplitude=data[target_qubit].calib_value
     )
 
-    return ExperimentResult(data=data), opt_duration_fixed, ps_result
+    return ExperimentResult(data=data), ps_result
 
 
 def _calc_fnco_settings(

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -34,6 +34,7 @@ __all__ = [
     "obtain_anharmonicity_with_cr",
 ]
 
+
 def calibrate_cr_pi_pulse(
     ex: qx.Experiment,
     control_qubit: str,
@@ -488,7 +489,8 @@ def obtain_anharmonicity_with_cr(
     plot: bool | None = None,
     **deprecated_options: Any,
 ) -> tuple[ExperimentResult[FreqRabiData], float]:
-    """Measure EF chevron (frequency vs Rabi rate) and estimate anharmonicity.
+    """
+    Measure EF chevron (frequency vs Rabi rate) and estimate anharmonicity.
 
     Parameters
     ----------
@@ -577,19 +579,21 @@ def obtain_anharmonicity_with_cr(
     frequency_range = detuning_range + ef_frequency
 
     data = FreqRabiData(
-            target=target_qubit,
-            data=np.array(rabi_rates, dtype=np.float64),
-            sweep_range=detuning_range,
-            frequency_range=frequency_range,
-            rabi_data=rabi_data,
-        )
+        target=target_qubit,
+        data=np.array(rabi_rates, dtype=np.float64),
+        sweep_range=detuning_range,
+        frequency_range=frequency_range,
+        rabi_data=rabi_data,
+    )
     result = ExperimentResult(data={target_qubit: data})
     fit_result = data.fit(plot=plot)
     if fit_result.status is FitStatus.SUCCESS:
-        ef_frequency = fit_result.data['f_resonance']
+        ef_frequency = fit_result.data["f_resonance"]
         anharmonicity = ef_frequency - ex.qubits[target_qubit].frequency
         print(f"Estimated EF resonance frequency: {ef_frequency:.6f} GHz")
         print(f"Estimated anharmonicity: {anharmonicity:.6f} GHz")
         return result, anharmonicity
     else:
-        raise RuntimeError("Failed to fit EF chevron pattern, cannot estimate resonance frequency and anharmonicity.")
+        raise RuntimeError(
+            "Failed to fit EF chevron pattern, cannot estimate resonance frequency and anharmonicity."
+        )

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -619,7 +619,7 @@ def ef_chevron_pattern(
                 # rabi_data.append(None)
             else:
                 rabi_data.append(rabi_datum)
-
+    detuning_range = np.asarray(detuning_range, dtype=np.float64)
     frequency_range = detuning_range + ef_frequency
 
     data = {

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -33,10 +33,8 @@ from qubex.system import MixingUtil
 # Public API exported from this module (contrib-style utilities)
 __all__ = [
     "calibrate_cr_pi_pulse",
-    "ef_chevron_pattern",
-    "ef_rabi_experiment",
+    "obtain_anharmonicity_with_cr",
 ]
-
 
 def calibrate_cr_pi_pulse(
     ex: qx.Experiment,

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -147,7 +147,7 @@ def calibrate_cr_pi_pulse(
             repetitions=n_per_rotation * n_rotations,
             shots=shots,
             interval=interval,
-            plot=True,
+            plot=plot,
         ).data[target_qubit]
 
         fit_result = fitting.fit_ampl_calib_data(
@@ -179,7 +179,7 @@ def calibrate_cr_pi_pulse(
             repetitions=n_per_rotation * n_rotations,
             shots=shots,
             interval=interval,
-            plot=True,
+            plot=plot,
         ).data[target_qubit]
 
         fit_result = fitting.fit_ampl_calib_data(

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -49,42 +49,48 @@ def calibrate_cr_pi_pulse(
     plot: bool | None = None,
     shots: int | None = None,
     interval: float | None = None,
-) -> tuple[ExperimentResult[AmplCalibData], int, qx.PulseSchedule]:
+) -> tuple[ExperimentResult[AmplCalibData], qx.PulseSchedule]:
     """
     Calibrate CR pi pulse by fitting duration first, then amplitude.
 
     Parameters
     ----------
-    ex
-        Experiment context providing measurement and device access.
-    control_qubit, target_qubit
-        Qubit labels used for control and target channels.
-    duration_range
-        Sequence of durations to sweep when fitting the pi pulse duration.
-    amplitude_range
-        Optional amplitude sweep range for amplitude calibration.
-    ramptime
-        Pulse ramp time.
-    n_points
-        Number of points used when generating an amplitude range if not provided.
-    n_rotations, n_iterations, ratio, r2_threshold
-        Calibration control parameters.
-    update_params
-        If True, update experiment calibration parameters (no-op here).
-    plot
-        If True, plotting is enabled.
-    shots, interval
-        Measurement shot options.
+    ex : qx.Experiment
+        qx.Experiment instance.
+    control_qubit : str
+        Label of the control qubit (CR drive channel source).
+    target_qubit : str
+        Label of the target qubit being driven by the CR pulse.
+    duration_range : Collection[float]
+        Iterable of pulse durations (same units as device timing) to sweep
+        when fitting the pi-pulse duration.
+    amplitude_range : Collection[float] or None, optional
+        Optional amplitude sweep range for amplitude calibration. If ``None``
+        a default linear range is generated using ``n_points``.
+    ramptime : float or None, optional
+        Pulse ramp (tau) used when constructing shaped pulses. Defaults to
+        ``PI_RAMPTIME`` if ``None``.
+    n_points : int or None, optional
+        Number of points used when generating an amplitude range if
+        ``amplitude_range`` is not provided. Defaults to 20.
+    n_rotations, n_iterations : int or None, optional
+        Control how many rotations and iterative calibration steps to perform.
+    ratio : float or None, optional
+        Fractional window to narrow the amplitude sweep between iterations.
+    r2_threshold : float or None, optional
+        Minimum acceptable fit R²; a warning is printed when the fit quality
+        is below this threshold.
+    plot : bool or None, optional
+        If True, enable plotting of fit results.
+    shots : int or None, optional
+        Number of measurement shots per point.
+    interval : float or None, optional
+        Measurement interval between repeats.
 
     Returns
     -------
     tuple
-        A tuple of (ExperimentResult[data], fixed_duration, pulse_schedule).
-
-    Notes
-    -----
-    This function preserves argument list and behavior; only docstring and
-    return type annotation were adjusted to match contrib guidelines.
+        A tuple of (ExperimentResult[data], pulse_schedule).
     """
     if n_points is None:
         if amplitude_range is not None:
@@ -249,17 +255,14 @@ def _calc_fnco_settings(
 
     Parameters
     ----------
-    ex
-        Experiment providing system and channel information.
-    channel_label
-        Channel label to inspect and (optionally) retune.
-    drive_frequency
+    ex : qx.Experiment
+        qx.Experiment instance.
+    channel_label : str
+        Channel/target label to evaluate.
+    drive_frequency : float
         Desired drive frequency in GHz.
-    force_retune
-        If True, force recalculation of FNCO even if current settings are within
-        tolerance.
-    print_info
-        If True, print informational messages about decisions.
+    force_retune : bool, optional
+        If True, force recomputation of FNCO regardless of current state.
 
     Returns
     -------
@@ -342,23 +345,30 @@ def _ef_rabi_experiment(
 
     Parameters
     ----------
-    ex
-        Experiment context with measurement and pulse configuration.
-    target_qubit
-        Qubit label for the experiment.
-    cr_x180
-        CR X180 pulse used to prepare the `e` state before EF drive.
-    time_range
-        Durations swept for the EF drive.
-    ef_amplitude, ef_ramptime
-        EF drive amplitude and ramp time. Defaults are taken from `ex` when
-        not provided.
-    is_damped
-        Whether to use a damped Rabi fit.
-    n_shots, shot_interval
-        Measurement shot options.
-    plot
-        If True, plotting is enabled.
+    ex : qx.Experiment
+        qx.Experiment instance.
+    target_qubit : str
+        Target qubit label for the EF drive.
+    cr_x180 : PulseSchedule
+        Pulse schedule performing a CR X180; this is invoked before the EF
+        drive in each sequence.
+    time_range : ArrayLike
+        Array-like durations to sweep for the EF drive. Units match the
+        device timing (usually ns).
+    ef_amplitude : float or None, optional
+        EF drive amplitude. If ``None``, retrieved from ``ex.params``.
+    ef_ramptime : float or None, optional
+        Ramp time for the EF drive pulses.
+    is_damped : bool or None, optional
+        If True, use a damped Rabi model when fitting.
+    n_shots : int or None, optional
+        Shots per point.
+    shot_interval : float or None, optional
+        Interval between shots.
+    plot : bool or None, optional
+        Enable plotting of fit diagnostics.
+    **deprecated_options : Any
+        Additional deprecated keyword options forwarded to the sweep call.
 
     Returns
     -------
@@ -477,29 +487,39 @@ def obtain_anharmonicity_with_cr(
     shot_interval: float | None = None,
     plot: bool | None = None,
     **deprecated_options: Any,
-) -> ExperimentResult[FreqRabiData]:
-    """
-    Measure an EF chevron (frequency-versus-Rabi) pattern by sweeping detuning.
+) -> tuple[ExperimentResult[FreqRabiData], float]:
+    """Measure EF chevron (frequency vs Rabi rate) and estimate anharmonicity.
 
     Parameters
     ----------
-    ex
-        Experiment context used to run measurements and manage backend settings.
-    target_qubit
-        Qubit label.
-    cr_x180
-        CR X180 pulse used to prepare the `e` state before EF drive.
-    time_range
-        Time sweep used for each Rabi experiment.
-    ef_frequency, detuning_range
-        Center EF drive frequency and detuning sweep (in GHz).
-    ef_amplitude, ef_ramptime, is_damped, n_shots, shot_interval, plot
-        Measurement control options.
+    ex : qx.Experiment
+        Experiment instance providing measurement and system management.
+    target_qubit : str
+        Target qubit label to probe.
+    cr_x180 : PulseSchedule
+        CR X180 schedule used to prepare the excited state prior to EF drive.
+    time_range : ArrayLike
+        Time sweep for each EF Rabi run.
+    ef_frequency : float or None, optional
+        Central EF drive frequency in GHz. If ``None``, computed from the
+        qubit frequency plus its known anharmonicity.
+    ef_amplitude, ef_ramptime : float or None, optional
+        EF drive amplitude and ramp time.
+    detuning_range : ArrayLike or None, optional
+        Array-like detunings (in GHz) to sweep around ``ef_frequency``. A
+        default symmetric range is used when ``None``.
+    is_damped, n_shots, shot_interval, plot : optional
+        Measurement and fitting options forwarded to the underlying Rabi
+        experiment.
 
     Returns
     -------
-    ExperimentResult
-        Container with `FreqRabiData` over the detuning sweep.
+    tuple
+        ``(result, anharmonicity)`` where ``result`` is an
+        :class:`ExperimentResult` containing a :class:`FreqRabiData` entry for
+        ``target_qubit``, and ``anharmonicity`` is a float (GHz) estimated
+        from the fitted resonance frequency minus the qubit fundamental
+        frequency.
     """
     if ef_frequency is None:
         ef_frequency = (
@@ -573,4 +593,3 @@ def obtain_anharmonicity_with_cr(
         return result, anharmonicity
     else:
         raise RuntimeError("Failed to fit EF chevron pattern, cannot estimate resonance frequency and anharmonicity.")
-

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -8,12 +8,10 @@ from typing import Any
 
 import numpy as np
 from numpy.typing import ArrayLike
-from plotly import graph_objects as go
 from qxpulse import Blank, FlatTop, PulseSchedule
 from tqdm import tqdm
 
 import qubex as qx
-from qubex import visualization as viz
 from qubex.analysis import FitStatus, fitting
 from qubex.experiment.experiment_constants import (
     CALIBRATION_SHOTS,
@@ -575,4 +573,4 @@ def obtain_anharmonicity_with_cr(
         return result, anharmonicity
     else:
         raise RuntimeError("Failed to fit EF chevron pattern, cannot estimate resonance frequency and anharmonicity.")
-    
+

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -505,13 +505,10 @@ def _ef_rabi_experiment(
     return result
 
 
-def ef_chevron_pattern(
+def obtain_anharmonicity_with_cr(
     ex: qx.Experiment,
     target_qubit: str,
-    control_qubit: str,
-    cr_amplitude: float,
-    cr_duration: int,
-    cr_ramptime: float,
+    cr_x180: PulseSchedule,
     time_range: ArrayLike,
     ef_frequency: float | None = None,
     ef_amplitude: float | None = None,
@@ -530,10 +527,10 @@ def ef_chevron_pattern(
     ----------
     ex
         Experiment context used to run measurements and manage backend settings.
-    target_qubit, control_qubit
-        Qubit labels.
-    cr_amplitude, cr_duration, cr_ramptime
-        CR pi pulse parameters used to prepare the `e` state before EF drive.
+    target_qubit
+        Qubit label.
+    cr_x180
+        CR X180 pulse used to prepare the `e` state before EF drive.
     time_range
         Time sweep used for each Rabi experiment.
     ef_frequency, detuning_range
@@ -552,6 +549,8 @@ def ef_chevron_pattern(
         )
     if detuning_range is None:
         detuning_range = np.linspace(-0.01, 0.01, 21)
+    if plot is None:
+        plot = True
 
     rabi_data: list[RabiData] = []
     rabi_rates: list[float] = []
@@ -565,27 +564,23 @@ def ef_chevron_pattern(
                 ex.system_manager.modified_backend_settings(**backend_settings)
             )
 
-        # ex.obtain_rabi_params()
         for detuning in tqdm(detuning_range):
             with ex.modified_frequencies(
                 {
                     target_qubit: ef_frequency + detuning,
                 }
             ):
-                rabi_result = ef_rabi_experiment(
+                rabi_result = _ef_rabi_experiment(
                     ex=ex,
                     target_qubit=target_qubit,
-                    control_qubit=control_qubit,
-                    cr_amplitude=cr_amplitude,
-                    cr_duration=cr_duration,
-                    cr_ramptime=cr_ramptime,
+                    cr_x180=cr_x180,
                     time_range=time_range,
                     ef_amplitude=ef_amplitude,
                     ef_ramptime=ef_ramptime,
                     is_damped=is_damped,
                     n_shots=n_shots,
                     shot_interval=shot_interval,
-                    plot=plot,
+                    plot=False,
                     **deprecated_options,
                 )
 
@@ -603,16 +598,21 @@ def ef_chevron_pattern(
     detuning_range = np.asarray(detuning_range, dtype=np.float64)
     frequency_range = detuning_range + ef_frequency
 
-    data = {
-        target_qubit: FreqRabiData(
+    data = FreqRabiData(
             target=target_qubit,
             data=np.array(rabi_rates, dtype=np.float64),
             sweep_range=detuning_range,
             frequency_range=frequency_range,
             rabi_data=rabi_data,
         )
-    }
-    result = ExperimentResult(data=data)
-    if plot:
-        result.fit()
-    return result
+    result = ExperimentResult(data={target_qubit: data})
+    fit_result = data.fit(plot=plot)
+    if fit_result.status is FitStatus.SUCCESS:
+        ef_frequency = fit_result.data['f_resonance']
+        anharmonicity = ef_frequency - ex.qubits[target_qubit].frequency
+        print(f"Estimated EF resonance frequency: {ef_frequency:.6f} GHz")
+        print(f"Estimated anharmonicity: {anharmonicity:.6f} GHz")
+        return result, anharmonicity
+    else:
+        raise RuntimeError("Failed to fit EF chevron pattern, cannot estimate resonance frequency and anharmonicity.")
+    

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -366,13 +366,10 @@ def _calc_fnco_settings(
     return retune_needed, params
 
 
-def ef_rabi_experiment(
+def _ef_rabi_experiment(
     ex: qx.Experiment,
     target_qubit: str,
-    control_qubit: str,
-    cr_amplitude: float,
-    cr_duration: int,
-    cr_ramptime: float,
+    cr_x180: PulseSchedule,
     time_range: ArrayLike,
     ef_amplitude: float | None = None,
     ef_ramptime: float | None = None,
@@ -389,10 +386,10 @@ def ef_rabi_experiment(
     ----------
     ex
         Experiment context with measurement and pulse configuration.
-    target_qubit, control_qubit
-        Qubit labels for the experiment.
-    cr_amplitude, cr_duration, cr_ramptime
-        Parameters for the CR pi pulse used to prepare the `e` state.
+    target_qubit
+        Qubit label for the experiment.
+    cr_x180
+        CR X180 pulse used to prepare the `e` state before EF drive.
     time_range
         Durations swept for the EF drive.
     ef_amplitude, ef_ramptime
@@ -435,24 +432,10 @@ def ef_rabi_experiment(
     effective_time_range = time_range + ef_ramptime
     control_sampling_period = ex.measurement_service.ctx.measurement.sampling_period
 
-    def cr_pi_pulse() -> qx.PulseSchedule:
-        with qx.PulseSchedule() as ps:
-            ps.add(
-                control_qubit,
-                FlatTop(
-                    duration=cr_duration,
-                    amplitude=cr_amplitude,
-                    tau=cr_ramptime,
-                    type="RaisedCosine",
-                ),
-            )
-            ps.add(target_qubit, Blank(duration=cr_duration))
-        return ps
-
     # ef rabi sequence with rect pulses of duration T
     def ef_rabi_sequence(T: int) -> PulseSchedule:
         with PulseSchedule() as ps:
-            ps.call(cr_pi_pulse())
+            ps.call(cr_x180)
             ps.barrier()
             # apply the ef drive to induce the ef Rabi oscillation
             ps.add(

--- a/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
+++ b/src/qubex/contrib/experiment/ef_measurement_with_one_channel.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection
 from contextlib import ExitStack
 from typing import Any
 
@@ -39,10 +38,9 @@ def calibrate_cr_pi_pulse(
     ex: qx.Experiment,
     control_qubit: str,
     target_qubit: str,
-    duration_range: Collection[float],
-    amplitude_range: Collection[float] | None = None,
+    duration_range: ArrayLike,
+    amplitude_range: ArrayLike | None = None,
     ramptime: float | None = None,
-    n_points: int | None = None,
     n_rotations: int | None = None,
     n_iterations: int | None = None,
     ratio: float | None = None,
@@ -62,18 +60,15 @@ def calibrate_cr_pi_pulse(
         Label of the control qubit (CR drive channel source).
     target_qubit : str
         Label of the target qubit being driven by the CR pulse.
-    duration_range : Collection[float]
+    duration_range : ArrayLike
         Iterable of pulse durations (same units as device timing) to sweep
         when fitting the pi-pulse duration.
-    amplitude_range : Collection[float] or None, optional
+    amplitude_range : ArrayLike or None, optional
         Optional amplitude sweep range for amplitude calibration. If ``None``
         a default linear range is generated using ``n_points``.
     ramptime : float or None, optional
         Pulse ramp (tau) used when constructing shaped pulses. Defaults to
         ``PI_RAMPTIME`` if ``None``.
-    n_points : int or None, optional
-        Number of points used when generating an amplitude range if
-        ``amplitude_range`` is not provided. Defaults to 20.
     n_rotations, n_iterations : int or None, optional
         Control how many rotations and iterative calibration steps to perform.
     ratio : float or None, optional
@@ -93,11 +88,6 @@ def calibrate_cr_pi_pulse(
     tuple
         A tuple of (ExperimentResult[data], pulse_schedule).
     """
-    if n_points is None:
-        if amplitude_range is not None:
-            n_points = len(amplitude_range)
-        else:
-            n_points = 20
     if n_rotations is None:
         n_rotations = 1
     if n_iterations is None:
@@ -109,13 +99,15 @@ def calibrate_cr_pi_pulse(
     if ramptime is None:
         ramptime = PI_RAMPTIME
     if amplitude_range is None:
-        amplitude_range = np.linspace(0.5, 1, n_points)
+        amplitude_range = np.linspace(0.5, 1, 20)
     if plot is None:
         plot = True
     if shots is None:
         shots = CALIBRATION_SHOTS
     if interval is None:
         interval = DEFAULT_INTERVAL
+
+    amplitude_range = np.asarray(amplitude_range, dtype=np.float64)
 
     if target_qubit not in ex.ctx.calib_note.rabi_params:
         raise ValueError(f"Rabi parameters are not stored for {target_qubit}.")
@@ -143,8 +135,9 @@ def calibrate_cr_pi_pulse(
             ps.add(target_qubit, Blank(duration=duration))
         return ps
 
-    def calibrate_duration(duration_range: Collection[float]) -> float:
+    def calibrate_duration(duration_range: ArrayLike) -> float:
         n_per_rotation = 2
+        duration_range = np.asarray(duration_range, dtype=np.float64)
 
         sweep_data = ex.sweep_parameter(
             sequence=lambda sweep_duration: seq(duration=sweep_duration, amplitude=1.0),
@@ -172,9 +165,10 @@ def calibrate_cr_pi_pulse(
         return fit_result["amplitude"]
 
     def calibrate_amplitude(
-        amplitude_range: Collection[float], fixed_duration: float
+        amplitude_range: ArrayLike, fixed_duration: float
     ) -> AmplCalibData:
         n_per_rotation = 2
+        amplitude_range = np.asarray(amplitude_range, dtype=np.float64)
 
         sweep_data = ex.sweep_parameter(
             sequence=lambda amplitude: seq(
@@ -207,13 +201,13 @@ def calibrate_cr_pi_pulse(
             r2=r2,
         )
 
-    def _update_amplitude_range(center: float, ratio: float = 0.4) -> Collection[float]:
+    def _update_amplitude_range(center: float, ratio: float = 0.4) -> ArrayLike:
         if ratio <= 0 or ratio >= 1:
             raise ValueError("Ratio must be between 0 and 1.")
         new_range = np.linspace(
             np.max((0, center * (1 - ratio))),
             np.min((1, center * (1 + ratio))),
-            n_points,
+            len(amplitude_range),
         )
         return new_range
 
@@ -250,7 +244,7 @@ def _calc_fnco_settings(
     channel_label: str,
     drive_frequency: float,
     force_retune: bool = False,
-) -> tuple[bool, dict[str, float]]:
+) -> tuple[bool, dict]:
     """
     Return device settings kwargs when an FNCO retune is needed.
 
@@ -287,8 +281,13 @@ def _calc_fnco_settings(
     current_fnco = target.channel.fnco_freq
     current_cnco = target.channel.cnco_freq
 
-    current_diff_ghz = abs(drive_frequency - target.fine_frequency)
-    current_fnco_ok = abs(current_fnco) <= FNCO_MAX
+    if current_fnco is None:
+        raise ValueError(
+            f"Current FNCO frequency for channel {channel_label} is not available."
+        )
+
+    current_diff_ghz = np.abs(drive_frequency - target.fine_frequency)
+    current_fnco_ok = np.abs(current_fnco) <= FNCO_MAX
 
     if not force_retune and current_diff_ghz <= FINE_FREQ_TOL_GHZ and current_fnco_ok:
         retune_needed = False
@@ -308,7 +307,7 @@ def _calc_fnco_settings(
     )
 
     # Compare the desired FNCO magnitude with the FNCO limit (upper/lower bound)
-    diff = abs(new_fnco) - FNCO_MAX
+    diff = np.abs(new_fnco) - FNCO_MAX
     if diff > FINE_FREQ_TOL_GHZ * 1e9:
         # The required FNCO is outside the allowable range and cannot be compensated by the AWG
         raise RuntimeError(
@@ -376,7 +375,6 @@ def _ef_rabi_experiment(
     ExperimentResult
         Result object containing fitted `RabiData` and parameters.
     """
-    # TODO: Integrate with rabi_experiment
     if is_damped is None:
         is_damped = True
     if ef_amplitude is None:
@@ -532,6 +530,7 @@ def obtain_anharmonicity_with_cr(
     if plot is None:
         plot = True
 
+    detuning_range = np.asarray(detuning_range, dtype=np.float64)
     rabi_data: list[RabiData] = []
     rabi_rates: list[float] = []
 
@@ -565,6 +564,8 @@ def obtain_anharmonicity_with_cr(
                 )
 
             ef_label = ex.measurement_service.ctx.resolve_ef_label(target_qubit)
+            if rabi_result.rabi_params is None:
+                raise ValueError("Rabi parameters are not stored.")
             rabi_params = rabi_result.rabi_params.get(ef_label, None)
             rabi_datum = rabi_result.data.get(ef_label, None)
             if rabi_params is None:
@@ -588,7 +589,9 @@ def obtain_anharmonicity_with_cr(
     result = ExperimentResult(data={target_qubit: data})
     fit_result = data.fit(plot=plot)
     if fit_result.status is FitStatus.SUCCESS:
-        ef_frequency = fit_result.data["f_resonance"]
+        ef_frequency = fit_result.data.get("resonance_frequency", None)
+        if ef_frequency is None:
+            raise ValueError("Resonance frequency is not available in fit result.")
         anharmonicity = ef_frequency - ex.qubits[target_qubit].frequency
         print(f"Estimated EF resonance frequency: {ef_frequency:.6f} GHz")
         print(f"Estimated anharmonicity: {anharmonicity:.6f} GHz")

--- a/tests/contrib/ef_measurement_with_one_channel/test_function_api.py
+++ b/tests/contrib/ef_measurement_with_one_channel/test_function_api.py
@@ -9,7 +9,9 @@ from qubex.contrib import (
 )
 
 
-def test_all_ef_measurement_with_one_channel_functions_are_exported_from_contrib() -> None:
+def test_all_ef_measurement_with_one_channel_functions_are_exported_from_contrib() -> (
+    None
+):
     """Given contrib package, when imported, then EF measurement helpers are available."""
     assert callable(calibrate_cr_pi_pulse)
     assert callable(ef_rabi_experiment)

--- a/tests/contrib/ef_measurement_with_one_channel/test_function_api.py
+++ b/tests/contrib/ef_measurement_with_one_channel/test_function_api.py
@@ -4,8 +4,7 @@ from __future__ import annotations
 
 from qubex.contrib import (
     calibrate_cr_pi_pulse,
-    ef_chevron_pattern,
-    ef_rabi_experiment,
+    obtain_anharmonicity_with_cr,
 )
 
 
@@ -14,5 +13,4 @@ def test_all_ef_measurement_with_one_channel_functions_are_exported_from_contrib
 ):
     """Given contrib package, when imported, then EF measurement helpers are available."""
     assert callable(calibrate_cr_pi_pulse)
-    assert callable(ef_rabi_experiment)
-    assert callable(ef_chevron_pattern)
+    assert callable(obtain_anharmonicity_with_cr)

--- a/tests/contrib/ef_measurement_with_one_channel/test_function_api.py
+++ b/tests/contrib/ef_measurement_with_one_channel/test_function_api.py
@@ -1,0 +1,16 @@
+"""Tests for functional APIs in `qubex.contrib.experiment.ef_measurement_with_one_channel`."""
+
+from __future__ import annotations
+
+from qubex.contrib import (
+    calibrate_cr_pi_pulse,
+    ef_chevron_pattern,
+    ef_rabi_experiment,
+)
+
+
+def test_all_ef_measurement_with_one_channel_functions_are_exported_from_contrib() -> None:
+    """Given contrib package, when imported, then EF measurement helpers are available."""
+    assert callable(calibrate_cr_pi_pulse)
+    assert callable(ef_rabi_experiment)
+    assert callable(ef_chevron_pattern)


### PR DESCRIPTION
## Background

Add experimental ef measurement helpers as contrib APIs for one-channel EF workflows.

## Summary

- Add `ef_measurement_with_one_channel` contrib experiment module.
- Export EF measurement helpers from `qubex.contrib` and `qubex.contrib.experiment`.
- Add contrib function API tests for exported helpers.

## User-facing/API impact

New contrib APIs are available from `qubex.contrib`:

- `calibrate_cr_pi_pulse_fixed_duration`
- `ef_rabi_experiment`
- `ef_chevron_pattern`

## Risks and compatibility notes

- This is added under `contrib`, so the API is experimental and may evolve.
- No existing public API is changed.

## Validation

- uv run ruff check: All checks passed!
- uv run ruff format: 473 files already formatted
