### PR TITLE
fix: support unit-qualified QuEL-3 aliases

### DIFF
--- a/src/qubex/backend/quel3/interfaces/resolver.py
+++ b/src/qubex/backend/quel3/interfaces/resolver.py
@@ -22,7 +22,12 @@ class InstrumentResolverProtocol(Protocol):
         """Resolve instrument aliases to resource IDs."""
         ...
 
-    def find_inst_info_by_alias(self, alias: str) -> InstrumentInfoProtocol:
+    def find_inst_info_by_alias(
+        self,
+        alias: str,
+        *,
+        unit: str | None = None,
+    ) -> InstrumentInfoProtocol:
         """Return one instrument info resolved by alias."""
         ...
 

--- a/src/qubex/backend/quel3/managers/configuration_manager.py
+++ b/src/qubex/backend/quel3/managers/configuration_manager.py
@@ -162,7 +162,7 @@ class Quel3ConfigurationManager:
 
     @property
     def target_alias_map(self) -> dict[str, str]:
-        """Return last deployed target-to-alias mapping."""
+        """Return last deployed target-to-runtime-alias mapping."""
         return dict(self._target_alias_map)
 
     def deploy_instruments(
@@ -232,7 +232,7 @@ class Quel3ConfigurationManager:
                         definition=definition,
                     ),
                 )
-                target_alias_map[alias] = alias
+                target_alias_map[alias] = definition.alias
 
         self._last_deployed_instrument_infos = deployed
         self._target_alias_map = target_alias_map
@@ -339,7 +339,11 @@ class Quel3ConfigurationManager:
         )
         infos_by_alias: dict[str, list[InstrumentInfoProtocol]] = defaultdict(list)
         for inst_info in inst_infos:
-            infos_by_alias[inst_info.definition.alias].append(inst_info)
+            local_alias, _runtime_alias = self._split_alias_for_port(
+                alias=inst_info.definition.alias,
+                port_id=inst_info.port_id,
+            )
+            infos_by_alias[local_alias].append(inst_info)
 
         deployed: dict[str, tuple[InstrumentInfoProtocol, ...]] = {}
         target_alias_map: dict[str, str] = {}
@@ -350,8 +354,12 @@ class Quel3ConfigurationManager:
                     "quelware did not return the deployed instrument info for one request."
                 )
             deployed[request.alias] = matched_infos
+            runtime_alias = self._runtime_alias_from_instrument_info(
+                instrument_info=matched_infos[0],
+                fallback_alias=request.alias,
+            )
             for target_label in request.target_labels:
-                target_alias_map[target_label] = request.alias
+                target_alias_map[target_label] = runtime_alias
         return _PortDeployResult(
             deployed=deployed,
             target_alias_map=target_alias_map,
@@ -377,9 +385,12 @@ class Quel3ConfigurationManager:
             alias = instrument_info.definition.alias
             if len(alias.strip()) == 0:
                 continue
-            normalized_alias = alias.strip()
-            deployed[normalized_alias] = (instrument_info,)
-            target_alias_map[normalized_alias] = normalized_alias
+            local_alias, runtime_alias = self._split_alias_for_port(
+                alias=alias,
+                port_id=instrument_info.port_id,
+            )
+            deployed[local_alias] = (instrument_info,)
+            target_alias_map[local_alias] = runtime_alias
 
         self._last_deployed_instrument_infos = deployed
         self._target_alias_map = target_alias_map
@@ -416,7 +427,10 @@ class Quel3ConfigurationManager:
             box_id = box_id_by_unit_label.get(unit_label)
             if box_id is None:
                 continue
-            alias = instrument_info.definition.alias.strip()
+            alias, _runtime_alias = self._split_alias_for_port(
+                alias=instrument_info.definition.alias,
+                port_id=instrument_info.port_id,
+            )
             if len(alias) == 0:
                 continue
             definition = self._serialize_instrument_definition(
@@ -478,6 +492,37 @@ class Quel3ConfigurationManager:
         """Extract unit label prefix from one quelware resource ID."""
         return resource_id.split(":", maxsplit=1)[0]
 
+    @classmethod
+    def _split_alias_for_port(cls, *, alias: str, port_id: str) -> tuple[str, str]:
+        """Return local and runtime aliases for one instrument on a port."""
+        runtime_alias = alias.strip()
+        unit_label = cls._extract_unit_label(str(port_id))
+        local_alias = cls._strip_unit_label_prefix(
+            alias=runtime_alias,
+            unit_label=unit_label,
+        )
+        return local_alias, runtime_alias
+
+    @staticmethod
+    def _strip_unit_label_prefix(*, alias: str, unit_label: str) -> str:
+        """Strip the quelware unit prefix from an alias when it matches the port."""
+        prefix = f"{unit_label}:"
+        if alias.startswith(prefix):
+            return alias.removeprefix(prefix)
+        return alias
+
+    @staticmethod
+    def _runtime_alias_from_instrument_info(
+        *,
+        instrument_info: InstrumentInfoProtocol,
+        fallback_alias: str,
+    ) -> str:
+        """Return the runtime alias stored on one quelware instrument info."""
+        alias = instrument_info.definition.alias.strip()
+        if len(alias) > 0:
+            return alias
+        return fallback_alias
+
     @staticmethod
     def _normalize_role_name(role: object) -> str:
         """Normalize one runtime instrument role value to a comparable string."""
@@ -531,6 +576,13 @@ class Quel3ConfigurationManager:
         if not isinstance(definition_config, Mapping):
             return _CachedInstrumentDefinition(alias=alias, role=role_name)
 
+        definition_alias = definition_config.get("alias")
+        runtime_alias = (
+            definition_alias.strip()
+            if isinstance(definition_alias, str) and len(definition_alias.strip()) > 0
+            else alias
+        )
+
         mode = definition_config.get("mode")
         mode_name = None
         if mode is not None:
@@ -551,7 +603,7 @@ class Quel3ConfigurationManager:
             )
 
         return _CachedInstrumentDefinition(
-            alias=alias,
+            alias=runtime_alias,
             role=role_name,
             mode=mode_name,
             profile=profile,

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -23,6 +23,7 @@ from qubex.backend.quel3.interfaces import (
     DirectiveProtocol,
     InstrumentDriverFactory,
     InstrumentDriverProtocol,
+    InstrumentInfoProtocol,
     InstrumentResolverFactory,
     InstrumentResolverProtocol,
     IqWaveformResultProtocol,
@@ -217,6 +218,7 @@ class Quel3ExecutionManager:
                 resolved_payload = self._resolve_payload(
                     payload=payload,
                     resolver=runtime.resolver,
+                    default_unit_label=self._standalone_unit_label,
                 )
                 resolved_payload = self._filter_runnable_payload(resolved_payload)
                 resolved_aliases = tuple(sorted(resolved_payload.fixed_timelines))
@@ -323,12 +325,14 @@ class Quel3ExecutionManager:
         resolved_payload = self._resolve_payload(
             payload=payload,
             resolver=resolver,
+            default_unit_label=self._standalone_unit_label,
         )
         resolved_payload = self._filter_runnable_payload(resolved_payload)
         aliases = sorted(resolved_payload.fixed_timelines.keys())
         alias_to_id = self._resolve_alias_to_id_map(
             resolver=resolver,
             aliases=aliases,
+            default_unit_label=self._standalone_unit_label,
         )
         instrument_ids = [alias_to_id[alias] for alias in aliases]
         await self._session_manager.open(
@@ -340,7 +344,11 @@ class Quel3ExecutionManager:
         alias_to_driver: dict[str, InstrumentDriverProtocol] = {}
         capture_sampling_period_ns: float | None = None
         for alias in aliases:
-            instrument_info = resolver.find_inst_info_by_alias(alias)
+            instrument_info = self._find_inst_info_by_alias(
+                resolver=resolver,
+                alias=alias,
+                default_unit_label=self._standalone_unit_label,
+            )
             driver = create_instrument_driver_fixed_timeline(
                 session,
                 instrument_info,
@@ -549,19 +557,41 @@ class Quel3ExecutionManager:
             alias_results[alias] = await alias_to_driver[alias].fetch_result()
         return alias_results
 
-    @staticmethod
+    @classmethod
     def _resolve_alias_to_id_map(
+        cls,
         *,
         resolver: InstrumentResolverProtocol,
         aliases: list[str],
+        default_unit_label: str | None = None,
     ) -> dict[str, ResourceIdProtocol]:
         """Resolve alias-to-resource-id mapping using InstrumentResolver."""
-        resource_ids = resolver.resolve(aliases)
-        if len(resource_ids) != len(aliases):
+        alias_to_id: dict[str, ResourceIdProtocol] = {}
+        aliases_needing_legacy_resolve: list[str] = []
+        for alias in aliases:
+            instrument_info = cls._find_inst_info_by_alias(
+                resolver=resolver,
+                alias=alias,
+                default_unit_label=default_unit_label,
+            )
+            resource_id = getattr(instrument_info, "id", None)
+            if isinstance(resource_id, str) and len(resource_id) > 0:
+                alias_to_id[alias] = resource_id
+            else:
+                aliases_needing_legacy_resolve.append(alias)
+
+        if len(aliases_needing_legacy_resolve) == 0:
+            return alias_to_id
+
+        resource_ids = resolver.resolve(aliases_needing_legacy_resolve)
+        if len(resource_ids) != len(aliases_needing_legacy_resolve):
             raise ValueError(
                 "InstrumentResolver returned inconsistent alias resolution length."
             )
-        return dict(zip(aliases, resource_ids, strict=True))
+        alias_to_id.update(
+            zip(aliases_needing_legacy_resolve, resource_ids, strict=True)
+        )
+        return alias_to_id
 
     @classmethod
     def _resolve_payload(
@@ -569,6 +599,7 @@ class Quel3ExecutionManager:
         *,
         payload: Quel3ExecutionPayload,
         resolver: InstrumentResolverProtocol,
+        default_unit_label: str | None = None,
     ) -> Quel3ExecutionPayload:
         """Resolve timeline bindings to concrete instrument aliases."""
         bindings = (
@@ -602,6 +633,7 @@ class Quel3ExecutionManager:
                 capture_port_binding=capture_port_binding,
                 has_events=len(timeline.events) > 0,
                 has_captures=len(timeline.capture_windows) > 0,
+                default_unit_label=default_unit_label,
             )
             alias_to_length_ns[alias] = max(
                 alias_to_length_ns.get(alias, 0.0),
@@ -700,20 +732,69 @@ class Quel3ExecutionManager:
         capture_port_binding: str | None,
         has_events: bool,
         has_captures: bool,
+        default_unit_label: str | None = None,
     ) -> str:
         """Resolve one target binding to one instrument alias with fail-fast rules."""
+        del target, capture_port_binding, has_events, has_captures
         if binding.startswith("alias:"):
             alias = binding.removeprefix("alias:").strip()
             if len(alias) == 0:
                 raise ValueError("Empty alias binding is not allowed.")
             try:
-                resolver.find_inst_info_by_alias(alias)
+                instrument_info = cls._find_inst_info_by_alias(
+                    resolver=resolver,
+                    alias=alias,
+                    default_unit_label=default_unit_label,
+                )
             except ValueError as exc:
                 raise ValueError(
                     f"Instrument alias `{alias}` could not be resolved."
                 ) from exc
-            return alias
+            return cls._runtime_alias_from_instrument_info(
+                instrument_info=instrument_info,
+                fallback_alias=alias,
+            )
         raise ValueError(f"Unsupported instrument binding: `{binding}`.")
+
+    @classmethod
+    def _find_inst_info_by_alias(
+        cls,
+        *,
+        resolver: InstrumentResolverProtocol,
+        alias: str,
+        default_unit_label: str | None = None,
+    ) -> InstrumentInfoProtocol:
+        """Find one instrument info, passing unit when the alias is unit-qualified."""
+        local_alias, alias_unit_label = cls._split_unit_qualified_alias(alias)
+        unit_label = alias_unit_label or default_unit_label
+        if unit_label is not None:
+            try:
+                return resolver.find_inst_info_by_alias(local_alias, unit=unit_label)
+            except TypeError:
+                return resolver.find_inst_info_by_alias(alias)
+        return resolver.find_inst_info_by_alias(alias)
+
+    @staticmethod
+    def _split_unit_qualified_alias(alias: str) -> tuple[str, str | None]:
+        """Split `unit_label:alias` into local alias and unit label."""
+        stripped_alias = alias.strip()
+        unit_label, separator, local_alias = stripped_alias.partition(":")
+        if separator and len(unit_label) > 0 and len(local_alias) > 0:
+            return local_alias, unit_label
+        return stripped_alias, None
+
+    @staticmethod
+    def _runtime_alias_from_instrument_info(
+        *,
+        instrument_info: object,
+        fallback_alias: str,
+    ) -> str:
+        """Return the runtime alias stored on one runtime instrument info."""
+        definition = getattr(instrument_info, "definition", None)
+        alias = getattr(definition, "alias", None)
+        if isinstance(alias, str) and len(alias.strip()) > 0:
+            return alias.strip()
+        return fallback_alias
 
     @staticmethod
     def _build_capture_mode_directive(

--- a/src/qubex/backend/quel3/quel3_backend_controller.py
+++ b/src/qubex/backend/quel3/quel3_backend_controller.py
@@ -311,7 +311,7 @@ class Quel3BackendController(BackendController):
 
     @property
     def target_alias_map(self) -> dict[str, str]:
-        """Return deployed target-to-alias mapping from backend runtime state."""
+        """Return deployed target-to-runtime-alias mapping from backend runtime state."""
         return self._configuration_manager.target_alias_map
 
     @property

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -664,6 +664,97 @@ def test_resolve_payload_accepts_alias_binding() -> None:
     assert set(resolved.fixed_timelines.keys()) == {"inst-q00"}
 
 
+def test_execute_resolves_unit_prefixed_alias_binding(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given unit-prefixed alias binding, execute should resolve with the unit label."""
+    payload = _make_payload()
+    payload = replace(
+        payload,
+        fixed_timelines={"Q00": payload.fixed_timelines["alias-rq00"]},
+        instrument_bindings={"Q00": "alias:quel3-02-a01:Q00"},
+    )
+    manager = Quel3ExecutionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+        sampling_period_ns=0.4,
+        capture_decimation_factor=4,
+    )
+
+    @dataclass(frozen=True)
+    class _Definition:
+        alias: str
+        role: str
+
+    @dataclass(frozen=True)
+    class _InstrumentInfo:
+        id: str
+        port_id: str
+        definition: _Definition
+
+    class _UnitAwareResolver:
+        def __init__(self) -> None:
+            self.find_calls: list[tuple[str, str | None]] = []
+
+        async def refresh(self, client: object) -> None:
+            del client
+
+        def resolve(self, aliases: list[str]) -> list[str]:
+            return aliases
+
+        def find_inst_info_by_alias(
+            self,
+            alias: str,
+            *,
+            unit: str | None = None,
+        ) -> _InstrumentInfo:
+            self.find_calls.append((alias, unit))
+            if (alias, unit) != ("Q00", "quel3-02-a01"):
+                raise ValueError(alias)
+            return _InstrumentInfo(
+                id="inst-q00",
+                port_id="quel3-02-a01:tx_p04",
+                definition=_Definition(
+                    alias="quel3-02-a01:Q00",
+                    role="TRANSMITTER",
+                ),
+            )
+
+    resolver = _UnitAwareResolver()
+    driver = _FakeInstrumentDriver()
+    session = _FakeSession()
+    client = _FakeClient(session)
+
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_api",
+        lambda: (
+            lambda endpoint, port: client,
+            lambda: resolver,
+            _FakeSequencer,
+            lambda _session, _instrument_info: driver,
+            SimpleNamespace(AVERAGED_VALUE="avg"),
+            lambda *, hz: ("frequency", hz),
+            lambda *, mode: ("capture_mode", mode),
+        ),
+    )
+
+    result = asyncio.run(
+        manager.execute_async(request=BackendExecutionRequest(payload=payload))
+    )
+
+    assert resolver.find_calls == [
+        ("Q00", "quel3-02-a01"),
+        ("Q00", "quel3-02-a01"),
+        ("Q00", "quel3-02-a01"),
+    ]
+    assert driver.apply_calls == [
+        [("capture_mode", "avg"), ("timeline", "quel3-02-a01:Q00")]
+    ]
+    assert session.trigger_calls == [["inst-q00"]]
+    assert "quel3-02-a01:Q00" in result.data
+
+
 @dataclass(frozen=True)
 class _FakeInstrumentConfig:
     sampling_period_fs: int

--- a/tests/backend/test_quel3_configuration_manager.py
+++ b/tests/backend/test_quel3_configuration_manager.py
@@ -161,6 +161,120 @@ def test_deploy_instruments_calls_session_api(
     assert definition.alias in deployed
 
 
+def test_deploy_instruments_accepts_unit_prefixed_returned_alias(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given quelware prefixes aliases by unit, deploy should keep target bindings usable."""
+    manager = Quel3ConfigurationManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    class _Profile:
+        def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
+            self.frequency_range_min = frequency_range_min
+            self.frequency_range_max = frequency_range_max
+
+    class _Definition:
+        def __init__(self, *, alias: str, mode: object, role: object, profile: object):
+            self.alias = alias
+            self.mode = mode
+            self.role = role
+            self.profile = profile
+
+    class _Mode:
+        FIXED_TIMELINE = "fixed_timeline"
+
+    class _Role:
+        TRANSMITTER = "transmitter"
+
+    @dataclass(frozen=True)
+    class _InstrumentInfo:
+        id: str
+        port_id: str
+        definition: _Definition
+
+    deploy_definitions: list[_Definition] = []
+
+    class _FakeSession:
+        async def __aenter__(self) -> _FakeSession:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            _ = (exc_type, exc, tb)
+
+        async def deploy_instruments(
+            self,
+            port_id: str,
+            *,
+            definitions: list[_Definition],
+            append: bool = False,
+        ) -> list[_InstrumentInfo]:
+            del append
+            deploy_definitions.extend(definitions)
+            returned_definition = _Definition(
+                alias="quel3-02-a01:Q00",
+                mode=definitions[0].mode,
+                role=definitions[0].role,
+                profile=definitions[0].profile,
+            )
+            return [
+                _InstrumentInfo(
+                    id="inst-q00",
+                    port_id=port_id,
+                    definition=returned_definition,
+                )
+            ]
+
+    class _FakeClient:
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            _ = (exc_type, exc, tb)
+
+        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+            del resource_ids
+            return _FakeSession()
+
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_client_factory",
+        lambda: lambda endpoint, port: _FakeClient(),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_load_instrument_entities",
+        lambda: (_Profile, _Definition, _Mode, _Role),
+    )
+
+    request = InstrumentDeployRequest(
+        port_id="quel3-02-a01:tx_p02",
+        role="TRANSMITTER",
+        frequency_range_min_hz=4.1e9,
+        frequency_range_max_hz=4.3e9,
+        alias="Q00",
+        target_labels=("Q00",),
+    )
+
+    deployed = manager.deploy_instruments(requests=(request,))
+
+    assert [definition.alias for definition in deploy_definitions] == ["Q00"]
+    assert set(deployed) == {"Q00"}
+    assert deployed["Q00"][0].definition.alias == "quel3-02-a01:Q00"
+    assert manager.target_alias_map == {"Q00": "quel3-02-a01:Q00"}
+
+
 def test_deploy_instruments_clears_cache_for_empty_requests() -> None:
     """Given empty requests, backend configuration manager should clear deployment cache."""
     manager = Quel3ConfigurationManager(
@@ -788,6 +902,66 @@ def test_refresh_instrument_cache_loads_existing_instruments(
     assert set(cached.keys()) == {"Q00", "RQ00"}
     assert manager.target_alias_map == {"Q00": "Q00", "RQ00": "RQ00"}
     assert set(manager.last_deployed_instrument_infos.keys()) == {"Q00", "RQ00"}
+
+
+def test_refresh_instrument_cache_maps_unit_prefixed_aliases(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given cached quelware aliases with unit prefixes, refresh should map local targets to runtime aliases."""
+    manager = Quel3ConfigurationManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    class _Category:
+        name = "INSTRUMENT"
+
+    class _ResourceInfo:
+        def __init__(self, resource_id: str) -> None:
+            self.id = resource_id
+            self.category = _Category()
+
+    class _Definition:
+        def __init__(self, alias: str) -> None:
+            self.alias = alias
+
+    class _InstrumentInfo:
+        def __init__(self, alias: str, port_id: str) -> None:
+            self.definition = _Definition(alias)
+            self.port_id = port_id
+
+    class _FakeClient:
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            _ = (exc_type, exc, tb)
+
+        async def list_resource_infos(self) -> list[object]:
+            return [_ResourceInfo("inst-q00")]
+
+        async def get_instrument_info(self, resource_id: str) -> object:
+            assert resource_id == "inst-q00"
+            return _InstrumentInfo("quel3-02-a01:Q00", "quel3-02-a01:tx_p04")
+
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_client_factory",
+        lambda: lambda endpoint, port: _FakeClient(),
+    )
+
+    cached = manager.refresh_instrument_cache()
+
+    assert set(cached) == {"Q00"}
+    assert manager.target_alias_map == {"Q00": "quel3-02-a01:Q00"}
+    assert manager.last_deployed_instrument_infos["Q00"][0].definition.alias == (
+        "quel3-02-a01:Q00"
+    )
 
 
 def test_fetch_backend_settings_from_hardware_groups_instruments_by_box(


### PR DESCRIPTION
## Summary
- Keep the runtime alias returned by quelware-client in `target_alias_map` while preserving local target labels as cache keys.
- Resolve `unit_label:alias` runtime aliases by passing the unit label to `InstrumentResolver`.
- Add regression coverage for deploy, refresh, and execution paths.

## Background
Newer quelware-client behavior can register aliases in the `unit_label:alias` form. Qubex previously treated the configured alias and the runtime alias as the same value, which made deployment cache updates and execution-time resolver lookups disagree once the unit label prefix appeared.

## Impact
- `target_alias_map` now means target label to runtime alias.
- Existing bare aliases still resolve through the previous path.
- The resolver protocol accepts an optional `unit` keyword to match quelware-client lookup behavior.

## Validation
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`