### PR TITLE
fix: preserve PulseSchedule structure in legacy sweeps

### DIFF
--- a/src/qubex/experiment/services/measurement_service.py
+++ b/src/qubex/experiment/services/measurement_service.py
@@ -156,6 +156,49 @@ class MeasurementService:
             ]
         )
 
+    @staticmethod
+    def _schedule_from_waveform_map(
+        sequence: TargetMap[IQArray] | TargetMap[Waveform],
+    ) -> PulseSchedule:
+        """Return a schedule that preserves waveform objects in a target map."""
+        with PulseSchedule(list(sequence)) as schedule:
+            for target, waveform in sequence.items():
+                if isinstance(waveform, Waveform):
+                    schedule.add(target, waveform)
+                else:
+                    schedule.add(target, Arbitrary(waveform))
+        return schedule
+
+    @staticmethod
+    def _sampled_waveform_map(
+        sequence: TargetMap[IQArray] | TargetMap[Waveform],
+    ) -> dict[str, NDArray[np.complex128]]:
+        """Return sampled arrays for dense waveform-map inputs."""
+        waveforms: dict[str, NDArray[np.complex128]] = {}
+        for target, waveform in sequence.items():
+            if isinstance(waveform, Waveform):
+                waveforms[target] = waveform.values
+            else:
+                waveforms[target] = np.array(waveform, dtype=np.complex128)
+        return waveforms
+
+    def _prepend_initial_states(
+        self,
+        *,
+        schedule: PulseSchedule,
+        initial_states: dict[str, str],
+    ) -> PulseSchedule:
+        """Return a schedule with initial-state pulses prepended."""
+        labels = self.unique_in_order([*schedule.labels, *initial_states.keys()])
+        with PulseSchedule(labels) as prepared:
+            for target, state in initial_states.items():
+                if target not in self.ctx.qubit_labels:
+                    raise ValueError(f"Invalid init target: {target}")
+                prepared.add(target, self.pulse.get_pulse_for_state(target, state))
+            prepared.barrier()
+            prepared.call(schedule)
+        return prepared
+
     def _resolve_measurement_schedule(
         self,
         *,
@@ -790,58 +833,37 @@ class MeasurementService:
         if plot is None:
             plot = False
 
-        waveforms: dict[str, NDArray[np.complex128]] = {}
-
         if isinstance(sequence, PulseSchedule):
             if not sequence.is_valid():
                 raise ValueError("Invalid pulse schedule.")
 
             if initial_states is not None:
-                labels = self.unique_in_order(
-                    [*sequence.labels, *initial_states.keys()]
+                measurement_input: PulseSchedule | dict[str, NDArray[np.complex128]] = (
+                    self._prepend_initial_states(
+                        schedule=sequence,
+                        initial_states=initial_states,
+                    )
                 )
-                with PulseSchedule(labels) as ps:
-                    for target, state in initial_states.items():
-                        if target in self.ctx.qubit_labels:
-                            ps.add(
-                                target, self.pulse.get_pulse_for_state(target, state)
-                            )
-                        else:
-                            raise ValueError(f"Invalid init target: {target}")
-                    ps.barrier()
-                    ps.call(sequence)
-                waveforms = ps.get_sampled_sequences()
             else:
-                waveforms = sequence.get_sampled_sequences()
+                measurement_input = sequence
         else:
             if initial_states is not None:
-                labels = self.unique_in_order(
-                    [*sequence.keys(), *initial_states.keys()]
+                measurement_input = self._prepend_initial_states(
+                    schedule=self._schedule_from_waveform_map(sequence),
+                    initial_states=initial_states,
                 )
-                with PulseSchedule(labels) as ps:
-                    for target, state in initial_states.items():
-                        if target in self.ctx.qubit_labels:
-                            ps.add(
-                                target, self.pulse.get_pulse_for_state(target, state)
-                            )
-                        else:
-                            raise ValueError(f"Invalid init target: {target}")
-                    ps.barrier()
-                    for target, waveform in sequence.items():
-                        if isinstance(waveform, Waveform):
-                            ps.add(target, waveform)
-                        else:
-                            ps.add(target, Arbitrary(waveform))
-                waveforms = ps.get_sampled_sequences()
+            elif any(isinstance(waveform, Waveform) for waveform in sequence.values()):
+                measurement_input = self._schedule_from_waveform_map(sequence)
             else:
-                for target, waveform in sequence.items():
-                    if isinstance(waveform, Waveform):
-                        waveforms[target] = waveform.values
-                    else:
-                        waveforms[target] = np.array(waveform, dtype=np.complex128)
+                measurement_input = self._sampled_waveform_map(sequence)
 
         if reset_awg_and_capunits:
-            qubits = {self.ctx.resolve_qubit_label(target) for target in waveforms}
+            labels = (
+                measurement_input.labels
+                if isinstance(measurement_input, PulseSchedule)
+                else measurement_input.keys()
+            )
+            qubits = {self.ctx.resolve_qubit_label(target) for target in labels}
             self.ctx.reset_awg_and_capunits(qubits=qubits)
 
         readout_duration, readout_pre_margin, readout_post_margin = (
@@ -853,7 +875,7 @@ class MeasurementService:
         )
         with self.ctx.modified_frequencies(frequencies):
             result = self.ctx.measurement.measure(
-                waveforms=waveforms,
+                waveforms=measurement_input,
                 n_shots=n_shots,
                 shot_interval=shot_interval,
                 time_integration=time_integration,
@@ -1110,18 +1132,18 @@ class MeasurementService:
             initial_sequence = sequence(sweep_range[0])
             if isinstance(initial_sequence, PulseSchedule):
                 sequences = [
-                    sequence(param)
-                    .repeated(repetitions)  # type: ignore
-                    .get_sampled_sequences()
+                    sequence(param).repeated(repetitions)  # type: ignore[union-attr]
                     for param in sweep_range
                 ]
                 ordered_qubits = self.ctx.ordered_qubit_labels(initial_sequence.labels)
             elif isinstance(initial_sequence, dict):
                 sequences = [
-                    {
-                        target: waveform.repeated(repetitions).values
-                        for target, waveform in sequence(param).items()  # type: ignore
-                    }
+                    self._schedule_from_waveform_map(
+                        {
+                            target: waveform.repeated(repetitions)
+                            for target, waveform in sequence(param).items()  # type: ignore[union-attr]
+                        }
+                    )
                     for param in sweep_range
                 ]
                 ordered_qubits = self.ctx.ordered_qubit_labels(list(initial_sequence))

--- a/src/qubex/measurement/measurement.py
+++ b/src/qubex/measurement/measurement.py
@@ -804,7 +804,7 @@ class Measurement:
 
     def measure(
         self,
-        waveforms: Mapping[str, IQArray],
+        waveforms: PulseSchedule | Mapping[str, IQArray],
         *,
         n_shots: int | None = None,
         shot_interval: float | None = None,
@@ -826,13 +826,13 @@ class Measurement:
         **deprecated_options: Any,
     ) -> MeasureResult:
         """
-        Execute one measurement from target waveform mappings.
+        Execute one measurement from a pulse schedule or target waveform mapping.
 
         Parameters
         ----------
-        waveforms : Mapping[str, IQArray]
-            Control waveforms keyed by target label. Each waveform is a complex
-            I/Q array sampled at `sampling_period` ns.
+        waveforms : PulseSchedule | Mapping[str, IQArray]
+            Pulse schedule or control waveforms keyed by target label. Mapping
+            values are complex I/Q arrays sampled at `sampling_period` ns.
         n_shots : int | None, optional
             Number of shots.
         shot_interval : float | None, optional

--- a/src/qubex/measurement/services/measurement_execution_service.py
+++ b/src/qubex/measurement/services/measurement_execution_service.py
@@ -841,7 +841,7 @@ class MeasurementExecutionService:
 
     def measure(
         self,
-        waveforms: Mapping[str, IQArray],
+        waveforms: PulseSchedule | Mapping[str, IQArray],
         *,
         n_shots: int | None = None,
         shot_interval: float | None = None,
@@ -863,12 +863,12 @@ class MeasurementExecutionService:
         **deprecated_options: Any,
     ) -> MeasureResult:
         """
-        Measure with the given control waveforms.
+        Measure with the given pulse schedule or control waveforms.
 
         Parameters
         ----------
-        waveforms : Mapping[str, IQArray]
-            Control waveforms for each target.
+        waveforms : PulseSchedule | Mapping[str, IQArray]
+            Pulse schedule or control waveforms for each target.
 
         n_shots : int | None, optional
             Number of shots.

--- a/tests/experiment/test_measurement_service_registry_resolution.py
+++ b/tests/experiment/test_measurement_service_registry_resolution.py
@@ -20,8 +20,16 @@ from qubex.measurement.models import (
 
 
 class _DummyResult:
+    data: dict[str, Any]
+
     def plot(self) -> None:
         return None
+
+
+class _NoSamplingPulseSchedule(PulseSchedule):
+    def get_sampled_sequences(self, *args: object, **kwargs: object) -> object:
+        """PulseSchedule should not be sampled in preservation tests."""
+        raise AssertionError("PulseSchedule must not be sampled.")
 
 
 def _make_measurement_result(target: str = "custom-target") -> MeasurementResult:
@@ -106,11 +114,16 @@ def _make_service() -> tuple[MeasurementService, dict[str, object]]:
         reset_awg_and_capunits=lambda *, qubits: reset_calls.append(set(qubits)),
         modified_frequencies=_modified_frequencies,
         qubit_labels=["Q17"],
+        state_centers={},
     )
     pulse_service = SimpleNamespace(
         readout_duration=1024.0,
         readout_pre_margin=8.0,
         readout_post_margin=16.0,
+        ge_rabi_params={},
+        ef_rabi_params={},
+        rabi_params={},
+        get_pulse_for_state=lambda _target, _state: Blank(0),
     )
 
     service = cast(Any, object.__new__(MeasurementService))
@@ -255,6 +268,66 @@ def test_measure_uses_experiment_readout_timing_defaults() -> None:
     assert measure_calls[0]["readout_duration"] == 1024.0
     assert measure_calls[0]["readout_pre_margin"] == 8.0
     assert measure_calls[0]["readout_post_margin"] == 16.0
+
+
+def test_measure_delegates_pulse_schedule_without_sampling() -> None:
+    """Given PulseSchedule input, when measuring, then schedule structure is delegated unchanged."""
+    service, captured = _make_service()
+    schedule = _NoSamplingPulseSchedule(["custom-target"])
+    schedule.add("custom-target", Blank(16))
+    schedule.barrier()
+
+    service.measure(sequence=schedule, plot=False)
+
+    measure_calls = cast(list[dict[str, object]], captured["measure_calls"])
+    assert measure_calls[0]["waveforms"] is schedule
+
+
+def test_measure_composes_initial_states_without_sampling() -> None:
+    """Given initial states, when measuring a schedule, then composed schedule is delegated."""
+    service, captured = _make_service()
+    schedule = _NoSamplingPulseSchedule(["Q17"])
+    schedule.add("Q17", Blank(16))
+    schedule.barrier()
+
+    service.measure(sequence=schedule, initial_states={"Q17": "0"}, plot=False)
+
+    measure_calls = cast(list[dict[str, object]], captured["measure_calls"])
+    delegated = measure_calls[0]["waveforms"]
+    assert isinstance(delegated, PulseSchedule)
+    assert delegated is not schedule
+    assert delegated.get_blank_ranges(["Q17"])["Q17"]
+
+
+def test_sweep_parameter_delegates_pulse_schedules_without_sampling() -> None:
+    """Given parametric schedules, when sweeping, then each point is measured as a schedule."""
+    service, captured = _make_service()
+    schedules: list[PulseSchedule] = []
+    measure_calls = cast(list[dict[str, object]], captured["measure_calls"])
+
+    def _sequence(value: float) -> PulseSchedule:
+        schedule = _NoSamplingPulseSchedule(["Q17"])
+        schedule.add("Q17", Blank(value))
+        schedule.barrier()
+        schedules.append(schedule)
+        return schedule
+
+    def _measure(sequence: object, **kwargs: object) -> _DummyResult:
+        measure_calls.append({"sequence": sequence, **kwargs})
+        result = _DummyResult()
+        result.data = {"Q17": SimpleNamespace(kerneled=1.0 + 0.0j)}
+        return result
+
+    service.__dict__["measure"] = _measure
+
+    result = service.sweep_parameter(
+        sequence=_sequence,
+        sweep_range=[16.0, 32.0],
+        plot=False,
+    )
+
+    assert [call["sequence"] for call in measure_calls] == schedules[1:]
+    assert result.data["Q17"].data.tolist() == [1.0 + 0.0j, 1.0 + 0.0j]
 
 
 def test_check_waveform_resolves_read_labels_via_target_registry() -> None:


### PR DESCRIPTION
## Background

Legacy `sweep_parameter` and `MeasurementService.measure()` sampled `PulseSchedule` inputs into dense waveform maps before execution. That erased `Blank` segments, so QuEL-3 could no longer preserve idle timing as structured blank regions.

## Summary

- Preserve structured `PulseSchedule` inputs through legacy `measure()` and `sweep_parameter()` paths.
- Compose initial states and sweep repetitions as schedule operations when the input is a `PulseSchedule`.
- Keep the existing dense waveform-map path for raw array inputs.
- Update measurement service type hints and add regression tests that fail if these legacy paths call `get_sampled_sequences()` on schedules.

## Impact

This keeps QuEL-3 blank timing information intact while avoiding QuEL-1 / QuEL-3-specific branching in the legacy measurement API. Existing dense waveform-map behavior is preserved.

## Validation

- `uv run pytest tests/experiment/test_measurement_service_registry_resolution.py -q`
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`
- `git diff --check`
- `git merge-tree --write-tree upstream/develop HEAD`
