### PR TITLE
feat(quel3): build controller from system config

### DIFF
--- a/src/qubex/system/config_loader.py
+++ b/src/qubex/system/config_loader.py
@@ -397,6 +397,19 @@ class ConfigLoader:
         return self._backend_kind
 
     @property
+    def backend_runtime_config(self) -> dict[str, Any]:
+        """Return backend-specific runtime configuration for the loaded system."""
+        self._ensure_loaded()
+        value = self._system_dict.get(self._backend_kind)
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"`{self._backend_kind}` section in `{self._system_file}` must be a mapping."
+            )
+        return dict(value)
+
+    @property
     def measurement_defaults(self) -> MeasurementDefaults:
         """Return parsed partial measurement defaults for the loaded system."""
         self._ensure_loaded()

--- a/src/qubex/system/system_manager.py
+++ b/src/qubex/system/system_manager.py
@@ -162,11 +162,73 @@ class SystemManager:
     @staticmethod
     def _create_backend_controller(
         backend_kind: BackendKind,
+        backend_runtime_config: Mapping[str, Any] | None = None,
     ) -> SystemBackendController:
         """Create a backend controller instance for one experiment session."""
         if backend_kind == BACKEND_KIND_QUEL3:
-            return Quel3BackendController()
+            return Quel3BackendController(
+                **SystemManager._resolve_quel3_controller_kwargs(backend_runtime_config)
+            )
         return Quel1BackendController()
+
+    @staticmethod
+    def _resolve_quel3_controller_kwargs(
+        backend_runtime_config: Mapping[str, Any] | None,
+    ) -> dict[str, Any]:
+        """Return `Quel3BackendController` kwargs from system runtime config."""
+        if backend_runtime_config is None:
+            return {}
+        kwargs: dict[str, Any] = {}
+        endpoint = SystemManager._get_runtime_config_value(
+            backend_runtime_config,
+            "quelware_endpoint",
+            "endpoint",
+        )
+        port = SystemManager._get_runtime_config_value(
+            backend_runtime_config,
+            "quelware_port",
+            "port",
+        )
+        client_mode = SystemManager._get_runtime_config_value(
+            backend_runtime_config,
+            "client_mode",
+        )
+        standalone_unit_label = SystemManager._get_runtime_config_value(
+            backend_runtime_config,
+            "standalone_unit_label",
+        )
+        if endpoint is not None:
+            kwargs["quelware_endpoint"] = endpoint
+        if port is not None:
+            kwargs["quelware_port"] = port
+        if client_mode is not None:
+            kwargs["client_mode"] = client_mode
+        if standalone_unit_label is not None:
+            kwargs["standalone_unit_label"] = standalone_unit_label
+        return kwargs
+
+    @staticmethod
+    def _get_runtime_config_value(
+        backend_runtime_config: Mapping[str, Any],
+        *keys: str,
+    ) -> Any | None:
+        """Return the first present runtime config value for one alias set."""
+        for key in keys:
+            if key in backend_runtime_config:
+                return backend_runtime_config[key]
+        return None
+
+    @staticmethod
+    def _get_backend_runtime_config(
+        config_loader: ConfigLoader,
+    ) -> Mapping[str, Any]:
+        """Return backend runtime config from loaders that expose it."""
+        runtime_config = getattr(config_loader, "backend_runtime_config", {})
+        if runtime_config is None:
+            return {}
+        if not isinstance(runtime_config, Mapping):
+            raise TypeError("`backend_runtime_config` must be a mapping.")
+        return runtime_config
 
     @property
     def backend_kind(self) -> BackendKind:
@@ -367,6 +429,7 @@ class SystemManager:
         next_experiment_system = next_config_loader.get_experiment_system()
 
         resolved_backend_kind = next_config_loader.backend_kind
+        backend_runtime_config = self._get_backend_runtime_config(next_config_loader)
         self.set_backend_kind(resolved_backend_kind)
         if backend_controller is not None:
             self._validate_backend_controller_kind(
@@ -376,6 +439,16 @@ class SystemManager:
             self._backend_controller = backend_controller
             self._system_synchronizer = self._create_system_synchronizer(
                 backend_controller,
+                resolved_backend_kind,
+            )
+            self._backend_settings = BackendSettings()
+        elif resolved_backend_kind == BACKEND_KIND_QUEL3:
+            self._backend_controller = self._create_backend_controller(
+                resolved_backend_kind,
+                backend_runtime_config=backend_runtime_config,
+            )
+            self._system_synchronizer = self._create_system_synchronizer(
+                self._backend_controller,
                 resolved_backend_kind,
             )
             self._backend_settings = BackendSettings()

--- a/tests/backend/test_config_loader.py
+++ b/tests/backend/test_config_loader.py
@@ -1224,6 +1224,49 @@ def test_load_uses_wiring_yaml_for_quel3_backend(tmp_path: Path) -> None:
     assert loader.wiring_file == "wiring.yaml"
 
 
+def test_backend_runtime_config_returns_selected_backend_section(
+    tmp_path: Path,
+) -> None:
+    """Given backend runtime settings, when loading, then ConfigLoader exposes that section."""
+    config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)
+    runtime_config = {
+        "endpoint": "192.0.2.10",
+        "port": 50052,
+        "client_mode": "standalone",
+        "standalone_unit_label": "quel3-02-a01",
+    }
+
+    _write_yaml(
+        config_dir / "box.yaml",
+        {
+            "BOX1": {
+                "name": "Box One",
+                "type": "quel3",
+            }
+        },
+    )
+    _write_yaml(
+        config_dir / "system.yaml",
+        {
+            "schema_version": 1,
+            "chip_id": chip_id,
+            "backend": BACKEND_KIND_QUEL3,
+            BACKEND_KIND_QUEL3: runtime_config,
+        },
+    )
+
+    loader = ConfigLoader(
+        system_id=chip_id,
+        config_dir=config_dir,
+        params_dir=params_dir,
+    )
+    loaded_config = loader.backend_runtime_config
+    loaded_config["endpoint"] = "mutated"
+
+    assert loaded_config != loader.backend_runtime_config
+    assert loader.backend_runtime_config == runtime_config
+
+
 def test_load_configures_quel3_readout_without_lo(tmp_path: Path) -> None:
     """Given quel3 backend, when loading, then readout ports are configured without LO."""
     config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)

--- a/tests/backend/test_system_manager.py
+++ b/tests/backend/test_system_manager.py
@@ -1235,6 +1235,50 @@ def test_load_uses_provided_backend_controller(
     assert manager.backend_controller is injected_controller
 
 
+def test_load_creates_quel3_controller_from_runtime_config(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given quel3 runtime config, when loading without injected controller, then SystemManager configures the controller."""
+    manager = SystemManager.shared()
+
+    class _FakeConfigLoader:
+        def __init__(self, **_: object) -> None:
+            pass
+
+        def load(self, **_: object) -> None:
+            pass
+
+        @property
+        def backend_kind(self) -> str:
+            return BACKEND_KIND_QUEL3
+
+        @property
+        def backend_runtime_config(self) -> dict[str, object]:
+            return {
+                "endpoint": "192.0.2.10",
+                "port": 50052,
+                "client_mode": "standalone",
+                "standalone_unit_label": "quel3-02-a01",
+            }
+
+        def get_experiment_system(self) -> object:
+            return SimpleNamespace(hash=hash("TEST"))
+
+    monkeypatch.setattr("qubex.system.system_manager.ConfigLoader", _FakeConfigLoader)
+
+    manager.load(
+        chip_id="TEST",
+        mock_mode=True,
+    )
+
+    controller = manager.backend_controller
+    assert isinstance(controller, Quel3BackendController)
+    assert controller.quelware_endpoint == "192.0.2.10"
+    assert controller.quelware_port == 50052
+    assert controller.client_mode == "standalone"
+    assert controller.standalone_unit_label == "quel3-02-a01"
+
+
 def test_load_defaults_to_quel1_when_system_backend_is_missing(
     tmp_path: Path,
     monkeypatch: pytest.MonkeyPatch,


### PR DESCRIPTION
## Summary

- Expose the selected backend runtime section from `ConfigLoader`.
- Let `SystemManager` pass QuEL-3 runtime settings into the default `Quel3BackendController`.
- Preserve explicit `backend_controller` injection as the highest-priority path.
- Add regression coverage for copied runtime config and default controller creation.

## Impact

QuEL-3 sessions can now use `system.yaml` values for `endpoint`, `port`, `client_mode`, and `standalone_unit_label` without requiring callers to construct and pass a backend controller manually.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`