### PR TITLE
feat(quel3): preserve raw waveform captures

### DIFF
--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -468,6 +468,7 @@ class Quel3ExecutionManager:
                 capture_samples = self._extract_capture_samples(
                     result,
                     window_key,
+                    capture_mode=payload.capture_mode,
                 )
                 if capture_samples is None:
                     continue
@@ -840,6 +841,8 @@ class Quel3ExecutionManager:
     def _extract_capture_samples(
         result: ResultContainerProtocol,
         window_key: str,
+        *,
+        capture_mode: Quel3CaptureMode,
     ) -> np.ndarray | None:
         """Extract one capture sample-array from a result container entry."""
         values = result.iq_result.get(window_key)
@@ -847,6 +850,13 @@ class Quel3ExecutionManager:
             return None
         first = values[0]
         if _has_iq_array(first):
+            if capture_mode is Quel3CaptureMode.RAW_WAVEFORMS:
+                waveforms = []
+                for value in values:
+                    if not _has_iq_array(value):
+                        return None
+                    waveforms.append(np.asarray(value.iq_array, dtype=np.complex128))
+                return np.stack(waveforms, axis=0)
             latest = values[-1]
             if not _has_iq_array(latest):
                 return None

--- a/src/qubex/measurement/adapters/quel3_backend_adapter.py
+++ b/src/qubex/measurement/adapters/quel3_backend_adapter.py
@@ -330,6 +330,7 @@ class Quel3MeasurementBackendAdapter:
             Quel3CaptureMode.AVERAGED_VALUE,
             Quel3CaptureMode.AVERAGED_WAVEFORM,
             Quel3CaptureMode.VALUES_PER_ITER,
+            Quel3CaptureMode.RAW_WAVEFORMS,
         ):
             return shots
         return 1

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -247,10 +247,49 @@ def test_extract_capture_samples_from_waveform_result_container() -> None:
                 ]
             }
 
-    values = Quel3ExecutionManager._extract_capture_samples(_Result(), "RQ00:0")
+    values = Quel3ExecutionManager._extract_capture_samples(
+        _Result(),
+        "RQ00:0",
+        capture_mode=Quel3CaptureMode.AVERAGED_WAVEFORM,
+    )
 
     assert values is not None
     assert np.array_equal(values, np.array([2.0 + 0.0j], dtype=np.complex128))
+
+
+def test_extract_capture_samples_from_raw_waveform_result_container() -> None:
+    """Given raw waveform iq_result, extraction returns one waveform per shot."""
+
+    class _Waveform:
+        def __init__(self, values: np.ndarray) -> None:
+            self.iq_array = values
+
+    class _Result:
+        def __init__(self) -> None:
+            self.iq_result = {
+                "RQ00:0": [
+                    _Waveform(np.array([1.0 + 0.0j, 2.0 + 0.0j])),
+                    _Waveform(np.array([3.0 + 0.0j, 4.0 + 0.0j])),
+                ]
+            }
+
+    values = Quel3ExecutionManager._extract_capture_samples(
+        _Result(),
+        "RQ00:0",
+        capture_mode=Quel3CaptureMode.RAW_WAVEFORMS,
+    )
+
+    assert values is not None
+    assert np.array_equal(
+        values,
+        np.array(
+            [
+                [1.0 + 0.0j, 2.0 + 0.0j],
+                [3.0 + 0.0j, 4.0 + 0.0j],
+            ],
+            dtype=np.complex128,
+        ),
+    )
 
 
 def test_extract_capture_samples_from_point_result_container() -> None:
@@ -262,7 +301,11 @@ def test_extract_capture_samples_from_point_result_container() -> None:
                 "RQ00:0": [1.0 + 2.0j, 3.0 + 4.0j],
             }
 
-    values = Quel3ExecutionManager._extract_capture_samples(_Result(), "RQ00:0")
+    values = Quel3ExecutionManager._extract_capture_samples(
+        _Result(),
+        "RQ00:0",
+        capture_mode=Quel3CaptureMode.VALUES_PER_ITER,
+    )
 
     assert values is not None
     assert np.array_equal(

--- a/tests/measurement/test_quel3_measurement_backend_adapter.py
+++ b/tests/measurement/test_quel3_measurement_backend_adapter.py
@@ -320,6 +320,46 @@ def test_quel3_adapter_embeds_schedule_frequency_in_payload() -> None:
     assert payload.fixed_timelines[target].frequency_hz == pytest.approx(6.25e9)
 
 
+def test_quel3_adapter_raw_waveforms_use_one_iteration_per_shot() -> None:
+    """Given raw waveform mode, payload iterations should preserve one waveform per shot."""
+    target = "RQ00"
+    alias = "alias-RQ00"
+    schedule = MeasurementSchedule.model_construct(
+        pulse_schedule=_FakePulseSchedule(
+            duration=1.2,
+            sequences={
+                target: _pulse_array(
+                    values=np.array([0.0 + 0.0j], dtype=np.complex128),
+                    sampling_period=0.4,
+                )
+            },
+        ),
+        capture_schedule=CaptureSchedule(
+            captures=[
+                Capture(
+                    channels=[target],
+                    start_time=0.4,
+                    duration=0.8,
+                ),
+            ]
+        ),
+    )
+    config = _make_config(mode="single", shots=3, time_integration=False)
+    adapter = Quel3MeasurementBackendAdapter(
+        backend_controller=_make_backend_controller(),
+        experiment_system=cast(Any, _FakeExperimentSystem()),
+        constraint_profile=MeasurementConstraintProfile.quel3(0.4),
+        instrument_alias_map={target: alias},
+    )
+
+    request = adapter.build_execution_request(schedule=schedule, config=config)
+
+    payload = request.payload
+    assert isinstance(payload, Quel3ExecutionPayload)
+    assert payload.capture_mode is Quel3CaptureMode.RAW_WAVEFORMS
+    assert payload.n_iterations == 3
+
+
 def test_quel3_adapter_falls_back_to_target_frequency_in_payload() -> None:
     """Given target frequency metadata, when schedule frequency is absent, then timeline frequency uses target frequency."""
     target = "RQ00"
@@ -1098,6 +1138,73 @@ def test_quel3_adapter_build_measurement_result_normalizes_iq_series_to_1d() -> 
     assert np.array_equal(
         result.data["Q00"][0].data,
         np.array([8.0 + 4.0j, 12.0 + 6.0j], dtype=np.complex128),
+    )
+
+
+def test_quel3_adapter_build_measurement_result_accepts_raw_waveform_series() -> None:
+    """Given raw waveform data, adapter conversion should keep the shot axis."""
+    target = "RQ00"
+    alias = "alias-RQ00"
+    schedule = MeasurementSchedule.model_construct(
+        pulse_schedule=_FakePulseSchedule(
+            duration=1.2,
+            sequences={
+                target: _pulse_array(
+                    values=np.array([0.0 + 0.0j], dtype=np.complex128),
+                    sampling_period=0.4,
+                )
+            },
+        ),
+        capture_schedule=CaptureSchedule(
+            captures=[
+                Capture(
+                    channels=[target],
+                    start_time=0.4,
+                    duration=0.8,
+                ),
+            ]
+        ),
+    )
+    config = _make_config(mode="single", shots=2, time_integration=False)
+    backend_result = Quel3BackendExecutionResult(
+        status={},
+        data={
+            alias: [
+                np.array(
+                    [
+                        [8.0 + 4.0j, 10.0 + 5.0j],
+                        [12.0 + 6.0j, 14.0 + 7.0j],
+                    ],
+                    dtype=np.complex128,
+                )
+            ],
+        },
+        config={"sampling_period_ns": 0.8},
+    )
+    adapter = Quel3MeasurementBackendAdapter(
+        backend_controller=_make_backend_controller(),
+        experiment_system=cast(Any, _FakeExperimentSystem()),
+        constraint_profile=MeasurementConstraintProfile.quel3(0.4),
+        instrument_alias_map={target: alias},
+    )
+    _ = adapter.build_execution_request(schedule=schedule, config=config)
+
+    result = adapter.build_measurement_result(
+        backend_result=backend_result,
+        measurement_config=config,
+        device_config={},
+        sampling_period=1.0,
+    )
+
+    assert np.array_equal(
+        result.data["Q00"][0].data,
+        np.array(
+            [
+                [8.0 + 4.0j, 10.0 + 5.0j],
+                [12.0 + 6.0j, 14.0 + 7.0j],
+            ],
+            dtype=np.complex128,
+        ),
     )
 
 


### PR DESCRIPTION
## Summary

- Thread the requested QuEL-3 capture mode into backend result extraction.
- Preserve one waveform array per shot for `RAW_WAVEFORMS` instead of collapsing waveform results to the latest entry.
- Treat `RAW_WAVEFORMS` as a shot-preserving mode in the measurement adapter.
- Add backend extraction and measurement-result conversion regression tests.

## Impact

QuEL-3 raw waveform capture results keep their shot axis, matching the capture mode contract expected by waveform inspection flows.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`