### PR TITLE
fix: tolerate qxpulse float sampling grid rounding

### DIFF
--- a/packages/qxpulse/src/qxpulse/library/cpmg.py
+++ b/packages/qxpulse/src/qxpulse/library/cpmg.py
@@ -6,7 +6,7 @@ from typing import Final
 
 from qxpulse.blank import Blank
 from qxpulse.pulse_array import PulseArray
-from qxpulse.waveform import Waveform, _is_sampling_period_multiple
+from qxpulse.waveform import Waveform, is_sampling_period_multiple
 
 
 class CPMG(PulseArray):
@@ -53,7 +53,7 @@ class CPMG(PulseArray):
         self.n: Final = n
         self.alternating: Final = alternating
 
-        if not _is_sampling_period_multiple(tau, self.SAMPLING_PERIOD):
+        if not is_sampling_period_multiple(tau, self.SAMPLING_PERIOD):
             raise ValueError(
                 f"Tau must be a multiple of the sampling period ({self.SAMPLING_PERIOD} ns)."
             )

--- a/packages/qxpulse/src/qxpulse/library/cpmg.py
+++ b/packages/qxpulse/src/qxpulse/library/cpmg.py
@@ -6,7 +6,7 @@ from typing import Final
 
 from qxpulse.blank import Blank
 from qxpulse.pulse_array import PulseArray
-from qxpulse.waveform import Waveform
+from qxpulse.waveform import Waveform, _is_sampling_period_multiple
 
 
 class CPMG(PulseArray):
@@ -53,7 +53,7 @@ class CPMG(PulseArray):
         self.n: Final = n
         self.alternating: Final = alternating
 
-        if tau % self.SAMPLING_PERIOD != 0:
+        if not _is_sampling_period_multiple(tau, self.SAMPLING_PERIOD):
             raise ValueError(
                 f"Tau must be a multiple of the sampling period ({self.SAMPLING_PERIOD} ns)."
             )

--- a/packages/qxpulse/src/qxpulse/library/flat_top.py
+++ b/packages/qxpulse/src/qxpulse/library/flat_top.py
@@ -9,6 +9,7 @@ from numpy.typing import ArrayLike, NDArray
 from typing_extensions import override
 
 from qxpulse.pulse import Pulse
+from qxpulse.waveform import _floor_to_sampling_period
 
 from .bump import Bump
 from .gaussian import Gaussian
@@ -265,7 +266,10 @@ def _ramp_func(
             t=t,
             duration=duration,
             amplitude=amplitude,
-            tau=(duration * 0.5) // Pulse.SAMPLING_PERIOD * Pulse.SAMPLING_PERIOD,
+            tau=_floor_to_sampling_period(
+                duration * 0.5,
+                Pulse.SAMPLING_PERIOD,
+            ),
             delta=delta,
             factor=0,
             **kwargs,

--- a/packages/qxpulse/src/qxpulse/library/flat_top.py
+++ b/packages/qxpulse/src/qxpulse/library/flat_top.py
@@ -9,7 +9,7 @@ from numpy.typing import ArrayLike, NDArray
 from typing_extensions import override
 
 from qxpulse.pulse import Pulse
-from qxpulse.waveform import _floor_to_sampling_period
+from qxpulse.waveform import floor_to_sampling_period
 
 from .bump import Bump
 from .gaussian import Gaussian
@@ -266,7 +266,7 @@ def _ramp_func(
             t=t,
             duration=duration,
             amplitude=amplitude,
-            tau=_floor_to_sampling_period(
+            tau=floor_to_sampling_period(
                 duration * 0.5,
                 Pulse.SAMPLING_PERIOD,
             ),

--- a/packages/qxpulse/src/qxpulse/library/sintegral.py
+++ b/packages/qxpulse/src/qxpulse/library/sintegral.py
@@ -9,6 +9,7 @@ from numpy.typing import ArrayLike, NDArray
 from typing_extensions import override
 
 from qxpulse.pulse import Pulse
+from qxpulse.waveform import _floor_to_sampling_period
 
 
 class Sintegral(Pulse):
@@ -123,7 +124,10 @@ class Sintegral(Pulse):
             np.where(
                 (
                     t
-                    <= (duration * 0.5) // Pulse.SAMPLING_PERIOD * Pulse.SAMPLING_PERIOD
+                    <= _floor_to_sampling_period(
+                        duration * 0.5,
+                        Pulse.SAMPLING_PERIOD,
+                    )
                 ),
                 values,
                 values if is_odd else 2 * amplitude - values,
@@ -354,7 +358,10 @@ class MultiDerivativeSintegral(Pulse):
             np.where(
                 (
                     t
-                    <= (duration * 0.5) // Pulse.SAMPLING_PERIOD * Pulse.SAMPLING_PERIOD
+                    <= _floor_to_sampling_period(
+                        duration * 0.5,
+                        Pulse.SAMPLING_PERIOD,
+                    )
                 ),
                 values,
                 values if is_odd else 2 * amplitude - values,

--- a/packages/qxpulse/src/qxpulse/library/sintegral.py
+++ b/packages/qxpulse/src/qxpulse/library/sintegral.py
@@ -9,7 +9,7 @@ from numpy.typing import ArrayLike, NDArray
 from typing_extensions import override
 
 from qxpulse.pulse import Pulse
-from qxpulse.waveform import _floor_to_sampling_period
+from qxpulse.waveform import floor_to_sampling_period
 
 
 class Sintegral(Pulse):
@@ -124,7 +124,7 @@ class Sintegral(Pulse):
             np.where(
                 (
                     t
-                    <= _floor_to_sampling_period(
+                    <= floor_to_sampling_period(
                         duration * 0.5,
                         Pulse.SAMPLING_PERIOD,
                     )
@@ -358,7 +358,7 @@ class MultiDerivativeSintegral(Pulse):
             np.where(
                 (
                     t
-                    <= _floor_to_sampling_period(
+                    <= floor_to_sampling_period(
                         duration * 0.5,
                         Pulse.SAMPLING_PERIOD,
                     )

--- a/packages/qxpulse/src/qxpulse/library/xy4.py
+++ b/packages/qxpulse/src/qxpulse/library/xy4.py
@@ -6,7 +6,7 @@ from typing import Final
 
 from qxpulse.blank import Blank
 from qxpulse.pulse_array import PulseArray
-from qxpulse.waveform import Waveform
+from qxpulse.waveform import Waveform, _is_sampling_period_multiple
 
 
 class XY4(PulseArray):
@@ -57,7 +57,7 @@ class XY4(PulseArray):
         self.pi_y: Final = pi_y
         self.n: Final = n
 
-        if tau % self.SAMPLING_PERIOD != 0:
+        if not _is_sampling_period_multiple(tau, self.SAMPLING_PERIOD):
             raise ValueError(
                 f"Tau must be a multiple of the sampling period ({self.SAMPLING_PERIOD} ns)."
             )

--- a/packages/qxpulse/src/qxpulse/library/xy4.py
+++ b/packages/qxpulse/src/qxpulse/library/xy4.py
@@ -6,7 +6,7 @@ from typing import Final
 
 from qxpulse.blank import Blank
 from qxpulse.pulse_array import PulseArray
-from qxpulse.waveform import Waveform, _is_sampling_period_multiple
+from qxpulse.waveform import Waveform, is_sampling_period_multiple
 
 
 class XY4(PulseArray):
@@ -57,7 +57,7 @@ class XY4(PulseArray):
         self.pi_y: Final = pi_y
         self.n: Final = n
 
-        if not _is_sampling_period_multiple(tau, self.SAMPLING_PERIOD):
+        if not is_sampling_period_multiple(tau, self.SAMPLING_PERIOD):
             raise ValueError(
                 f"Tau must be a multiple of the sampling period ({self.SAMPLING_PERIOD} ns)."
             )

--- a/packages/qxpulse/src/qxpulse/waveform.py
+++ b/packages/qxpulse/src/qxpulse/waveform.py
@@ -35,7 +35,7 @@ def _nearest_sampling_period_sample_count(
     return None
 
 
-def _is_sampling_period_multiple(
+def is_sampling_period_multiple(
     duration: float,
     sampling_period: float,
     *,
@@ -52,7 +52,7 @@ def _is_sampling_period_multiple(
     )
 
 
-def _floor_to_sampling_period(
+def floor_to_sampling_period(
     duration: float,
     sampling_period: float,
     *,

--- a/packages/qxpulse/src/qxpulse/waveform.py
+++ b/packages/qxpulse/src/qxpulse/waveform.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from abc import ABC, abstractmethod
 from functools import cached_property
 from typing import Literal, cast
@@ -17,6 +18,51 @@ logger = logging.getLogger(__name__)
 
 # Default sampling period in ns
 DEFAULT_SAMPLING_PERIOD = 2.0
+SAMPLING_PERIOD_TOLERANCE = 1e-9
+
+
+def _nearest_sampling_period_sample_count(
+    duration: float,
+    sampling_period: float,
+    *,
+    tolerance: float = SAMPLING_PERIOD_TOLERANCE,
+) -> int | None:
+    """Return the nearest sample count when `duration` is on the sampling grid."""
+    samples = duration / sampling_period
+    sample_count = round(samples)
+    if abs(samples - sample_count) <= tolerance:
+        return sample_count
+    return None
+
+
+def _is_sampling_period_multiple(
+    duration: float,
+    sampling_period: float,
+    *,
+    tolerance: float = SAMPLING_PERIOD_TOLERANCE,
+) -> bool:
+    """Return whether `duration` is an integer multiple of the sampling period."""
+    return (
+        _nearest_sampling_period_sample_count(
+            duration,
+            sampling_period,
+            tolerance=tolerance,
+        )
+        is not None
+    )
+
+
+def _floor_to_sampling_period(
+    duration: float,
+    sampling_period: float,
+    *,
+    tolerance: float = SAMPLING_PERIOD_TOLERANCE,
+) -> float:
+    """Return `duration` floored to the sampling grid."""
+    sample_count = math.floor(duration / sampling_period + tolerance)
+    # Multiplication can round slightly above `duration` (for example 3 * 0.1),
+    # so clamp the snapped value to keep the floor contract.
+    return min(sample_count * sampling_period, duration)
 
 
 class Waveform(ABC):
@@ -180,11 +226,8 @@ class Waveform(ABC):
         if duration < 0:
             raise ValueError("Duration must be positive.")
 
-        # Tolerance for floating point comparison
-        tolerance = 1e-9
-        frac = duration / dt
-        N = round(frac)
-        if abs(frac - N) > tolerance:
+        N = _nearest_sampling_period_sample_count(duration, dt)
+        if N is None:
             raise ValueError(
                 f"Duration must be a multiple of the sampling period ({dt} ns)."
             )

--- a/tests/pulse/test_cpmg.py
+++ b/tests/pulse/test_cpmg.py
@@ -1,0 +1,32 @@
+"""Tests for the CPMG dynamical decoupling sequence."""
+
+import pytest
+from qxpulse.blank import Blank
+from qxpulse.library.cpmg import CPMG
+from qxpulse.pulse import Pulse
+from qxpulse.waveform import Waveform
+
+
+def test_cpmg_requires_multiple_of_sampling_period():
+    """Given tau not divisible by the sampling period, then CPMG rejects the value."""
+    with pytest.raises(
+        ValueError,
+        match=r"Tau must be a multiple of the sampling period",
+    ):
+        CPMG(
+            tau=Pulse.SAMPLING_PERIOD + 1,
+            pi=Blank(duration=Pulse.SAMPLING_PERIOD),
+        )
+
+
+def test_cpmg_accepts_float_multiple_of_sampling_period(monkeypatch):
+    """Given a float multiple of dt, then CPMG accepts tau despite float remainder noise."""
+    monkeypatch.setattr(Waveform, "SAMPLING_PERIOD", 0.4)
+
+    cpmg = CPMG(
+        tau=1.2,
+        pi=Blank(duration=0.4),
+    )
+
+    # Default n=2 creates two (tau, pi, tau) blocks: 2 * (3 + 1 + 3) samples.
+    assert cpmg.length == 14

--- a/tests/pulse/test_flat_top.py
+++ b/tests/pulse/test_flat_top.py
@@ -2,6 +2,7 @@
 
 import pytest
 from qxpulse import FlatTop, Pulse
+from qxpulse.waveform import Waveform
 
 import qubex as qx
 
@@ -75,6 +76,22 @@ def test_shape_kwargs_do_not_leak_pulse_init_parameters(monkeypatch):
     assert captured["window"] == "hann"
     assert "sampling_period" not in captured
     assert "lazy" not in captured
+
+
+def test_squad_ramp_snaps_half_duration_to_float_sampling_grid(monkeypatch):
+    """Given a float dt grid, then Squad ramps keep near-grid half durations stable."""
+    monkeypatch.setattr(Waveform, "SAMPLING_PERIOD", 0.4)
+
+    values = FlatTop.func(
+        [1.0],
+        duration=4.0,
+        amplitude=1.0,
+        tau=1.2,
+        delta=0.4,
+        type="Squad",
+    )
+
+    assert 0.0 < values[0].real < 1.0
 
 
 def test_cd_correction_without_beta_returns_complex_values():

--- a/tests/pulse/test_sintegral.py
+++ b/tests/pulse/test_sintegral.py
@@ -12,6 +12,7 @@ from qxpulse.library.sintegral import (
     sin_pow_integral,
 )
 from qxpulse.pulse import Pulse
+from qxpulse.waveform import Waveform
 
 
 def test_sin_pow_integral_derivative_matches():
@@ -80,6 +81,15 @@ def test_sintegral_func_requires_positive_duration():
     """Given a zero duration, then Sintegral.func raises ValueError."""
     with pytest.raises(ValueError, match=r"Duration cannot be zero\."):
         Sintegral.func([0.0], duration=0, amplitude=1.0, power=2)
+
+
+def test_sintegral_func_snaps_half_threshold_to_float_sampling_grid(monkeypatch):
+    """Given a float dt grid, then Sintegral keeps near-grid midpoints stable."""
+    monkeypatch.setattr(Waveform, "SAMPLING_PERIOD", 0.4)
+
+    values = Sintegral.func([1.0], duration=2.4, amplitude=1.0, power=2)
+
+    assert 0.0 < values[0].real < 1.0
 
 
 def test_multiderivative_sintegral_even_odd_contributions():

--- a/tests/pulse/test_xy4.py
+++ b/tests/pulse/test_xy4.py
@@ -4,6 +4,7 @@ import pytest
 from qxpulse.blank import Blank
 from qxpulse.library.xy4 import XY4
 from qxpulse.pulse import Pulse
+from qxpulse.waveform import Waveform
 
 
 def test_xy4_requires_multiple_of_sampling_period():
@@ -17,6 +18,20 @@ def test_xy4_requires_multiple_of_sampling_period():
             pi_x=Blank(duration=Pulse.SAMPLING_PERIOD),
             pi_y=Blank(duration=Pulse.SAMPLING_PERIOD),
         )
+
+
+def test_xy4_accepts_float_multiple_of_sampling_period(monkeypatch):
+    """Given a float multiple of dt, then XY4 accepts tau despite float remainder noise."""
+    monkeypatch.setattr(Waveform, "SAMPLING_PERIOD", 0.4)
+
+    xy4 = XY4(
+        tau=1.2,
+        pi_x=Blank(duration=0.4),
+        pi_y=Blank(duration=0.4),
+    )
+
+    # One XY4 cycle creates eight tau blanks and four pi pulses: 8 * 3 + 4 samples.
+    assert xy4.length == 28
 
 
 def test_xy4_requires_positive_cycle_count():


### PR DESCRIPTION
## Background

qxpulse validates pulse timings against the sampling period, but some call sites used direct float modulo or floor division. QuEL-3 control waveforms use a 0.4 ns grid, and 1.2 ns is mathematically three ticks while Python float arithmetic can still produce a non-zero remainder or one-sample floor drift.

## Summary

- Added shared sampling-grid helpers with the same tolerance model used by waveform sample counting.
- Replaced direct float modulo checks in CPMG and XY4 tau validation.
- Replaced direct float floor-division grid snapping in Sintegral and Squad-based FlatTop ramp setup.
- Added regression tests for 1.2 ns timings on a 0.4 ns QuEL-3-style sampling grid.

## Impact

This preserves the existing public contract: durations and tau values must still be multiples of the sampling period. The change only prevents binary floating-point representation noise from rejecting valid values or shifting sampling-grid boundaries.

## Compatibility

No API signatures or import paths changed. No migration is required.

## Validation

- uv run --package qxpulse pytest tests/pulse/test_cpmg.py tests/pulse/test_xy4.py tests/pulse/test_sintegral.py tests/pulse/test_flat_top.py
- uv run ruff check --fix
- uv run ruff format
- uv run pyright
- uv run pytest

All validation passed locally, including 1001 pytest tests.