### PR TITLE
feat(contrib): add repeated coherence measurement helper

### DIFF
--- a/src/qubex/contrib/__init__.py
+++ b/src/qubex/contrib/__init__.py
@@ -75,6 +75,7 @@ from .experiment.readout_parameters_characterization import (
     characterize_readout_parameters,
     fit_readout_parameters,
 )
+from .experiment.repeated_coherence_measurement import repeated_coherence_measurement
 from .experiment.rzx_gate import rzx, rzx_gate_property
 from .experiment.simultaneous_coherence_measurement import (
     simultaneous_coherence_measurement,
@@ -147,6 +148,7 @@ __all__ = [
     "purity_sequence_2q",
     "quantum_efficiency_measurement",
     "readout_snr",
+    "repeated_coherence_measurement",
     "rzx",
     "rzx_gate_property",
     "simultaneous_coherence_measurement",

--- a/src/qubex/contrib/experiment/__init__.py
+++ b/src/qubex/contrib/experiment/__init__.py
@@ -70,6 +70,7 @@ from .quantum_efficiency_measurement import (
     sweep_readout_snr,
 )
 from .readout_parameters_characterization import characterize_readout_parameters
+from .repeated_coherence_measurement import repeated_coherence_measurement
 from .rzx_gate import rzx, rzx_gate_property
 from .simultaneous_coherence_measurement import simultaneous_coherence_measurement
 from .stark_characterization import stark_ramsey_experiment, stark_t1_experiment
@@ -133,6 +134,7 @@ __all__ = [
     "purity_sequence_2q",
     "quantum_efficiency_measurement",
     "readout_snr",
+    "repeated_coherence_measurement",
     "rzx",
     "rzx_gate_property",
     "simultaneous_coherence_measurement",

--- a/src/qubex/contrib/experiment/repeated_coherence_measurement.py
+++ b/src/qubex/contrib/experiment/repeated_coherence_measurement.py
@@ -1,0 +1,298 @@
+"""Contributed repeated coherence measurement helper function."""
+
+from __future__ import annotations
+
+from collections.abc import Collection, Mapping
+from typing import Any, NamedTuple
+
+import numpy as np
+
+from qubex.experiment import Experiment
+from qubex.experiment.models.result import Result
+
+
+class _ModeSpec(NamedTuple):
+    method_name: str
+    value_attribute: str
+    metric_name: str
+
+
+_MODE_SPECS: dict[str, _ModeSpec] = {
+    "t1": _ModeSpec(
+        method_name="t1_experiment",
+        value_attribute="t1",
+        metric_name="t1",
+    ),
+    "t2_echo": _ModeSpec(
+        method_name="t2_experiment",
+        value_attribute="t2",
+        metric_name="t2_echo",
+    ),
+    "ramsey": _ModeSpec(
+        method_name="ramsey_experiment",
+        value_attribute="t2",
+        metric_name="t2_star",
+    ),
+}
+
+_MODE_ALIASES: dict[str, str] = {
+    "t1": "t1",
+    "t_1": "t1",
+    "t2": "t2_echo",
+    "t_2": "t2_echo",
+    "t2_echo": "t2_echo",
+    "t2echo": "t2_echo",
+    "echo": "t2_echo",
+    "ramsey": "ramsey",
+    "t2_star": "ramsey",
+    "t2star": "ramsey",
+    "t2*": "ramsey",
+}
+
+
+def _normalize_modes(modes: Collection[str] | None) -> list[str]:
+    if modes is None:
+        return list(_MODE_SPECS)
+
+    normalized_modes: list[str] = []
+    for mode in modes:
+        normalized = _MODE_ALIASES.get(mode.strip().lower())
+        if normalized is None:
+            raise ValueError(
+                f"Unknown coherence measurement mode `{mode}`. "
+                f"Expected one of {sorted(_MODE_SPECS)}."
+            )
+        if normalized in normalized_modes:
+            raise ValueError(f"Duplicate coherence measurement mode `{mode}`.")
+        normalized_modes.append(normalized)
+
+    if len(normalized_modes) == 0:
+        raise ValueError("At least one coherence measurement mode must be specified.")
+
+    return normalized_modes
+
+
+def _normalize_targets(
+    exp: Experiment,
+    targets: Collection[str] | str | None,
+) -> list[str]:
+    if targets is None:
+        return list(exp.ctx.qubit_labels)
+    if isinstance(targets, str):
+        return [targets]
+    return list(targets)
+
+
+def _validate_options(
+    *,
+    t1_options: Mapping[str, Any] | None,
+    t2_options: Mapping[str, Any] | None,
+    ramsey_options: Mapping[str, Any] | None,
+) -> dict[str, Mapping[str, Any]]:
+    return {
+        "t1": t1_options or {},
+        "t2_echo": t2_options or {},
+        "ramsey": ramsey_options or {},
+    }
+
+
+def _build_measurement_kwargs(
+    *,
+    targets: Collection[str] | str | None,
+    n_shots: int | None,
+    shot_interval: float | None,
+    plot: bool | None,
+    save_image: bool | None,
+    options: Mapping[str, Any],
+) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {
+        "targets": targets,
+        "n_shots": n_shots,
+        "shot_interval": shot_interval,
+        "plot": plot,
+        "save_image": save_image,
+    }
+    kwargs.update(options)
+    return kwargs
+
+
+def _ensure_target_storage(
+    *,
+    values: dict[str, dict[str, list[float]]],
+    failed_runs: dict[str, dict[str, list[int]]],
+    mode: str,
+    target: str,
+    run_index: int,
+) -> None:
+    if target in values[mode]:
+        return
+
+    values[mode][target] = [np.nan] * run_index
+    failed_runs[mode][target] = []
+
+
+def _extract_float_value(data: object, attribute: str) -> float:
+    value = getattr(data, attribute, np.nan)
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return float("nan")
+
+
+def _build_statistics(
+    values: dict[str, dict[str, list[float]]],
+    metric_names: Mapping[str, str],
+    n_runs: int,
+) -> dict[str, dict[str, dict[str, float | int | str]]]:
+    statistics: dict[str, dict[str, dict[str, float | int | str]]] = {}
+    for mode, target_values in values.items():
+        statistics[mode] = {}
+        for target, series in target_values.items():
+            value_array = np.asarray(series, dtype=float)
+            finite_values = value_array[np.isfinite(value_array)]
+            count = int(finite_values.size)
+            mean = float(np.mean(finite_values)) if count > 0 else float("nan")
+            std = float(np.std(finite_values, ddof=1)) if count > 1 else float("nan")
+            statistics[mode][target] = {
+                "metric": metric_names[mode],
+                "mean": mean,
+                "std": std,
+                "count": count,
+                "n_runs": n_runs,
+            }
+    return statistics
+
+
+def repeated_coherence_measurement(
+    exp: Experiment,
+    targets: Collection[str] | str | None = None,
+    *,
+    n_runs: int,
+    modes: Collection[str] | None = None,
+    n_shots: int | None = None,
+    shot_interval: float | None = None,
+    plot: bool | None = False,
+    save_image: bool | None = False,
+    t1_options: Mapping[str, Any] | None = None,
+    t2_options: Mapping[str, Any] | None = None,
+    ramsey_options: Mapping[str, Any] | None = None,
+) -> Result:
+    """
+    Run coherence measurements repeatedly and summarize their variability.
+
+    Parameters
+    ----------
+    exp
+        Experiment instance used to run the underlying coherence measurements.
+    targets
+        Target qubits to characterize. When omitted, all experiment qubits are
+        used.
+    n_runs
+        Number of repeated measurements to run for each selected mode.
+    modes
+        Measurement modes to execute. Accepted canonical values are ``"t1"``,
+        ``"t2_echo"``, and ``"ramsey"``. ``"t2"`` aliases ``"t2_echo"`` and
+        ``"t2_star"`` aliases ``"ramsey"``.
+    n_shots
+        Common number of shots passed to each underlying measurement unless a
+        mode-specific options mapping overrides it.
+    shot_interval
+        Common shot interval passed to each underlying measurement unless a
+        mode-specific options mapping overrides it.
+    plot
+        Common plotting flag for underlying measurements.
+    save_image
+        Common image saving flag for underlying measurements.
+    t1_options
+        Additional keyword arguments passed to ``exp.t1_experiment``.
+    t2_options
+        Additional keyword arguments passed to ``exp.t2_experiment``.
+    ramsey_options
+        Additional keyword arguments passed to ``exp.ramsey_experiment``.
+
+    Returns
+    -------
+    Result
+        Mapping-style result containing raw per-run results, extracted values,
+        summary statistics, and failed run indexes.
+    """
+    if n_runs < 1:
+        raise ValueError("n_runs must be at least 1.")
+
+    normalized_modes = _normalize_modes(modes)
+    options_by_mode = _validate_options(
+        t1_options=t1_options,
+        t2_options=t2_options,
+        ramsey_options=ramsey_options,
+    )
+
+    raw_results: dict[str, list[object]] = {mode: [] for mode in normalized_modes}
+    values: dict[str, dict[str, list[float]]] = {mode: {} for mode in normalized_modes}
+    failed_runs: dict[str, dict[str, list[int]]] = {
+        mode: {} for mode in normalized_modes
+    }
+    target_sets: dict[str, list[str]] = {}
+    metric_names = {mode: _MODE_SPECS[mode].metric_name for mode in normalized_modes}
+
+    measurement_kwargs: dict[str, dict[str, Any]] = {}
+    for mode in normalized_modes:
+        kwargs = _build_measurement_kwargs(
+            targets=targets,
+            n_shots=n_shots,
+            shot_interval=shot_interval,
+            plot=plot,
+            save_image=save_image,
+            options=options_by_mode[mode],
+        )
+        measurement_kwargs[mode] = kwargs
+        target_sets[mode] = _normalize_targets(exp, kwargs.get("targets"))
+        for target in target_sets[mode]:
+            _ensure_target_storage(
+                values=values,
+                failed_runs=failed_runs,
+                mode=mode,
+                target=target,
+                run_index=0,
+            )
+
+    for run_index in range(n_runs):
+        for mode in normalized_modes:
+            spec = _MODE_SPECS[mode]
+            method = getattr(exp, spec.method_name)
+            result = method(**measurement_kwargs[mode])
+            raw_results[mode].append(result)
+
+            result_data = getattr(result, "data", {})
+            measured_targets = set(result_data)
+            expected_targets = set(target_sets[mode])
+            targets_to_record = [*target_sets[mode]]
+            for target in measured_targets - expected_targets:
+                target_sets[mode].append(target)
+                targets_to_record.append(target)
+                _ensure_target_storage(
+                    values=values,
+                    failed_runs=failed_runs,
+                    mode=mode,
+                    target=target,
+                    run_index=run_index,
+                )
+
+            for target in targets_to_record:
+                target_data = result_data.get(target)
+                value = _extract_float_value(target_data, spec.value_attribute)
+                values[mode][target].append(value)
+                if not np.isfinite(value):
+                    failed_runs[mode][target].append(run_index)
+
+    return Result(
+        data={
+            "targets": target_sets,
+            "n_runs": n_runs,
+            "modes": normalized_modes,
+            "metrics": metric_names,
+            "raw_results": raw_results,
+            "values": values,
+            "statistics": _build_statistics(values, metric_names, n_runs),
+            "failed_runs": failed_runs,
+        },
+    )

--- a/tests/contrib/repeated_coherence_measurement/test_function_api.py
+++ b/tests/contrib/repeated_coherence_measurement/test_function_api.py
@@ -1,0 +1,154 @@
+"""Tests for `qubex.contrib.experiment.repeated_coherence_measurement`."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from qubex.contrib import repeated_coherence_measurement
+from qubex.experiment.models.experiment_result import ExperimentResult
+
+
+class _FakeExperiment:
+    def __init__(self) -> None:
+        self.ctx = SimpleNamespace(qubit_labels=["Q00", "Q01"])
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.t1_values = [
+            {"Q00": 10.0, "Q01": 20.0},
+            {"Q00": 12.0, "Q01": 22.0},
+            {"Q00": 14.0, "Q01": 24.0},
+        ]
+        self.t2_values = [
+            {"Q00": 30.0, "Q01": 40.0},
+            {"Q00": 32.0, "Q01": 42.0},
+            {"Q00": 34.0, "Q01": 44.0},
+        ]
+        self.ramsey_values = [
+            {"Q00": 50.0, "Q01": 60.0},
+            {"Q00": 52.0, "Q01": 62.0},
+            {"Q00": 54.0, "Q01": 64.0},
+        ]
+
+    def t1_experiment(self, **kwargs: Any) -> ExperimentResult[Any]:
+        self.calls.append(("t1", kwargs))
+        return _result(self.t1_values[len(self.calls_for("t1")) - 1], "t1")
+
+    def t2_experiment(self, **kwargs: Any) -> ExperimentResult[Any]:
+        self.calls.append(("t2_echo", kwargs))
+        return _result(self.t2_values[len(self.calls_for("t2_echo")) - 1], "t2")
+
+    def ramsey_experiment(self, **kwargs: Any) -> ExperimentResult[Any]:
+        self.calls.append(("ramsey", kwargs))
+        return _result(self.ramsey_values[len(self.calls_for("ramsey")) - 1], "t2")
+
+    def calls_for(self, mode: str) -> list[tuple[str, dict[str, Any]]]:
+        return [call for call in self.calls if call[0] == mode]
+
+
+def _result(values: dict[str, float], attribute: str) -> ExperimentResult[Any]:
+    return ExperimentResult(
+        data={
+            target: SimpleNamespace(**{attribute: value})
+            for target, value in values.items()
+        }
+    )
+
+
+def test_repeated_coherence_measurement_is_exported_from_contrib() -> None:
+    """Given contrib package, when imported, then repeated coherence helper is available."""
+    assert callable(repeated_coherence_measurement)
+
+
+def test_repeated_coherence_measurement_returns_raw_values_and_statistics() -> None:
+    """Given repeated measurements, when all fits succeed, then all data and stats are returned."""
+    exp = _FakeExperiment()
+
+    result = repeated_coherence_measurement(
+        cast(Any, exp),
+        targets=["Q00", "Q01"],
+        n_runs=3,
+        modes=["T1", "t2", "t2_star"],
+        n_shots=100,
+        shot_interval=1.5,
+        t1_options={"n_shots": 200, "time_range": [1, 2, 3]},
+        ramsey_options={"detuning": 0.001},
+    )
+
+    assert result.data["modes"] == ["t1", "t2_echo", "ramsey"]
+    assert result.data["metrics"] == {
+        "t1": "t1",
+        "t2_echo": "t2_echo",
+        "ramsey": "t2_star",
+    }
+    assert result.data["values"]["t1"]["Q00"] == [10.0, 12.0, 14.0]
+    assert result.data["values"]["t2_echo"]["Q01"] == [40.0, 42.0, 44.0]
+    assert result.data["values"]["ramsey"]["Q00"] == [50.0, 52.0, 54.0]
+    assert result.data["statistics"]["t1"]["Q00"] == {
+        "metric": "t1",
+        "mean": 12.0,
+        "std": 2.0,
+        "count": 3,
+        "n_runs": 3,
+    }
+    assert result.data["statistics"]["ramsey"]["Q01"] == {
+        "metric": "t2_star",
+        "mean": 62.0,
+        "std": 2.0,
+        "count": 3,
+        "n_runs": 3,
+    }
+    assert len(result.data["raw_results"]["t1"]) == 3
+    assert result.data["failed_runs"]["t1"]["Q00"] == []
+
+    assert exp.calls_for("t1")[0][1]["n_shots"] == 200
+    assert exp.calls_for("t1")[0][1]["time_range"] == [1, 2, 3]
+    assert exp.calls_for("t2_echo")[0][1]["n_shots"] == 100
+    assert exp.calls_for("t2_echo")[0][1]["shot_interval"] == 1.5
+    assert exp.calls_for("ramsey")[0][1]["detuning"] == 0.001
+
+
+def test_repeated_coherence_measurement_summarizes_successful_values_only() -> None:
+    """Given missing target results, when summarized, then failed runs are recorded."""
+    exp = _FakeExperiment()
+    exp.t1_values = [
+        {"Q00": 10.0, "Q01": 20.0},
+        {"Q00": 12.0},
+        {"Q00": 14.0, "Q01": 24.0},
+    ]
+
+    result = repeated_coherence_measurement(
+        cast(Any, exp),
+        targets=["Q00", "Q01"],
+        n_runs=3,
+        modes=["t1"],
+    )
+
+    q01_values = result.data["values"]["t1"]["Q01"]
+    assert q01_values[0] == 20.0
+    assert np.isnan(q01_values[1])
+    assert q01_values[2] == 24.0
+    assert result.data["failed_runs"]["t1"]["Q01"] == [1]
+    assert result.data["statistics"]["t1"]["Q01"]["mean"] == 22.0
+    assert result.data["statistics"]["t1"]["Q01"]["std"] == pytest.approx(np.sqrt(8.0))
+    assert result.data["statistics"]["t1"]["Q01"]["count"] == 2
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"n_runs": 0}, "n_runs must be at least 1"),
+        ({"n_runs": 1, "modes": ["unknown"]}, "Unknown coherence measurement mode"),
+        ({"n_runs": 1, "modes": ["t1", "T1"]}, "Duplicate coherence measurement mode"),
+        ({"n_runs": 1, "modes": []}, "At least one coherence measurement mode"),
+    ],
+)
+def test_repeated_coherence_measurement_validates_inputs(
+    kwargs: dict[str, Any],
+    match: str,
+) -> None:
+    """Given invalid options, when called, then a clear ValueError is raised."""
+    with pytest.raises(ValueError, match=match):
+        repeated_coherence_measurement(cast(Any, _FakeExperiment()), **kwargs)


### PR DESCRIPTION
## Background

This PR adds a contrib helper for repeatedly running coherence measurements and summarizing run-to-run variation. The intended use case is measuring average T1, T2 echo, and Ramsey T2* values over multiple runs while keeping the raw per-run experiment results.

## Summary

- Add `repeated_coherence_measurement` under `qubex.contrib.experiment`.
- Wrap existing `Experiment` methods:
  - `exp.t1_experiment`
  - `exp.t2_experiment`
  - `exp.ramsey_experiment`
- Return a `Result` containing:
  - `raw_results`
  - extracted per-run `values`
  - `statistics` with mean, sample standard deviation, count, and n_runs
  - `failed_runs` indexes for missing or non-finite values
- Export the helper from `qubex.contrib` and `qubex.contrib.experiment`.

## User-facing / API impact

Users can call:

```python
from qubex import contrib as ctb

result = ctb.repeated_coherence_measurement(
    exp=ex,
    targets="Q40",
    n_runs=3,
    modes=["t1"],
    t1_options={"shot_interval": 300 * 1024},
    plot=False,
)
