### PR TITLE
feat(quel3): accept quelware PAT file paths

### DIFF
--- a/src/qubex/backend/quel3/infra/quelware_imports.py
+++ b/src/qubex/backend/quel3/infra/quelware_imports.py
@@ -4,8 +4,9 @@ from __future__ import annotations
 
 import importlib
 import logging
-from collections.abc import Iterator
+from collections.abc import Callable, Iterator
 from contextlib import contextmanager
+from pathlib import Path
 from typing import Any, Final, Literal, cast
 
 from qubex.backend.quel3.interfaces import QuelwareClientFactory
@@ -48,13 +49,17 @@ def _create_standalone_client_safely(
     endpoint: str,
     port: int,
     unit_label: str | None,
+    pat: Callable[[], str] | None,
 ):
     """Create standalone client while suppressing the repeated testing notice."""
     with _suppress_standalone_notice():
+        kwargs: dict[str, object] = {"unit_label": unit_label}
+        if pat is not None:
+            kwargs["pat"] = pat
         return client_module.create_standalone_client(
             endpoint,
             port,
-            unit_label=unit_label,
+            **kwargs,
         )
 
 
@@ -91,6 +96,7 @@ def load_quelware_client_factory(
     *,
     client_mode: Quel3ClientMode,
     standalone_unit_label: str | None,
+    pat_path: str | None = None,
 ) -> QuelwareClientFactory:
     """Load one quelware client factory for the configured runtime mode."""
     normalized_client_mode = validate_quelware_client_runtime(
@@ -98,7 +104,20 @@ def load_quelware_client_factory(
         standalone_unit_label=standalone_unit_label,
     )
     client_module = importlib.import_module("quelware_client.client")
+    pat_provider: Callable[[], str] | None = None
+    if pat_path is not None:
+        path = Path(pat_path)
+        pat_provider = lambda: path.read_text(encoding="utf-8").rstrip("\r\n")
     if normalized_client_mode == "server":
+        if pat_provider is not None:
+            return cast(
+                QuelwareClientFactory,
+                lambda endpoint, port: client_module.create_quelware_client(
+                    endpoint,
+                    port,
+                    pat=pat_provider,
+                ),
+            )
         return cast(QuelwareClientFactory, client_module.create_quelware_client)
     unit_label = standalone_unit_label
     return cast(
@@ -108,5 +127,6 @@ def load_quelware_client_factory(
             endpoint=endpoint,
             port=port,
             unit_label=unit_label,
+            pat=pat_provider,
         ),
     )

--- a/src/qubex/backend/quel3/managers/configuration_manager.py
+++ b/src/qubex/backend/quel3/managers/configuration_manager.py
@@ -119,6 +119,7 @@ class Quel3ConfigurationManager:
         quelware_port: int,
         client_mode: Quel3ClientMode = "server",
         standalone_unit_label: str | None = None,
+        quelware_pat_path: str | None = None,
     ) -> None:
         normalized_client_mode = validate_quelware_client_runtime(
             client_mode=client_mode,
@@ -128,6 +129,7 @@ class Quel3ConfigurationManager:
         self._quelware_port = quelware_port
         self._client_mode: Quel3ClientMode = normalized_client_mode
         self._standalone_unit_label = standalone_unit_label
+        self._quelware_pat_path = quelware_pat_path
         self._last_deployed_instrument_infos: dict[
             str, tuple[InstrumentInfoProtocol, ...]
         ] = {}
@@ -152,6 +154,11 @@ class Quel3ConfigurationManager:
     def standalone_unit_label(self) -> str | None:
         """Return configured standalone unit label."""
         return self._standalone_unit_label
+
+    @property
+    def quelware_pat_path(self) -> str | None:
+        """Return configured quelware personal access token path."""
+        return self._quelware_pat_path
 
     @property
     def last_deployed_instrument_infos(
@@ -449,6 +456,7 @@ class Quel3ConfigurationManager:
         return load_quelware_client_factory(
             client_mode=self._client_mode,
             standalone_unit_label=self._standalone_unit_label,
+            pat_path=self._quelware_pat_path,
         )
 
     @staticmethod

--- a/src/qubex/backend/quel3/managers/connection_manager.py
+++ b/src/qubex/backend/quel3/managers/connection_manager.py
@@ -36,6 +36,7 @@ class Quel3ConnectionManager:
         quelware_port: int,
         client_mode: Quel3ClientMode = "server",
         standalone_unit_label: str | None = None,
+        quelware_pat_path: str | None = None,
     ) -> None:
         normalized_client_mode = validate_quelware_client_runtime(
             client_mode=client_mode,
@@ -46,6 +47,7 @@ class Quel3ConnectionManager:
         self._quelware_port = quelware_port
         self._client_mode: Quel3ClientMode = normalized_client_mode
         self._standalone_unit_label = standalone_unit_label
+        self._quelware_pat_path = quelware_pat_path
 
     @property
     def hash(self) -> int:
@@ -57,6 +59,7 @@ class Quel3ConnectionManager:
                 self._quelware_port,
                 self._client_mode,
                 self._standalone_unit_label,
+                self._quelware_pat_path,
             )
         )
 
@@ -84,6 +87,11 @@ class Quel3ConnectionManager:
     def standalone_unit_label(self) -> str | None:
         """Return configured standalone unit label."""
         return self._standalone_unit_label
+
+    @property
+    def quelware_pat_path(self) -> str | None:
+        """Return configured quelware personal access token path."""
+        return self._quelware_pat_path
 
     def connect(
         self,
@@ -122,4 +130,5 @@ class Quel3ConnectionManager:
         return load_quelware_client_factory(
             client_mode=self._client_mode,
             standalone_unit_label=self._standalone_unit_label,
+            pat_path=self._quelware_pat_path,
         )

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -92,6 +92,7 @@ class Quel3ExecutionManager:
         capture_decimation_factor: int,
         client_mode: Quel3ClientMode = "server",
         standalone_unit_label: str | None = None,
+        quelware_pat_path: str | None = None,
         session_manager: Quel3SessionManager | None = None,
     ) -> None:
         normalized_client_mode = validate_quelware_client_runtime(
@@ -104,6 +105,7 @@ class Quel3ExecutionManager:
         self._capture_decimation_factor = capture_decimation_factor
         self._client_mode: Quel3ClientMode = normalized_client_mode
         self._standalone_unit_label = standalone_unit_label
+        self._quelware_pat_path = quelware_pat_path
         self._sequencer_builder = Quel3SequencerBuilder()
         self._session_manager = (
             session_manager
@@ -113,6 +115,7 @@ class Quel3ExecutionManager:
                 quelware_port=quelware_port,
                 client_mode=normalized_client_mode,
                 standalone_unit_label=standalone_unit_label,
+                quelware_pat_path=quelware_pat_path,
             )
         )
 
@@ -140,6 +143,11 @@ class Quel3ExecutionManager:
     def standalone_unit_label(self) -> str | None:
         """Return configured standalone unit label."""
         return self._standalone_unit_label
+
+    @property
+    def quelware_pat_path(self) -> str | None:
+        """Return configured quelware personal access token path."""
+        return self._quelware_pat_path
 
     def execute_sync(
         self,
@@ -931,6 +939,7 @@ class Quel3ExecutionManager:
         create_quelware_client: QuelwareClientFactory = load_quelware_client_factory(
             client_mode=self._client_mode,
             standalone_unit_label=self._standalone_unit_label,
+            pat_path=self._quelware_pat_path,
         )
         instrument_resolver_factory: InstrumentResolverFactory = (
             resolver_module.InstrumentResolver

--- a/src/qubex/backend/quel3/managers/session_manager.py
+++ b/src/qubex/backend/quel3/managers/session_manager.py
@@ -28,6 +28,7 @@ class Quel3SessionManager:
         quelware_port: int,
         client_mode: Quel3ClientMode = "server",
         standalone_unit_label: str | None = None,
+        quelware_pat_path: str | None = None,
     ) -> None:
         normalized_client_mode = validate_quelware_client_runtime(
             client_mode=client_mode,
@@ -37,6 +38,7 @@ class Quel3SessionManager:
         self._quelware_port = quelware_port
         self._client_mode: Quel3ClientMode = normalized_client_mode
         self._standalone_unit_label = standalone_unit_label
+        self._quelware_pat_path = quelware_pat_path
         self._client_cm = None
         self._client: QuelwareClientProtocol | None = None
         self._session_cm = None
@@ -62,6 +64,11 @@ class Quel3SessionManager:
     def standalone_unit_label(self) -> str | None:
         """Return configured standalone unit label."""
         return self._standalone_unit_label
+
+    @property
+    def quelware_pat_path(self) -> str | None:
+        """Return configured quelware personal access token path."""
+        return self._quelware_pat_path
 
     @property
     def is_open(self) -> bool:
@@ -161,4 +168,5 @@ class Quel3SessionManager:
         return load_quelware_client_factory(
             client_mode=self._client_mode,
             standalone_unit_label=self._standalone_unit_label,
+            pat_path=self._quelware_pat_path,
         )

--- a/src/qubex/backend/quel3/quel3_backend_controller.py
+++ b/src/qubex/backend/quel3/quel3_backend_controller.py
@@ -54,6 +54,7 @@ class Quel3BackendController(BackendController):
         quelware_port: int | None = None,
         client_mode: Quel3ClientMode | None = None,
         standalone_unit_label: str | None = None,
+        quelware_pat_path: str | None = None,
         connection_manager: Quel3ConnectionManager | None = None,
         session_manager: Quel3SessionManager | None = None,
         configuration_manager: Quel3ConfigurationManager | None = None,
@@ -149,6 +150,21 @@ class Quel3BackendController(BackendController):
             client_mode=resolved_client_mode,
             standalone_unit_label=resolved_standalone_unit_label,
         )
+        resolved_quelware_pat_path = self._resolve_optional_runtime_value(
+            name="quelware_pat_path",
+            explicit_value=quelware_pat_path,
+            candidates=[
+                getattr(manager, "quelware_pat_path", None)
+                for manager in (
+                    connection_manager,
+                    session_manager,
+                    configuration_manager,
+                    execution_manager,
+                )
+                if manager is not None
+            ],
+            default=None,
+        )
         self._sampling_period_ns = (
             execution_manager.sampling_period_ns
             if execution_manager is not None
@@ -158,6 +174,7 @@ class Quel3BackendController(BackendController):
         self._quelware_port = port
         self._client_mode: Quel3ClientMode = resolved_client_mode
         self._standalone_unit_label = resolved_standalone_unit_label
+        self._quelware_pat_path = resolved_quelware_pat_path
 
         self._connection_manager = (
             connection_manager
@@ -167,6 +184,7 @@ class Quel3BackendController(BackendController):
                 quelware_port=port,
                 client_mode=resolved_client_mode,
                 standalone_unit_label=resolved_standalone_unit_label,
+                quelware_pat_path=resolved_quelware_pat_path,
             )
         )
         self._session_manager = (
@@ -177,6 +195,7 @@ class Quel3BackendController(BackendController):
                 quelware_port=port,
                 client_mode=resolved_client_mode,
                 standalone_unit_label=resolved_standalone_unit_label,
+                quelware_pat_path=resolved_quelware_pat_path,
             )
         )
         self._configuration_manager = (
@@ -187,6 +206,7 @@ class Quel3BackendController(BackendController):
                 quelware_port=port,
                 client_mode=resolved_client_mode,
                 standalone_unit_label=resolved_standalone_unit_label,
+                quelware_pat_path=resolved_quelware_pat_path,
             )
         )
         self._execution_manager = (
@@ -199,6 +219,7 @@ class Quel3BackendController(BackendController):
                 capture_decimation_factor=self.CAPTURE_DECIMATION_FACTOR,
                 client_mode=resolved_client_mode,
                 standalone_unit_label=resolved_standalone_unit_label,
+                quelware_pat_path=resolved_quelware_pat_path,
                 session_manager=self._session_manager,
             )
         )
@@ -288,6 +309,11 @@ class Quel3BackendController(BackendController):
     def standalone_unit_label(self) -> str | None:
         """Return configured standalone unit label."""
         return self._standalone_unit_label
+
+    @property
+    def quelware_pat_path(self) -> str | None:
+        """Return configured quelware personal access token path."""
+        return self._quelware_pat_path
 
     @property
     def configuration_manager(self) -> Quel3ConfigurationManager:

--- a/src/qubex/system/system_manager.py
+++ b/src/qubex/system/system_manager.py
@@ -197,6 +197,11 @@ class SystemManager:
             backend_runtime_config,
             "standalone_unit_label",
         )
+        quelware_pat_path = SystemManager._get_runtime_config_value(
+            backend_runtime_config,
+            "quelware_pat_path",
+            "pat_path",
+        )
         if endpoint is not None:
             kwargs["quelware_endpoint"] = endpoint
         if port is not None:
@@ -205,6 +210,8 @@ class SystemManager:
             kwargs["client_mode"] = client_mode
         if standalone_unit_label is not None:
             kwargs["standalone_unit_label"] = standalone_unit_label
+        if quelware_pat_path is not None:
+            kwargs["quelware_pat_path"] = quelware_pat_path
         return kwargs
 
     @staticmethod

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -302,6 +302,18 @@ def test_constructor_accepts_standalone_runtime_options() -> None:
     assert controller.execution_manager.client_mode == "standalone"
 
 
+def test_constructor_accepts_quelware_pat_path_runtime_option() -> None:
+    """Given PAT path runtime option, controller should propagate only the path."""
+    pat_path = "/run/secrets/quelware-pat"
+    controller = Quel3BackendController(quelware_pat_path=pat_path)
+
+    assert controller.quelware_pat_path == pat_path
+    assert controller.connection_manager.quelware_pat_path == pat_path
+    assert controller.session_manager.quelware_pat_path == pat_path
+    assert controller.configuration_manager.quelware_pat_path == pat_path
+    assert controller.execution_manager.quelware_pat_path == pat_path
+
+
 def test_constructor_rejects_standalone_mode_without_unit_label() -> None:
     """Given standalone mode without unit label, controller construction should fail fast."""
     with pytest.raises(ValueError, match="standalone_unit_label"):
@@ -317,6 +329,7 @@ def test_constructor_accepts_injected_managers() -> None:
         quelware_port=61000,
         client_mode="standalone",
         standalone_unit_label="quel3-02-a01",
+        quelware_pat_path="/run/secrets/quelware-pat",
         connect=lambda box_names=None, parallel=None: None,
         disconnect=lambda: None,
     )
@@ -326,6 +339,7 @@ def test_constructor_accepts_injected_managers() -> None:
         quelware_port=61000,
         client_mode="standalone",
         standalone_unit_label="quel3-02-a01",
+        quelware_pat_path="/run/secrets/quelware-pat",
         open=lambda box_names=None, parallel=None: None,
         close=lambda: None,
     )
@@ -334,6 +348,7 @@ def test_constructor_accepts_injected_managers() -> None:
         quelware_port=61000,
         client_mode="standalone",
         standalone_unit_label="quel3-02-a01",
+        quelware_pat_path="/run/secrets/quelware-pat",
         target_alias_map={"Q00": "Q00"},
         last_deployed_instrument_infos={"Q00": (object(),)},
         deploy_instruments=lambda *, requests: {"Q00": tuple(requests)},
@@ -344,6 +359,7 @@ def test_constructor_accepts_injected_managers() -> None:
         sampling_period_ns=0.8,
         client_mode="standalone",
         standalone_unit_label="quel3-02-a01",
+        quelware_pat_path="/run/secrets/quelware-pat",
         execute_sync=lambda *, request: request,
         execute_async=lambda *, request: request,
     )
@@ -364,6 +380,7 @@ def test_constructor_accepts_injected_managers() -> None:
     assert controller.sampling_period_ns == pytest.approx(0.8)
     assert controller.client_mode == "standalone"
     assert controller.standalone_unit_label == "quel3-02-a01"
+    assert controller.quelware_pat_path == "/run/secrets/quelware-pat"
 
 
 def test_constructor_accepts_injected_session_manager() -> None:
@@ -374,6 +391,7 @@ def test_constructor_accepts_injected_session_manager() -> None:
         quelware_port=61000,
         client_mode="standalone",
         standalone_unit_label="quel3-02-a01",
+        quelware_pat_path=None,
         open=lambda box_names=None, parallel=None: None,
         close=lambda: None,
     )
@@ -395,6 +413,7 @@ def test_connect_refreshes_existing_instrument_cache() -> None:
         quelware_port=50051,
         client_mode="server",
         standalone_unit_label=None,
+        quelware_pat_path=None,
         connect=lambda box_names=None, parallel=None: calls.append("connect"),
         disconnect=lambda: None,
     )
@@ -403,6 +422,7 @@ def test_connect_refreshes_existing_instrument_cache() -> None:
         quelware_port=50051,
         client_mode="server",
         standalone_unit_label=None,
+        quelware_pat_path=None,
         target_alias_map={},
         last_deployed_instrument_infos={},
         refresh_instrument_cache=lambda: calls.append("refresh") or {},
@@ -436,6 +456,7 @@ def test_deploy_instruments_forwards_parallel_flag_to_configuration_manager() ->
                 quelware_port=50051,
                 client_mode="server",
                 standalone_unit_label=None,
+                quelware_pat_path=None,
                 target_alias_map={},
                 last_deployed_instrument_infos={},
                 deploy_instruments=_deploy_instruments,
@@ -466,6 +487,9 @@ def test_constructor_rejects_mismatched_injected_manager_runtime_values() -> Non
         is_connected=False,
         quelware_endpoint="host-a",
         quelware_port=50051,
+        client_mode="server",
+        standalone_unit_label=None,
+        quelware_pat_path=None,
         connect=lambda box_names=None, parallel=None: None,
         disconnect=lambda: None,
     )
@@ -474,6 +498,7 @@ def test_constructor_rejects_mismatched_injected_manager_runtime_values() -> Non
         quelware_port=50051,
         client_mode="server",
         standalone_unit_label=None,
+        quelware_pat_path=None,
         target_alias_map={},
         last_deployed_instrument_infos={},
         deploy_instruments=lambda *, requests: {},
@@ -495,6 +520,7 @@ def test_constructor_rejects_mismatched_injected_client_runtime_values() -> None
         quelware_port=50051,
         client_mode="server",
         standalone_unit_label=None,
+        quelware_pat_path=None,
         connect=lambda box_names=None, parallel=None: None,
         disconnect=lambda: None,
     )
@@ -503,6 +529,7 @@ def test_constructor_rejects_mismatched_injected_client_runtime_values() -> None
         quelware_port=50051,
         client_mode="standalone",
         standalone_unit_label="quel3-02-a01",
+        quelware_pat_path=None,
         target_alias_map={},
         last_deployed_instrument_infos={},
         deploy_instruments=lambda *, requests: {},

--- a/tests/backend/test_quel3_client_factory.py
+++ b/tests/backend/test_quel3_client_factory.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+from collections.abc import Callable
 from types import SimpleNamespace
 
 import pytest
@@ -51,6 +52,49 @@ def test_load_client_factory_returns_server_client(
     assert client_factory is create_quelware_client
 
 
+def test_load_client_factory_binds_pat_for_server_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Given PAT path, loading the server client factory should pass a file-backed provider."""
+    captured: dict[str, object] = {}
+    pat_path = tmp_path / "pat.txt"
+    pat_path.write_text("dummy-token\n", encoding="utf-8")
+
+    def _create_quelware_client(
+        endpoint: str,
+        port: int,
+        *,
+        pat: Callable[[], str],
+    ) -> tuple[str, int]:
+        captured["endpoint"] = endpoint
+        captured["port"] = port
+        captured["pat"] = pat
+        return (endpoint, port)
+
+    monkeypatch.setattr(
+        quelware_imports_module.importlib,
+        "import_module",
+        lambda _: SimpleNamespace(
+            create_quelware_client=_create_quelware_client,
+            create_standalone_client=object(),
+        ),
+    )
+
+    client_factory = quelware_imports_module.load_quelware_client_factory(
+        client_mode="server",
+        standalone_unit_label=None,
+        pat_path=str(pat_path),
+    )
+    context_manager = client_factory("worker-host", 61000)
+
+    assert context_manager == ("worker-host", 61000)
+    pat_provider = captured.pop("pat")
+    assert callable(pat_provider)
+    assert pat_provider() == "dummy-token"
+    assert captured == {"endpoint": "worker-host", "port": 61000}
+
+
 def test_load_client_factory_binds_unit_label_for_standalone_mode(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -84,6 +128,55 @@ def test_load_client_factory_binds_unit_label_for_standalone_mode(
     context_manager = client_factory("worker-host", 61000)
 
     assert context_manager == ("worker-host", 61000, "quel3-02-a01")
+    assert captured == {
+        "endpoint": "worker-host",
+        "port": 61000,
+        "unit_label": "quel3-02-a01",
+    }
+
+
+def test_load_client_factory_binds_pat_for_standalone_mode(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Given standalone mode with PAT path, loading the factory should pass a provider."""
+    captured: dict[str, object] = {}
+    pat_path = tmp_path / "pat.txt"
+    pat_path.write_text("dummy-token\n", encoding="utf-8")
+
+    def _create_standalone_client(
+        endpoint: str,
+        port: int,
+        *,
+        unit_label: str,
+        pat: Callable[[], str],
+    ) -> tuple[str, int, str]:
+        captured["endpoint"] = endpoint
+        captured["port"] = port
+        captured["unit_label"] = unit_label
+        captured["pat"] = pat
+        return (endpoint, port, unit_label)
+
+    monkeypatch.setattr(
+        quelware_imports_module.importlib,
+        "import_module",
+        lambda _: SimpleNamespace(
+            create_quelware_client=object(),
+            create_standalone_client=_create_standalone_client,
+        ),
+    )
+
+    client_factory = quelware_imports_module.load_quelware_client_factory(
+        client_mode="standalone",
+        standalone_unit_label="quel3-02-a01",
+        pat_path=str(pat_path),
+    )
+    context_manager = client_factory("worker-host", 61000)
+
+    assert context_manager == ("worker-host", 61000, "quel3-02-a01")
+    pat_provider = captured.pop("pat")
+    assert callable(pat_provider)
+    assert pat_provider() == "dummy-token"
     assert captured == {
         "endpoint": "worker-host",
         "port": 61000,

--- a/tests/backend/test_quel3_configuration_manager.py
+++ b/tests/backend/test_quel3_configuration_manager.py
@@ -817,11 +817,12 @@ def test_load_client_factory_uses_configured_client_runtime(
     monkeypatch.setattr(
         configuration_manager_module,
         "load_quelware_client_factory",
-        lambda *, client_mode, standalone_unit_label: (
+        lambda *, client_mode, standalone_unit_label, pat_path=None: (
             captured.update(
                 {
                     "client_mode": client_mode,
                     "standalone_unit_label": standalone_unit_label,
+                    "pat_path": pat_path,
                 }
             )
             or fake_client_factory
@@ -840,6 +841,47 @@ def test_load_client_factory_uses_configured_client_runtime(
     assert captured == {
         "client_mode": "standalone",
         "standalone_unit_label": "quel3-02-a01",
+        "pat_path": None,
+    }
+
+
+def test_load_client_factory_uses_configured_pat_path(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given PAT path runtime option, client factory loading should forward only the path."""
+    captured: dict[str, object] = {}
+    fake_client_factory = object()
+    pat_path = "/run/secrets/quelware-pat"
+
+    def _load_quelware_client_factory(
+        *,
+        client_mode: str,
+        standalone_unit_label: str | None,
+        pat_path: str,
+    ) -> object:
+        captured["client_mode"] = client_mode
+        captured["standalone_unit_label"] = standalone_unit_label
+        captured["pat_path"] = pat_path
+        return fake_client_factory
+
+    monkeypatch.setattr(
+        configuration_manager_module,
+        "load_quelware_client_factory",
+        _load_quelware_client_factory,
+    )
+    manager = Quel3ConfigurationManager(
+        quelware_endpoint="worker-host",
+        quelware_port=61000,
+        quelware_pat_path=pat_path,
+    )
+
+    client_factory = manager._load_quelware_client_factory()  # noqa: SLF001
+
+    assert client_factory is fake_client_factory
+    assert captured == {
+        "client_mode": "server",
+        "standalone_unit_label": None,
+        "pat_path": pat_path,
     }
 
 

--- a/tests/backend/test_system_manager.py
+++ b/tests/backend/test_system_manager.py
@@ -1259,6 +1259,7 @@ def test_load_creates_quel3_controller_from_runtime_config(
                 "port": 50052,
                 "client_mode": "standalone",
                 "standalone_unit_label": "quel3-02-a01",
+                "pat_path": "/run/secrets/quelware-pat",
             }
 
         def get_experiment_system(self) -> object:
@@ -1277,6 +1278,7 @@ def test_load_creates_quel3_controller_from_runtime_config(
     assert controller.quelware_port == 50052
     assert controller.client_mode == "standalone"
     assert controller.standalone_unit_label == "quel3-02-a01"
+    assert controller.quelware_pat_path == "/run/secrets/quelware-pat"
 
 
 def test_load_defaults_to_quel1_when_system_backend_is_missing(


### PR DESCRIPTION
## Summary

- Add a `quelware_pat_path` runtime option to `Quel3BackendController`.
- Propagate the path through QuEL-3 connection, session, configuration, and execution managers.
- Load the token lazily from the configured file path and pass a provider to `quelware-client` in both server and standalone modes.
- Allow `system.yaml` runtime config to use either `quelware_pat_path` or `pat_path` after the backend runtime config plumbing is present.

## Dependency

This PR is stacked on #266 (`feat(quel3): build controller from system config`) but still targets `quel3` as requested. Until #266 is merged, GitHub will show that prerequisite commit in this PR's diff. After #266 is merged with its commit preserved, this PR should shrink to the PAT path changes only.

## Impact

Users can provide a file path for the quelware personal access token without storing the token value in Qubex runtime state.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`