### PR TITLE
Work around QuEL-3 instrument deploy append bug

### DIFF
--- a/src/qubex/backend/quel3/managers/configuration_manager.py
+++ b/src/qubex/backend/quel3/managers/configuration_manager.py
@@ -294,11 +294,9 @@ class Quel3ConfigurationManager:
             deployed.update(port_result.deployed)
             target_alias_map.update(port_result.target_alias_map)
 
-        # Temporary limitation:
-        # quelware `append=True` is currently broken, so QuEL-3 deploy uses
-        # per-request replacement semantics. Until quelware is fixed, keep the
-        # local alias/instrument cache aligned with the explicit deploy subset.
         self._last_deployed_instrument_infos = dict(deployed)
+        # Keep local alias/instrument cache aligned with the explicitly deployed
+        # subset so it matches this replacement-style call behavior.
         self._target_alias_map = target_alias_map
         return deployed
 
@@ -332,7 +330,12 @@ class Quel3ConfigurationManager:
         inst_infos = await session.deploy_instruments(
             port_id,
             definitions=definitions,
-            append=True,
+            # Temporary limitation:
+            # quelware-client Session.deploy_instruments currently removes all
+            # instruments on the port even with append=True. Treat QuEL-3
+            # deploy as replacement-style semantics and pass append=False
+            # explicitly.
+            append=False,
         )
         infos_by_alias: dict[str, list[InstrumentInfoProtocol]] = defaultdict(list)
         for inst_info in inst_infos:

--- a/tests/backend/test_quel3_configuration_manager.py
+++ b/tests/backend/test_quel3_configuration_manager.py
@@ -98,7 +98,7 @@ def test_deploy_instruments_calls_session_api(
             definitions: list[_Definition],
             append: bool = False,
         ) -> list[_InstrumentInfo]:
-            assert append is True
+            assert append is False
             deploy_calls.append((port_id, definitions))
             return [
                 _InstrumentInfo(
@@ -310,7 +310,7 @@ def test_deploy_instruments_groups_requests_by_port(
     assert create_session_calls == [("quel3-02-a01:tx_p04",)]
     assert len(deploy_calls) == 1
     assert deploy_calls[0][0] == "quel3-02-a01:tx_p04"
-    assert deploy_calls[0][2] is True
+    assert deploy_calls[0][2] is False
     assert [definition.alias for definition in deploy_calls[0][1]] == [
         "Q00",
         "Q00-CR",
@@ -379,7 +379,7 @@ def test_deploy_instruments_uses_one_session_for_all_ports(
             definitions: list[_Definition],
             append: bool = False,
         ) -> list[_InstrumentInfo]:
-            assert append is True
+            assert append is False
             deploy_calls.append(port_id)
             return [
                 _InstrumentInfo(
@@ -504,7 +504,7 @@ def test_deploy_instruments_parallelizes_ports_by_default(
             definitions: list[_Definition],
             append: bool = False,
         ) -> list[_InstrumentInfo]:
-            assert append is True
+            assert append is False
             probe.active += 1
             probe.max_active = max(probe.max_active, probe.active)
             await asyncio.sleep(0)
@@ -628,7 +628,7 @@ def test_deploy_instruments_parallel_false_serializes_ports(
             definitions: list[_Definition],
             append: bool = False,
         ) -> list[_InstrumentInfo]:
-            assert append is True
+            assert append is False
             probe.active += 1
             probe.max_active = max(probe.max_active, probe.active)
             await asyncio.sleep(0)
@@ -1149,7 +1149,7 @@ def test_deploy_instruments_replaces_cached_alias(
     )
 
     assert len(deploy_calls) == 1
-    assert deploy_calls[0][2] is True
+    assert deploy_calls[0][2] is False
     assert deployed == {"Q00": (returned_info,)}
     assert manager.target_alias_map == {"Q00": "Q00"}
 
@@ -1284,6 +1284,6 @@ def test_deploy_instruments_replaces_cached_port_in_one_batched_deploy(
     )
 
     assert len(deploy_calls) == 1
-    assert deploy_calls[0][2] is True
+    assert deploy_calls[0][2] is False
     assert [definition.alias for definition in deploy_calls[0][1]] == ["Q00", "Q00-CR"]
     assert set(deployed) == {"Q00", "Q00-CR"}


### PR DESCRIPTION
## Summary

- Force QuEL-3 instrument deploy to call `Session.deploy_instruments` with `append=False`.
- Keep the local alias/instrument cache aligned with the explicit replacement-style deploy subset.
- Update QuEL-3 configuration manager tests to expect `append=False`.

## Background

`quelware-client` currently removes all instruments on the target port even when `Session.deploy_instruments(..., append=True)` is used. Until that behavior is fixed upstream, QuEL-3 deploy should avoid relying on append semantics and should model each deploy call as replacement-style.

## Validation

- `uv run ruff check --fix src/qubex/backend/quel3/managers/configuration_manager.py tests/backend/test_quel3_configuration_manager.py`
- `uv run ruff format src/qubex/backend/quel3/managers/configuration_manager.py tests/backend/test_quel3_configuration_manager.py`
- `uv run pyright`
- `uv run pytest tests/backend/test_quel3_configuration_manager.py`
- `uv run pytest`
