### PR TITLE
Send QuEL-3 instrument frequency directives

### DIFF
--- a/src/qubex/backend/quel3/interfaces/__init__.py
+++ b/src/qubex/backend/quel3/interfaces/__init__.py
@@ -16,6 +16,7 @@ from qubex.backend.quel3.interfaces.directives import (
     CaptureModeValue,
     DirectiveProtocol,
     SetCaptureModeFactory,
+    SetFrequencyFactory,
 )
 from qubex.backend.quel3.interfaces.driver import (
     InstrumentConfigProtocol,
@@ -50,4 +51,5 @@ __all__ = [
     "SequencerProtocol",
     "SessionProtocol",
     "SetCaptureModeFactory",
+    "SetFrequencyFactory",
 ]

--- a/src/qubex/backend/quel3/interfaces/directives.py
+++ b/src/qubex/backend/quel3/interfaces/directives.py
@@ -36,3 +36,11 @@ class SetCaptureModeFactory(Protocol):
     def __call__(self, *, mode: CaptureModeValue) -> DirectiveProtocol:
         """Create one capture-mode directive."""
         ...
+
+
+class SetFrequencyFactory(Protocol):
+    """Factory protocol for `SetFrequency` directives."""
+
+    def __call__(self, *, hz: float) -> DirectiveProtocol:
+        """Create one frequency directive."""
+        ...

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -32,6 +32,7 @@ from qubex.backend.quel3.interfaces import (
     SequencerProtocol,
     SessionProtocol,
     SetCaptureModeFactory,
+    SetFrequencyFactory,
 )
 from qubex.backend.quel3.managers.session_manager import Quel3SessionManager
 from qubex.backend.quel3.models import (
@@ -184,6 +185,7 @@ class Quel3ExecutionManager:
                 sequencer_factory,
                 create_instrument_driver_fixed_timeline,
                 capture_mode_enum,
+                set_frequency_factory,
                 set_capture_mode_factory,
             ) = self._load_quelware_api()
         except (ModuleNotFoundError, SyntaxError) as exc:
@@ -206,6 +208,7 @@ class Quel3ExecutionManager:
                     runtime=runtime,
                     sequencer_factory=sequencer_factory,
                     capture_mode_enum=capture_mode_enum,
+                    set_frequency_factory=set_frequency_factory,
                     set_capture_mode_factory=set_capture_mode_factory,
                     parallel=parallel,
                 )
@@ -228,6 +231,7 @@ class Quel3ExecutionManager:
                         runtime=runtime,
                         sequencer_factory=sequencer_factory,
                         capture_mode_enum=capture_mode_enum,
+                        set_frequency_factory=set_frequency_factory,
                         set_capture_mode_factory=set_capture_mode_factory,
                         parallel=parallel,
                     )
@@ -276,6 +280,7 @@ class Quel3ExecutionManager:
                 sequencer_factory,
                 create_instrument_driver_fixed_timeline,
                 capture_mode_enum,
+                set_frequency_factory,
                 set_capture_mode_factory,
             ) = self._load_quelware_api()
         except (ModuleNotFoundError, SyntaxError) as exc:
@@ -295,6 +300,7 @@ class Quel3ExecutionManager:
                 runtime=runtime,
                 sequencer_factory=sequencer_factory,
                 capture_mode_enum=capture_mode_enum,
+                set_frequency_factory=set_frequency_factory,
                 set_capture_mode_factory=set_capture_mode_factory,
                 parallel=parallel,
             )
@@ -377,6 +383,7 @@ class Quel3ExecutionManager:
         runtime: _ExecutionRuntime,
         sequencer_factory: Callable[..., SequencerProtocol],
         capture_mode_enum: CaptureModeNamespaceProtocol,
+        set_frequency_factory: SetFrequencyFactory,
         set_capture_mode_factory: SetCaptureModeFactory,
         parallel: bool,
     ) -> Quel3BackendExecutionResult:
@@ -421,8 +428,10 @@ class Quel3ExecutionManager:
             alias: self._build_driver_directives(
                 alias=alias,
                 sequencer=sequencer,
+                frequency_hz=payload.fixed_timelines[alias].frequency_hz,
                 capture_mode=payload.capture_mode,
                 capture_mode_enum=capture_mode_enum,
+                set_frequency_factory=set_frequency_factory,
                 set_capture_mode_factory=set_capture_mode_factory,
             )
             for alias in runtime.alias_to_driver
@@ -470,12 +479,16 @@ class Quel3ExecutionManager:
         *,
         alias: str,
         sequencer: SequencerProtocol,
+        frequency_hz: float | None,
         capture_mode: Quel3CaptureMode,
         capture_mode_enum: CaptureModeNamespaceProtocol,
+        set_frequency_factory: SetFrequencyFactory,
         set_capture_mode_factory: SetCaptureModeFactory,
     ) -> list[DirectiveProtocol]:
         """Build the directives applied to one instrument driver."""
         directives: list[DirectiveProtocol] = []
+        if frequency_hz is not None:
+            directives.append(set_frequency_factory(hz=frequency_hz))
         capture_mode_directive = cls._build_capture_mode_directive(
             capture_mode=capture_mode,
             capture_mode_enum=capture_mode_enum,
@@ -572,6 +585,7 @@ class Quel3ExecutionManager:
             list[tuple[float, float, int, str]],
         ] = defaultdict(list)
         alias_to_length_ns: dict[str, float] = {}
+        alias_to_frequency_hz: dict[str, float] = {}
         sequence_index = 0
 
         for target, timeline in payload.fixed_timelines.items():
@@ -593,6 +607,17 @@ class Quel3ExecutionManager:
                 alias_to_length_ns.get(alias, 0.0),
                 timeline.length_ns,
             )
+            if timeline.frequency_hz is not None:
+                current_frequency_hz = alias_to_frequency_hz.get(alias)
+                if (
+                    current_frequency_hz is not None
+                    and current_frequency_hz != timeline.frequency_hz
+                ):
+                    raise ValueError(
+                        "Conflicting frequency directives resolved to the same "
+                        f"instrument alias `{alias}`."
+                    )
+                alias_to_frequency_hz[alias] = timeline.frequency_hz
             for event in timeline.events:
                 alias_to_events[alias].append((sequence_index, event))
                 sequence_index += 1
@@ -636,6 +661,7 @@ class Quel3ExecutionManager:
                 events=events,
                 capture_windows=tuple(capture_windows),
                 length_ns=length_ns,
+                frequency_hz=alias_to_frequency_hz.get(alias),
             )
 
         return Quel3ExecutionPayload(
@@ -807,6 +833,7 @@ class Quel3ExecutionManager:
         Callable[..., SequencerProtocol],
         InstrumentDriverFactory,
         CaptureModeNamespaceProtocol,
+        SetFrequencyFactory,
         SetCaptureModeFactory,
     ]:
         """Import quelware helpers lazily and return required symbols."""
@@ -832,6 +859,7 @@ class Quel3ExecutionManager:
             driver_module.create_instrument_driver_fixed_timeline
         )
         capture_mode_enum: CaptureModeNamespaceProtocol = directive_module.CaptureMode
+        set_frequency_factory: SetFrequencyFactory = directive_module.SetFrequency
         set_capture_mode_factory: SetCaptureModeFactory = (
             directive_module.SetCaptureMode
         )
@@ -841,5 +869,6 @@ class Quel3ExecutionManager:
             sequencer_factory,
             create_instrument_driver_fixed_timeline,
             capture_mode_enum,
+            set_frequency_factory,
             set_capture_mode_factory,
         )

--- a/src/qubex/backend/quel3/models/payload.py
+++ b/src/qubex/backend/quel3/models/payload.py
@@ -43,6 +43,7 @@ class Quel3FixedTimeline:
     events: tuple[Quel3WaveformEvent, ...]
     capture_windows: tuple[Quel3CaptureWindow, ...]
     length_ns: float
+    frequency_hz: float | None = None
 
 
 class Quel3CaptureMode(str, Enum):

--- a/src/qubex/measurement/adapters/quel3_backend_adapter.py
+++ b/src/qubex/measurement/adapters/quel3_backend_adapter.py
@@ -166,6 +166,10 @@ class Quel3MeasurementBackendAdapter:
                 events=events,
                 capture_windows=capture_windows,
                 length_ns=timeline_length_ns,
+                frequency_hz=self._resolve_timeline_frequency_hz(
+                    target=target,
+                    pulse_schedule=pulse_schedule,
+                ),
             )
             try:
                 output_target_labels_by_target[target] = str(
@@ -329,6 +333,42 @@ class Quel3MeasurementBackendAdapter:
         ):
             return shots
         return 1
+
+    def _resolve_timeline_frequency_hz(
+        self,
+        *,
+        target: str,
+        pulse_schedule: object,
+    ) -> float:
+        """Resolve fixed-timeline frequency in Hz for quelware directives."""
+        schedule_frequency_ghz = self._resolve_schedule_frequency_ghz(
+            pulse_schedule=pulse_schedule,
+            target=target,
+        )
+        if schedule_frequency_ghz is not None:
+            return schedule_frequency_ghz * 1e9
+        return self._experiment_system.get_target(target).frequency * 1e9
+
+    @staticmethod
+    def _resolve_schedule_frequency_ghz(
+        *,
+        pulse_schedule: object,
+        target: str,
+    ) -> float | None:
+        """Resolve channel frequency metadata in GHz from pulse schedule."""
+        get_frequency = getattr(pulse_schedule, "get_frequency", None)
+        if not callable(get_frequency):
+            return None
+        try:
+            frequency = get_frequency(target)
+        except KeyError:
+            return None
+        if not isinstance(frequency, (int, float)):
+            return None
+        frequency_value = float(frequency)
+        if not math.isfinite(frequency_value):
+            return None
+        return frequency_value
 
     @staticmethod
     def _build_capture_targets_by_alias(

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -75,7 +75,12 @@ class _CountingInstrumentResolver(_FakeInstrumentResolver):
         self.refresh_calls += 1
 
 
-def _make_payload(*, mode: str = "avg", n_iterations: int = 2) -> Quel3ExecutionPayload:
+def _make_payload(
+    *,
+    mode: str = "avg",
+    n_iterations: int = 2,
+    frequency_hz: float | None = None,
+) -> Quel3ExecutionPayload:
     waveform_name = "wf0"
     timeline = Quel3FixedTimeline(
         events=(
@@ -88,6 +93,7 @@ def _make_payload(*, mode: str = "avg", n_iterations: int = 2) -> Quel3Execution
             Quel3CaptureWindow(name="capture_0", start_offset_ns=0.4, length_ns=0.4),
         ),
         length_ns=0.8,
+        frequency_hz=frequency_hz,
     )
     return Quel3ExecutionPayload(
         waveform_library={
@@ -511,7 +517,7 @@ def test_constructor_rejects_mismatched_injected_client_runtime_values() -> None
 
 def test_resolve_payload_merges_targets_mapped_to_one_alias() -> None:
     """Given shared alias bindings, resolved payload merges timelines per alias."""
-    payload = _make_payload()
+    payload = _make_payload(frequency_hz=6.2e9)
     payload = replace(
         payload,
         fixed_timelines={
@@ -543,6 +549,38 @@ def test_resolve_payload_merges_targets_mapped_to_one_alias() -> None:
         "alias-shared:0",
         "alias-shared:1",
     ]
+    assert timeline.frequency_hz == pytest.approx(6.2e9)
+
+
+def test_resolve_payload_rejects_conflicting_frequencies_for_shared_alias() -> None:
+    """Given shared alias with different frequencies, resolving payload should fail."""
+    payload = _make_payload()
+    base_timeline = payload.fixed_timelines["alias-rq00"]
+    payload = replace(
+        payload,
+        fixed_timelines={
+            "RQ00": replace(base_timeline, frequency_hz=6.0e9),
+            "RQ01": replace(base_timeline, frequency_hz=6.1e9),
+        },
+        instrument_bindings={
+            "RQ00": "alias:alias-shared",
+            "RQ01": "alias:alias-shared",
+        },
+    )
+    resolver = _FakeInstrumentResolver(
+        alias_to_info={
+            "alias-shared": _FakeInstrumentInfo(
+                port_id="unit-a:trx_p00",
+                definition=_FakeInstrumentDefinition(role="TRANSCEIVER"),
+            )
+        }
+    )
+
+    with pytest.raises(ValueError, match="Conflicting frequency"):
+        Quel3ExecutionManager._resolve_payload(
+            payload=payload,
+            resolver=cast(Any, resolver),
+        )
 
 
 def test_filter_runnable_payload_drops_empty_aliases() -> None:
@@ -883,6 +921,7 @@ def test_execute_batches_capture_mode_with_timeline_directive(
             _FakeSequencer,
             lambda _session, _instrument_info: driver,
             SimpleNamespace(AVERAGED_VALUE="avg"),
+            lambda *, hz: ("frequency", hz),
             lambda *, mode: ("capture_mode", mode),
         ),
     )
@@ -898,6 +937,50 @@ def test_execute_batches_capture_mode_with_timeline_directive(
         result.data["alias-rq00"][0],
         np.array([1.0 + 0.0j], dtype=np.complex128),
     )
+
+
+def test_execute_batches_frequency_capture_mode_with_timeline_directive(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given payload frequency, execute should apply frequency before capture mode and timeline."""
+    payload = _make_payload(frequency_hz=6.25e9)
+    manager = Quel3ExecutionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+        sampling_period_ns=0.4,
+        capture_decimation_factor=4,
+    )
+    resolver = _FakeInstrumentResolver(
+        alias_to_info={
+            "alias-rq00": _FakeInstrumentInfo(
+                port_id="quel3-02-a01:trx_p00",
+                definition=_FakeInstrumentDefinition(role="TRANSCEIVER"),
+            )
+        }
+    )
+    driver = _FakeInstrumentDriver()
+    session = _FakeSession()
+    client = _FakeClient(session)
+
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_api",
+        lambda: (
+            lambda endpoint, port: client,
+            lambda: resolver,
+            _FakeSequencer,
+            lambda _session, _instrument_info: driver,
+            SimpleNamespace(AVERAGED_VALUE="avg"),
+            lambda *, hz: ("frequency", hz),
+            lambda *, mode: ("capture_mode", mode),
+        ),
+    )
+
+    asyncio.run(manager.execute_async(request=BackendExecutionRequest(payload=payload)))
+
+    assert driver.apply_calls == [
+        [("frequency", 6.25e9), ("capture_mode", "avg"), ("timeline", "alias-rq00")]
+    ]
 
 
 def test_execute_rejects_runtime_without_required_capture_mode(
@@ -932,6 +1015,7 @@ def test_execute_rejects_runtime_without_required_capture_mode(
             _FakeSequencer,
             lambda _session, _instrument_info: driver,
             SimpleNamespace(),
+            lambda *, hz: ("frequency", hz),
             lambda *, mode: ("capture_mode", mode),
         ),
     )
@@ -1005,6 +1089,7 @@ def test_execute_parallelizes_driver_phases(
             _FakeSequencer,
             lambda _session, instrument_info: drivers[instrument_info.alias],
             SimpleNamespace(AVERAGED_VALUE="avg"),
+            lambda *, hz: ("frequency", hz),
             lambda *, mode: ("capture_mode", mode),
         ),
     )
@@ -1070,6 +1155,7 @@ def test_execute_batch_async_reuses_one_session(
             _FakeSequencer,
             lambda _session, _instrument_info: driver,
             SimpleNamespace(AVERAGED_VALUE="avg"),
+            lambda *, hz: ("frequency", hz),
             lambda *, mode: ("capture_mode", mode),
         ),
     )
@@ -1153,6 +1239,7 @@ def test_execute_serializes_driver_phases_when_parallel_disabled(
             _FakeSequencer,
             lambda _session, instrument_info: drivers[instrument_info.alias],
             SimpleNamespace(AVERAGED_VALUE="avg"),
+            lambda *, hz: ("frequency", hz),
             lambda *, mode: ("capture_mode", mode),
         ),
     )

--- a/tests/measurement/test_quel3_measurement_backend_adapter.py
+++ b/tests/measurement/test_quel3_measurement_backend_adapter.py
@@ -38,6 +38,7 @@ from qubex.typing import MeasurementMode
 class _FakePulseSchedule:
     duration: float
     sequences: dict[str, PulseArray]
+    frequencies: dict[str, float] = field(default_factory=dict)
     valid: bool = True
 
     @property
@@ -54,11 +55,18 @@ class _FakePulseSchedule:
     def get_sampled_sequences(self) -> dict[str, np.ndarray]:
         raise AssertionError("Quel3 adapter must not call get_sampled_sequences().")
 
+    def get_frequency(self, label: str) -> float:
+        return self.frequencies[label]
+
+    def set_frequency(self, label: str, frequency: float) -> None:
+        self.frequencies[label] = frequency
+
 
 @dataclass
 class _FakeExperimentSystem:
     target_registry: Any = field(default_factory=TargetRegistry)
     awg_frequency: float = 100_000_000.0
+    target_frequencies: dict[str, float] = field(default_factory=dict)
     target_port_ids: dict[str, str] = field(default_factory=dict)
     capture_port_ids: dict[str, str] = field(default_factory=dict)
     target_port_bindings: dict[str, tuple[str, int]] = field(default_factory=dict)
@@ -95,6 +103,7 @@ class _FakeExperimentSystem:
         port_id = self.target_port_ids.get(label, f"box-{label}")
         target_type = self._target_type_for_label(label)
         return SimpleNamespace(
+            frequency=self.target_frequencies.get(label, float("nan")),
             type=target_type,
             is_read=(target_type is TargetType.READ),
             channel=SimpleNamespace(
@@ -277,6 +286,138 @@ def test_quel3_adapter_builds_fixed_timeline_payload() -> None:
     assert timeline.capture_windows[0].name == f"{target}:0"
     assert timeline.capture_windows[0].start_offset_ns == pytest.approx(0.4)
     assert timeline.capture_windows[0].length_ns == pytest.approx(0.4)
+
+
+def test_quel3_adapter_embeds_schedule_frequency_in_payload() -> None:
+    """Given schedule frequency metadata, when building payload, then timeline frequency is preserved."""
+    target = "RQ00"
+    alias = "alias-RQ00"
+    pulse_schedule = _FakePulseSchedule(
+        duration=1.2,
+        sequences={
+            target: _pulse_array(
+                values=np.array([0.0 + 0.0j], dtype=np.complex128),
+                sampling_period=0.4,
+            )
+        },
+    )
+    pulse_schedule.set_frequency(target, 6.25)
+    schedule = MeasurementSchedule.model_construct(
+        pulse_schedule=pulse_schedule,
+        capture_schedule=CaptureSchedule(captures=[]),
+    )
+    adapter = Quel3MeasurementBackendAdapter(
+        backend_controller=_make_backend_controller(),
+        experiment_system=cast(Any, _FakeExperimentSystem()),
+        constraint_profile=MeasurementConstraintProfile.quel3(0.4),
+        instrument_alias_map={target: alias},
+    )
+
+    request = adapter.build_execution_request(schedule=schedule, config=_make_config())
+
+    payload = request.payload
+    assert isinstance(payload, Quel3ExecutionPayload)
+    assert payload.fixed_timelines[target].frequency_hz == pytest.approx(6.25e9)
+
+
+def test_quel3_adapter_falls_back_to_target_frequency_in_payload() -> None:
+    """Given target frequency metadata, when schedule frequency is absent, then timeline frequency uses target frequency."""
+    target = "RQ00"
+    alias = "alias-RQ00"
+    schedule = MeasurementSchedule.model_construct(
+        pulse_schedule=_FakePulseSchedule(
+            duration=1.2,
+            sequences={
+                target: _pulse_array(
+                    values=np.array([0.0 + 0.0j], dtype=np.complex128),
+                    sampling_period=0.4,
+                )
+            },
+        ),
+        capture_schedule=CaptureSchedule(captures=[]),
+    )
+    adapter = Quel3MeasurementBackendAdapter(
+        backend_controller=_make_backend_controller(),
+        experiment_system=cast(
+            Any,
+            _FakeExperimentSystem(target_frequencies={target: 9.87}),
+        ),
+        constraint_profile=MeasurementConstraintProfile.quel3(0.4),
+        instrument_alias_map={target: alias},
+    )
+
+    request = adapter.build_execution_request(schedule=schedule, config=_make_config())
+
+    payload = request.payload
+    assert isinstance(payload, Quel3ExecutionPayload)
+    assert payload.fixed_timelines[target].frequency_hz == pytest.approx(9.87e9)
+
+
+def test_quel3_adapter_treats_schedule_frequency_as_ghz() -> None:
+    """Given schedule frequency metadata, when building payload, then it is converted from GHz to Hz."""
+    target = "RQ00"
+    alias = "alias-RQ00"
+    pulse_schedule = _FakePulseSchedule(
+        duration=1.2,
+        sequences={
+            target: _pulse_array(
+                values=np.array([0.0 + 0.0j], dtype=np.complex128),
+                sampling_period=0.4,
+            )
+        },
+    )
+    pulse_schedule.set_frequency(target, 0.14)
+    schedule = MeasurementSchedule.model_construct(
+        pulse_schedule=pulse_schedule,
+        capture_schedule=CaptureSchedule(captures=[]),
+    )
+    adapter = Quel3MeasurementBackendAdapter(
+        backend_controller=_make_backend_controller(),
+        experiment_system=cast(Any, _FakeExperimentSystem()),
+        constraint_profile=MeasurementConstraintProfile.quel3(0.4),
+        instrument_alias_map={target: alias},
+    )
+
+    request = adapter.build_execution_request(schedule=schedule, config=_make_config())
+
+    payload = request.payload
+    assert isinstance(payload, Quel3ExecutionPayload)
+    assert payload.fixed_timelines[target].frequency_hz == pytest.approx(140e6)
+
+
+def test_quel3_adapter_prefers_schedule_frequency_over_target_frequency() -> None:
+    """Given both schedule and target frequencies, when building payload, then schedule frequency wins."""
+    target = "Q00"
+    alias = "alias-Q00"
+    pulse_schedule = _FakePulseSchedule(
+        duration=1.2,
+        sequences={
+            target: _pulse_array(
+                values=np.array([0.1 + 0.0j], dtype=np.complex128),
+                sampling_period=0.4,
+            )
+        },
+    )
+    pulse_schedule.set_frequency(target, 5.12)
+    schedule = MeasurementSchedule.model_construct(
+        pulse_schedule=pulse_schedule,
+        capture_schedule=CaptureSchedule(captures=[]),
+    )
+    adapter = Quel3MeasurementBackendAdapter(
+        backend_controller=_make_backend_controller(),
+        experiment_system=cast(
+            Any,
+            _FakeExperimentSystem(target_frequencies={target: 5.08}),
+        ),
+        constraint_profile=MeasurementConstraintProfile.quel3(0.4),
+        instrument_alias_map={target: alias},
+    )
+
+    request = adapter.build_execution_request(schedule=schedule, config=_make_config())
+
+    payload = request.payload
+    assert isinstance(payload, Quel3ExecutionPayload)
+    assert payload.fixed_timelines[target].frequency_hz == pytest.approx(5.12e9)
 
 
 def test_quel3_adapter_applies_mux_capture_delay_to_capture_windows() -> None:


### PR DESCRIPTION
## Summary
- Add QuEL-3 timeline frequency_hz payload metadata and SetFrequency directive emission.
- Resolve schedule frequencies as GHz, prioritizing PulseSchedule over target defaults, then convert to Hz for quelware.
- Cover directive emission, alias conflict handling, and adapter frequency precedence with tests.

## Validation
- uv run ruff check --fix
- uv run ruff format
- uv run pyright
- uv run pytest