### PR TITLE
build(quel3): require quelware-client 0.1.4.post1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 [project.optional-dependencies]
 backend = ["qxdriver-quel1 == 1.5.0b4"]
 quel1 = ["qxdriver-quel1 == 1.5.0b4"]
-quel3 = ["quelware-client >= 0.1.1"]
+quel3 = ["quelware-client >= 0.1.4.post1"]
 
 [project.scripts]
 qubex = "qubex.cli:main"

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -24,7 +24,7 @@ def test_project_optional_dependencies_split_backend_quel1_quel3() -> None:
         re.MULTILINE,
     )
     assert re.search(
-        r'^quel3\s*=\s*\["quelware-client >= 0\.1\.1"\]',
+        r'^quel3\s*=\s*\["quelware-client >= 0\.1\.4\.post1"\]',
         text,
         re.MULTILINE,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -3483,7 +3483,7 @@ requires-dist = [
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qctrl-visualizer", specifier = ">=8.0" },
-    { name = "quelware-client", marker = "extra == 'quel3'", specifier = ">=0.1.1" },
+    { name = "quelware-client", marker = "extra == 'quel3'", specifier = ">=0.1.4.post1" },
     { name = "qxcore", editable = "packages/qxcore" },
     { name = "qxdriver-quel1", marker = "extra == 'backend'", editable = "packages/qxdriver-quel1" },
     { name = "qxdriver-quel1", marker = "extra == 'quel1'", editable = "packages/qxdriver-quel1" },
@@ -3550,7 +3550,7 @@ wheels = [
 
 [[package]]
 name = "quelware-client"
-version = "0.1.2"
+version = "0.1.4.post1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "betterproto2" },
@@ -3559,14 +3559,14 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/70/51/12fe8ad26a3c5233d1c9f0c90518a0cc3d2c386487f15eca80e19479d380/quelware_client-0.1.2.tar.gz", hash = "sha256:635273f648b2dcdc601f9ccc02db6bf62d1d5727abd14951752c9025ce382d5a", size = 57428, upload-time = "2026-04-17T16:05:45.398Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/58/7b2fd171588b8778f679e83c4a2ca9f1a33f0a512684eb54b6144698ddd3/quelware_client-0.1.4.post1.tar.gz", hash = "sha256:30704906d8b71975695cdb32c7b6b21cedbecff5a57153d29af14ef9a7ff647d", size = 59189, upload-time = "2026-05-18T01:55:19.911Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/4c/02/71644288d58d4d653d6d0350d583a93a1f6e9214f05512f9988b781328b0/quelware_client-0.1.2-py3-none-any.whl", hash = "sha256:8abbd1ce0fa60635a269c6953f97487c4894cfce697ae15415744653cd7b1246", size = 32187, upload-time = "2026-04-17T16:05:42.56Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/32/d6bbd2fc59e41861a5c64b8147bae383762fc59b11a9b58394f43cecf1d1/quelware_client-0.1.4.post1-py3-none-any.whl", hash = "sha256:75009748fd06bbef5512dba582d8127008197f0ff86bc9f63b82cdc27d45292b", size = 34079, upload-time = "2026-05-18T01:55:17.759Z" },
 ]
 
 [[package]]
 name = "quelware-core"
-version = "0.1.2"
+version = "0.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "betterproto2" },
@@ -3576,9 +3576,9 @@ dependencies = [
     { name = "numpy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/11/97/a73e7bdecafe41abe29a7bd20588b9eb5c1603d3b4f71906874287171e7f/quelware_core-0.1.2.tar.gz", hash = "sha256:62ef2a971eee952b3977c19f4a9a47c1937e60b6d55f870ba41f922b810e796f", size = 50266, upload-time = "2026-04-17T16:05:46.703Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f4/3c/ac047fe0fd1216cdb4c9f6cdbfb24835d1e568e94593d45bf691be732b46/quelware_core-0.1.3.tar.gz", hash = "sha256:d322548a30fb426fb791cb239fd4ebc63e880186ffc8d9a2aad15b7890dca952", size = 51015, upload-time = "2026-05-15T06:53:44.66Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fc/9d/66d44448194740eb1f6537c682175ebcf2394c3fa9e487f88dfb94ca947c/quelware_core-0.1.2-py3-none-any.whl", hash = "sha256:e3fcbbed9298c7d5f5b4046ab37db8ebcd91877774a2d79b4cfb7f21e7559412", size = 33698, upload-time = "2026-04-17T16:05:44.1Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/79/4780cdedc1cc98b434d536072ebfc57034ab04b372e34b35720119fa05ec/quelware_core-0.1.3-py3-none-any.whl", hash = "sha256:e05b2bcd10844d993cc19908bf8fcfe525448c5204becc1d91733c3f1914f6f8", size = 35377, upload-time = "2026-05-15T06:53:42.947Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Raise the QuEL-3 optional dependency floor to `quelware-client >= 0.1.4.post1`.
- Keep `uv.lock` resolved to `quelware-client 0.1.4.post1` and the matching `quelware-core 0.1.3` release.
- Update the optional-dependency metadata regression test to match the new lower bound.

## Impact

QuEL-3 installs now pick up the client API baseline needed by the current runtime without pinning future compatible releases out.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`
- `make check-release-version`