### PR TITLE
docs(quel3): clarify instrument deploy ownership

### DIFF
--- a/src/qubex/backend/quel3/managers/configuration_manager.py
+++ b/src/qubex/backend/quel3/managers/configuration_manager.py
@@ -330,11 +330,8 @@ class Quel3ConfigurationManager:
         inst_infos = await session.deploy_instruments(
             port_id,
             definitions=definitions,
-            # Temporary limitation:
-            # quelware-client Session.deploy_instruments currently removes all
-            # instruments on the port even with append=True. Treat QuEL-3
-            # deploy as replacement-style semantics and pass append=False
-            # explicitly.
+            # Qubex push treats the current target registry as the source of
+            # truth for this port's selected instruments.
             append=False,
         )
         infos_by_alias: dict[str, list[InstrumentInfoProtocol]] = defaultdict(list)

--- a/src/qubex/system/quel3/quel3_system_synchronizer.py
+++ b/src/qubex/system/quel3/quel3_system_synchronizer.py
@@ -71,6 +71,9 @@ class Quel3SystemSynchronizer:
             box_ids=box_ids,
             target_labels=target_labels,
         )
+        # Treat QuEL-3 instrument deploy as the push-time hardware sync
+        # equivalent of QuEL-1 CNCO/FNCO updates. Execution paths should only
+        # resolve and use the instruments that push configured.
         self._backend_controller.deploy_instruments(
             requests=requests,
             parallel=True if parallel is None else parallel,


### PR DESCRIPTION
## Summary

- Update QuEL-3 source comments around instrument deployment.
- Describe deploy as push-time hardware synchronization driven by the current target registry.
- Keep `append=False` behavior unchanged while removing stale temporary-limitation wording.

## Impact

No runtime behavior changes. The comments now document the intended ownership boundary between QuEL-3 push synchronization and execution-time instrument resolution.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`