### PR TITLE
fix(quel3): retry and annotate quelware session failures

### DIFF
--- a/src/qubex/backend/quel3/managers/configuration_manager.py
+++ b/src/qubex/backend/quel3/managers/configuration_manager.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import logging
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Mapping, Sequence
 from dataclasses import dataclass
@@ -24,12 +25,17 @@ from qubex.backend.quel3.interfaces.client import (
 )
 from qubex.backend.quel3.managers.session_workarounds import (
     QUELWARE_SESSION_REQUEST_MAX_ATTEMPTS,
+    QuelwareSessionError,
     enter_quelware_session_with_resource_retry,
+    quelware_exception_summary,
+    quelware_session_token,
 )
 from qubex.backend.quel3.models import InstrumentDeployRequest
 from qubex.core.async_bridge import DEFAULT_TIMEOUT_SECONDS, get_shared_async_bridge
 
 T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
 
 
 class _FixedTimelineProfileFactory(Protocol):
@@ -288,11 +294,20 @@ class Quel3ConfigurationManager:
                     instrument_mode=instrument_mode,
                     instrument_role=instrument_role,
                     parallel=parallel,
+                    attempt=attempt + 1,
+                    max_attempts=QUELWARE_SESSION_REQUEST_MAX_ATTEMPTS,
                 )
                 break
-            except Exception:
+            except Exception as exc:
                 if attempt + 1 >= QUELWARE_SESSION_REQUEST_MAX_ATTEMPTS:
-                    raise
+                    if isinstance(exc, QuelwareSessionError):
+                        raise
+                    missing_session_id = "<unavailable>"
+                    raise QuelwareSessionError(
+                        "QuEL-3 quelware deploy request failed after retries",
+                        session_token=missing_session_id,
+                        cause=exc,
+                    ) from exc
         else:
             raise RuntimeError("unreachable QuEL-3 deploy retry state")
 
@@ -318,6 +333,8 @@ class Quel3ConfigurationManager:
         instrument_mode: _EnumNamespace,
         instrument_role: _EnumNamespace,
         parallel: bool,
+        attempt: int,
+        max_attempts: int,
     ) -> list[_PortDeployResult]:
         """Deploy port batches in one quelware client/session context."""
         async with client_factory(
@@ -329,6 +346,7 @@ class Quel3ConfigurationManager:
                 client=client,
                 resource_ids=session_resource_ids,
             )
+            session_token = quelware_session_token(session)
             try:
                 deploy_coroutines = [
                     self._deploy_port_batch(
@@ -347,8 +365,32 @@ class Quel3ConfigurationManager:
                     if parallel
                     else [await coro for coro in deploy_coroutines]
                 )
+            except Exception as exc:
+                if attempt >= max_attempts:
+                    raise QuelwareSessionError(
+                        "QuEL-3 quelware deploy request failed after retries",
+                        session_token=session_token,
+                        cause=exc,
+                    ) from exc
+                logger.warning(
+                    "QuEL-3 quelware deploy request failed; session_token=%s; "
+                    "attempt=%d/%d; retrying with a fresh session; cause=%s",
+                    session_token,
+                    attempt,
+                    max_attempts,
+                    quelware_exception_summary(exc),
+                )
+                raise
             finally:
-                await session_cm.__aexit__(None, None, None)
+                try:
+                    await session_cm.__aexit__(None, None, None)
+                except Exception as exc:
+                    logger.warning(
+                        "QuEL-3 quelware deploy session cleanup failed; "
+                        "session_token=%s; cause=%s",
+                        session_token,
+                        quelware_exception_summary(exc),
+                    )
 
     async def _deploy_port_batch(
         self,

--- a/src/qubex/backend/quel3/managers/configuration_manager.py
+++ b/src/qubex/backend/quel3/managers/configuration_manager.py
@@ -22,6 +22,10 @@ from qubex.backend.quel3.interfaces.client import (
     ResourceInfoProtocol,
     SessionProtocol,
 )
+from qubex.backend.quel3.managers.session_workarounds import (
+    QUELWARE_SESSION_REQUEST_MAX_ATTEMPTS,
+    enter_quelware_session_with_resource_retry,
+)
 from qubex.backend.quel3.models import InstrumentDeployRequest
 from qubex.core.async_bridge import DEFAULT_TIMEOUT_SECONDS, get_shared_async_bridge
 
@@ -273,12 +277,59 @@ class Quel3ConfigurationManager:
             (port_id, tuple(port_requests))
             for port_id, port_requests in requests_by_port.items()
         )
+        port_results: list[_PortDeployResult]
+        for attempt in range(QUELWARE_SESSION_REQUEST_MAX_ATTEMPTS):
+            try:
+                port_results = await self._deploy_port_batches(
+                    client_factory=client_factory,
+                    port_request_batches=port_request_batches,
+                    fixed_timeline_profile_cls=fixed_timeline_profile_cls,
+                    instrument_definition_cls=instrument_definition_cls,
+                    instrument_mode=instrument_mode,
+                    instrument_role=instrument_role,
+                    parallel=parallel,
+                )
+                break
+            except Exception:
+                if attempt + 1 >= QUELWARE_SESSION_REQUEST_MAX_ATTEMPTS:
+                    raise
+        else:
+            raise RuntimeError("unreachable QuEL-3 deploy retry state")
+
+        for port_result in port_results:
+            deployed.update(port_result.deployed)
+            target_alias_map.update(port_result.target_alias_map)
+
+        self._last_deployed_instrument_infos = dict(deployed)
+        # Keep local alias/instrument cache aligned with the explicitly deployed
+        # subset so it matches this replacement-style call behavior.
+        self._target_alias_map = target_alias_map
+        return deployed
+
+    async def _deploy_port_batches(
+        self,
+        *,
+        client_factory: QuelwareClientFactory,
+        port_request_batches: tuple[
+            tuple[str, tuple[InstrumentDeployRequest, ...]], ...
+        ],
+        fixed_timeline_profile_cls: _FixedTimelineProfileFactory,
+        instrument_definition_cls: _InstrumentDefinitionFactory,
+        instrument_mode: _EnumNamespace,
+        instrument_role: _EnumNamespace,
+        parallel: bool,
+    ) -> list[_PortDeployResult]:
+        """Deploy port batches in one quelware client/session context."""
         async with client_factory(
             self._quelware_endpoint,
             self._quelware_port,
         ) as client:
             session_resource_ids = [port_id for port_id, _ in port_request_batches]
-            async with client.create_session(session_resource_ids) as session:
+            session_cm, session = await enter_quelware_session_with_resource_retry(
+                client=client,
+                resource_ids=session_resource_ids,
+            )
+            try:
                 deploy_coroutines = [
                     self._deploy_port_batch(
                         session=session,
@@ -291,21 +342,13 @@ class Quel3ConfigurationManager:
                     )
                     for port_id, port_requests in port_request_batches
                 ]
-                port_results = (
-                    await asyncio.gather(*deploy_coroutines)
+                return (
+                    list(await asyncio.gather(*deploy_coroutines))
                     if parallel
                     else [await coro for coro in deploy_coroutines]
                 )
-
-        for port_result in port_results:
-            deployed.update(port_result.deployed)
-            target_alias_map.update(port_result.target_alias_map)
-
-        self._last_deployed_instrument_infos = dict(deployed)
-        # Keep local alias/instrument cache aligned with the explicitly deployed
-        # subset so it matches this replacement-style call behavior.
-        self._target_alias_map = target_alias_map
-        return deployed
+            finally:
+                await session_cm.__aexit__(None, None, None)
 
     async def _deploy_port_batch(
         self,

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -6,8 +6,9 @@ import asyncio
 import importlib
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
+from contextlib import suppress
 from dataclasses import dataclass, replace
-from typing import TypeGuard, TypeVar
+from typing import TypeGuard, TypeVar, cast
 
 import numpy as np
 
@@ -47,6 +48,8 @@ from qubex.backend.quel3.models import (
 from qubex.core.async_bridge import DEFAULT_TIMEOUT_SECONDS, get_shared_async_bridge
 
 T = TypeVar("T")
+
+QUEL3_SESSION_REQUEST_MAX_ATTEMPTS = 4
 
 
 def _run_async(
@@ -202,53 +205,19 @@ class Quel3ExecutionManager:
                 "quelware-client is not available. Install compatible quelware packages or configure PYTHONPATH."
             ) from exc
 
-        runtime, first_resolved_payload = await self._open_execution_runtime(
-            payload=payloads[0],
-            create_quelware_client=create_quelware_client,
-            instrument_resolver_factory=instrument_resolver_factory,
-            create_instrument_driver_fixed_timeline=create_instrument_driver_fixed_timeline,
-        )
-        results: list[Quel3BackendExecutionResult] = []
-        try:
-            expected_aliases = tuple(sorted(first_resolved_payload.fixed_timelines))
-            results.append(
-                await self._execute_resolved_payload(
-                    payload=first_resolved_payload,
-                    runtime=runtime,
-                    sequencer_factory=sequencer_factory,
-                    capture_mode_enum=capture_mode_enum,
-                    set_frequency_factory=set_frequency_factory,
-                    set_capture_mode_factory=set_capture_mode_factory,
-                    parallel=parallel,
-                )
+        return await self._run_with_session_request_retry(
+            lambda: self._execute_batch_once(
+                payloads=payloads,
+                create_quelware_client=create_quelware_client,
+                instrument_resolver_factory=instrument_resolver_factory,
+                sequencer_factory=sequencer_factory,
+                create_instrument_driver_fixed_timeline=create_instrument_driver_fixed_timeline,
+                capture_mode_enum=capture_mode_enum,
+                set_frequency_factory=set_frequency_factory,
+                set_capture_mode_factory=set_capture_mode_factory,
+                parallel=parallel,
             )
-            for payload in payloads[1:]:
-                resolved_payload = self._resolve_payload(
-                    payload=payload,
-                    resolver=runtime.resolver,
-                    default_unit_label=self._standalone_unit_label,
-                )
-                resolved_payload = self._filter_runnable_payload(resolved_payload)
-                resolved_aliases = tuple(sorted(resolved_payload.fixed_timelines))
-                if resolved_aliases != expected_aliases:
-                    raise ValueError(
-                        "Batched QuEL-3 execution requires all points to resolve "
-                        "to the same instrument alias set."
-                    )
-                results.append(
-                    await self._execute_resolved_payload(
-                        payload=resolved_payload,
-                        runtime=runtime,
-                        sequencer_factory=sequencer_factory,
-                        capture_mode_enum=capture_mode_enum,
-                        set_frequency_factory=set_frequency_factory,
-                        set_capture_mode_factory=set_capture_mode_factory,
-                        parallel=parallel,
-                    )
-                )
-            return results
-        finally:
-            await self._session_manager.close()
+        )
 
     async def execute(
         self,
@@ -298,15 +267,111 @@ class Quel3ExecutionManager:
                 "quelware-client is not available. Install compatible quelware packages or configure PYTHONPATH."
             ) from exc
 
+        return await self._run_with_session_request_retry(
+            lambda: self._execute_once(
+                payload=payload,
+                create_quelware_client=create_quelware_client,
+                instrument_resolver_factory=instrument_resolver_factory,
+                sequencer_factory=sequencer_factory,
+                create_instrument_driver_fixed_timeline=create_instrument_driver_fixed_timeline,
+                capture_mode_enum=capture_mode_enum,
+                set_frequency_factory=set_frequency_factory,
+                set_capture_mode_factory=set_capture_mode_factory,
+                parallel=parallel,
+            )
+        )
+
+    async def _run_with_session_request_retry(
+        self,
+        operation: Callable[[], Awaitable[T]],
+    ) -> T:
+        """Run one session request, recreating the session after failures."""
+        max_attempts = max(1, int(QUEL3_SESSION_REQUEST_MAX_ATTEMPTS))
+        for attempt in range(max_attempts):
+            succeeded, result = await self._run_session_request_attempt(
+                operation,
+                raise_on_failure=attempt + 1 >= max_attempts,
+            )
+            if succeeded:
+                return result
+        raise RuntimeError("unreachable QuEL-3 session request retry state")
+
+    async def _run_session_request_attempt(
+        self,
+        operation: Callable[[], Awaitable[T]],
+        *,
+        raise_on_failure: bool,
+    ) -> tuple[bool, T]:
+        """Run one session request attempt and always close the session manager."""
+        try:
+            result = await operation()
+        except Exception:
+            await self._close_session_manager_after_attempt()
+            if raise_on_failure:
+                raise
+            return False, cast(T, None)
+        await self._close_session_manager_after_attempt()
+        return True, result
+
+    async def _close_session_manager_after_attempt(self) -> None:
+        """Close session state without masking request success or failure."""
+        with suppress(Exception):
+            await self._session_manager.close()
+
+    async def _execute_once(
+        self,
+        *,
+        payload: Quel3ExecutionPayload,
+        create_quelware_client: QuelwareClientFactory,
+        instrument_resolver_factory: InstrumentResolverFactory,
+        sequencer_factory: Callable[..., SequencerProtocol],
+        create_instrument_driver_fixed_timeline: InstrumentDriverFactory,
+        capture_mode_enum: CaptureModeNamespaceProtocol,
+        set_frequency_factory: SetFrequencyFactory,
+        set_capture_mode_factory: SetCaptureModeFactory,
+        parallel: bool,
+    ) -> Quel3BackendExecutionResult:
+        """Execute one payload using a single fresh quelware session."""
         runtime, resolved_payload = await self._open_execution_runtime(
             payload=payload,
             create_quelware_client=create_quelware_client,
             instrument_resolver_factory=instrument_resolver_factory,
             create_instrument_driver_fixed_timeline=create_instrument_driver_fixed_timeline,
         )
-        try:
-            return await self._execute_resolved_payload(
-                payload=resolved_payload,
+        return await self._execute_resolved_payload(
+            payload=resolved_payload,
+            runtime=runtime,
+            sequencer_factory=sequencer_factory,
+            capture_mode_enum=capture_mode_enum,
+            set_frequency_factory=set_frequency_factory,
+            set_capture_mode_factory=set_capture_mode_factory,
+            parallel=parallel,
+        )
+
+    async def _execute_batch_once(
+        self,
+        *,
+        payloads: list[Quel3ExecutionPayload],
+        create_quelware_client: QuelwareClientFactory,
+        instrument_resolver_factory: InstrumentResolverFactory,
+        sequencer_factory: Callable[..., SequencerProtocol],
+        create_instrument_driver_fixed_timeline: InstrumentDriverFactory,
+        capture_mode_enum: CaptureModeNamespaceProtocol,
+        set_frequency_factory: SetFrequencyFactory,
+        set_capture_mode_factory: SetCaptureModeFactory,
+        parallel: bool,
+    ) -> list[Quel3BackendExecutionResult]:
+        """Execute one payload batch using a single fresh quelware session."""
+        runtime, first_resolved_payload = await self._open_execution_runtime(
+            payload=payloads[0],
+            create_quelware_client=create_quelware_client,
+            instrument_resolver_factory=instrument_resolver_factory,
+            create_instrument_driver_fixed_timeline=create_instrument_driver_fixed_timeline,
+        )
+        expected_aliases = tuple(sorted(first_resolved_payload.fixed_timelines))
+        results = [
+            await self._execute_resolved_payload(
+                payload=first_resolved_payload,
                 runtime=runtime,
                 sequencer_factory=sequencer_factory,
                 capture_mode_enum=capture_mode_enum,
@@ -314,8 +379,32 @@ class Quel3ExecutionManager:
                 set_capture_mode_factory=set_capture_mode_factory,
                 parallel=parallel,
             )
-        finally:
-            await self._session_manager.close()
+        ]
+        for payload in payloads[1:]:
+            resolved_payload = self._resolve_payload(
+                payload=payload,
+                resolver=runtime.resolver,
+                default_unit_label=self._standalone_unit_label,
+            )
+            resolved_payload = self._filter_runnable_payload(resolved_payload)
+            resolved_aliases = tuple(sorted(resolved_payload.fixed_timelines))
+            if resolved_aliases != expected_aliases:
+                raise ValueError(
+                    "Batched QuEL-3 execution requires all points to resolve "
+                    "to the same instrument alias set."
+                )
+            results.append(
+                await self._execute_resolved_payload(
+                    payload=resolved_payload,
+                    runtime=runtime,
+                    sequencer_factory=sequencer_factory,
+                    capture_mode_enum=capture_mode_enum,
+                    set_frequency_factory=set_frequency_factory,
+                    set_capture_mode_factory=set_capture_mode_factory,
+                    parallel=parallel,
+                )
+            )
+        return results
 
     async def _open_execution_runtime(
         self,

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -4,9 +4,9 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import logging
 from collections import defaultdict
 from collections.abc import Awaitable, Callable
-from contextlib import suppress
 from dataclasses import dataclass, replace
 from typing import TypeGuard, TypeVar, cast
 
@@ -37,6 +37,10 @@ from qubex.backend.quel3.interfaces import (
     SetFrequencyFactory,
 )
 from qubex.backend.quel3.managers.session_manager import Quel3SessionManager
+from qubex.backend.quel3.managers.session_workarounds import (
+    QuelwareSessionError,
+    quelware_exception_summary,
+)
 from qubex.backend.quel3.models import (
     Quel3BackendExecutionResult,
     Quel3CaptureMode,
@@ -50,6 +54,8 @@ from qubex.core.async_bridge import DEFAULT_TIMEOUT_SECONDS, get_shared_async_br
 T = TypeVar("T")
 
 QUEL3_SESSION_REQUEST_MAX_ATTEMPTS = 4
+
+logger = logging.getLogger(__name__)
 
 
 def _run_async(
@@ -290,7 +296,8 @@ class Quel3ExecutionManager:
         for attempt in range(max_attempts):
             succeeded, result = await self._run_session_request_attempt(
                 operation,
-                raise_on_failure=attempt + 1 >= max_attempts,
+                attempt=attempt + 1,
+                max_attempts=max_attempts,
             )
             if succeeded:
                 return result
@@ -300,23 +307,56 @@ class Quel3ExecutionManager:
         self,
         operation: Callable[[], Awaitable[T]],
         *,
-        raise_on_failure: bool,
+        attempt: int,
+        max_attempts: int,
     ) -> tuple[bool, T]:
         """Run one session request attempt and always close the session manager."""
         try:
             result = await operation()
-        except Exception:
+        except Exception as exc:
+            session_token = self._session_token_for_exception(exc)
             await self._close_session_manager_after_attempt()
-            if raise_on_failure:
-                raise
+            if attempt >= max_attempts:
+                if isinstance(exc, QuelwareSessionError):
+                    raise
+                raise QuelwareSessionError(
+                    "QuEL-3 quelware session request failed after retries",
+                    session_token=session_token,
+                    cause=exc,
+                ) from exc
+            logger.warning(
+                "QuEL-3 quelware session request failed; session_token=%s; "
+                "attempt=%d/%d; retrying with a fresh session; cause=%s",
+                session_token,
+                attempt,
+                max_attempts,
+                quelware_exception_summary(exc),
+            )
             return False, cast(T, None)
         await self._close_session_manager_after_attempt()
         return True, result
 
     async def _close_session_manager_after_attempt(self) -> None:
         """Close session state without masking request success or failure."""
-        with suppress(Exception):
+        session_token = self._active_session_token()
+        try:
             await self._session_manager.close()
+        except Exception as exc:
+            logger.warning(
+                "QuEL-3 quelware session cleanup failed; session_token=%s; cause=%s",
+                session_token,
+                quelware_exception_summary(exc),
+            )
+
+    def _active_session_token(self) -> str:
+        """Return the currently open session token for diagnostics."""
+        return self._session_manager.session_token or "<unavailable>"
+
+    def _session_token_for_exception(self, exc: BaseException) -> str:
+        """Return the best available session token for one exception."""
+        if isinstance(exc, QuelwareSessionError):
+            return exc.session_token
+        return self._active_session_token()
 
     async def _execute_once(
         self,

--- a/src/qubex/backend/quel3/managers/session_manager.py
+++ b/src/qubex/backend/quel3/managers/session_manager.py
@@ -18,6 +18,7 @@ from qubex.backend.quel3.interfaces import (
 )
 from qubex.backend.quel3.managers.session_workarounds import (
     enter_quelware_session_with_resource_retry,
+    quelware_session_token,
 )
 
 
@@ -46,6 +47,7 @@ class Quel3SessionManager:
         self._client: QuelwareClientProtocol | None = None
         self._session_cm = None
         self._session: SessionProtocol | None = None
+        self._session_token: str | None = None
         self._resource_ids: tuple[ResourceIdProtocol, ...] | None = None
 
     @property
@@ -91,6 +93,11 @@ class Quel3SessionManager:
         if self._session is None:
             raise RuntimeError("QuEL-3 execution session is not open.")
         return self._session
+
+    @property
+    def session_token(self) -> str | None:
+        """Return the token captured when the current session opened."""
+        return self._session_token
 
     @property
     def resource_ids(self) -> tuple[ResourceIdProtocol, ...] | None:
@@ -148,6 +155,7 @@ class Quel3SessionManager:
         except Exception:
             await self.close()
             raise
+        self._session_token = quelware_session_token(self._session)
         self._resource_ids = normalized_resource_ids
         return self._session
 
@@ -156,6 +164,7 @@ class Quel3SessionManager:
         session_cm = self._session_cm
         self._session_cm = None
         self._session = None
+        self._session_token = None
         self._resource_ids = None
         try:
             if session_cm is not None:

--- a/src/qubex/backend/quel3/managers/session_manager.py
+++ b/src/qubex/backend/quel3/managers/session_manager.py
@@ -16,6 +16,9 @@ from qubex.backend.quel3.interfaces import (
     ResourceIdProtocol,
     SessionProtocol,
 )
+from qubex.backend.quel3.managers.session_workarounds import (
+    enter_quelware_session_with_resource_retry,
+)
 
 
 class Quel3SessionManager:
@@ -117,7 +120,11 @@ class Quel3SessionManager:
                 self._quelware_endpoint,
                 self._quelware_port,
             )
-            self._client = await self._client_cm.__aenter__()
+            try:
+                self._client = await self._client_cm.__aenter__()
+            except Exception:
+                self._client_cm = None
+                raise
 
         if resource_ids is None:
             return None
@@ -130,23 +137,36 @@ class Quel3SessionManager:
                 )
             return self._session
 
-        self._session_cm = self._client.create_session(normalized_resource_ids)
-        self._session = await self._session_cm.__aenter__()
+        try:
+            (
+                self._session_cm,
+                self._session,
+            ) = await enter_quelware_session_with_resource_retry(
+                client=self._client,
+                resource_ids=normalized_resource_ids,
+            )
+        except Exception:
+            await self.close()
+            raise
         self._resource_ids = normalized_resource_ids
         return self._session
 
     async def close(self) -> None:
         """Close any open quelware session and client contexts."""
-        if self._session_cm is not None:
-            await self._session_cm.__aexit__(None, None, None)
+        session_cm = self._session_cm
         self._session_cm = None
         self._session = None
         self._resource_ids = None
+        try:
+            if session_cm is not None:
+                await session_cm.__aexit__(None, None, None)
+        finally:
+            client_cm = self._client_cm
+            self._client_cm = None
+            self._client = None
 
-        if self._client_cm is not None:
-            await self._client_cm.__aexit__(None, None, None)
-        self._client_cm = None
-        self._client = None
+            if client_cm is not None:
+                await client_cm.__aexit__(None, None, None)
 
     async def __aenter__(self) -> Quel3SessionManager:
         """Open the underlying quelware client context and return self."""

--- a/src/qubex/backend/quel3/managers/session_workarounds.py
+++ b/src/qubex/backend/quel3/managers/session_workarounds.py
@@ -1,0 +1,120 @@
+"""Workarounds for transient quelware-client session lifecycle failures."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Collection
+from contextlib import AbstractAsyncContextManager, suppress
+
+from qubex.backend.quel3.interfaces.client import (
+    QuelwareClientProtocol,
+    ResourceIdProtocol,
+    SessionProtocol,
+)
+
+QUELWARE_SESSION_CREATE_MAX_ATTEMPTS = 4
+QUELWARE_SESSION_CREATE_INITIAL_RETRY_DELAY_SECONDS = 0.5
+QUELWARE_SESSION_CREATE_MAX_RETRY_DELAY_SECONDS = 4.0
+QUELWARE_SESSION_CREATE_RETRY_BACKOFF_FACTOR = 1.5
+QUELWARE_SESSION_CREATE_RETRY_DELAY_SECONDS = (
+    QUELWARE_SESSION_CREATE_INITIAL_RETRY_DELAY_SECONDS
+)
+QUELWARE_SESSION_REQUEST_MAX_ATTEMPTS = 4
+
+
+def is_resource_allocation_error(exc: BaseException) -> bool:
+    """Return whether an exception looks like transient resource allocation failure."""
+    text = f"{type(exc).__module__}.{type(exc).__name__}: {exc}".lower()
+    grpc_code = _grpc_code_name(exc)
+    if grpc_code is not None:
+        text = f"{text} {grpc_code.lower()}"
+    if "unit" in text and ("unavailable" in text or "not ready" in text):
+        return True
+    if "resource" not in text:
+        return False
+    return any(
+        keyword in text
+        for keyword in (
+            "acquire",
+            "acquired",
+            "allocate",
+            "allocated",
+            "allocation",
+            "already",
+            "available",
+            "busy",
+            "exhausted",
+            "in use",
+            "locked",
+            "release",
+            "released",
+            "unavailable",
+        )
+    )
+
+
+async def enter_quelware_session_with_resource_retry(
+    *,
+    client: QuelwareClientProtocol,
+    resource_ids: Collection[ResourceIdProtocol],
+) -> tuple[AbstractAsyncContextManager[SessionProtocol], SessionProtocol]:
+    """
+    Enter a quelware session while retrying transient resource allocation failures.
+
+    Notes
+    -----
+    This is a QuEL-3-local workaround for observed `quelware-client` behavior
+    where resources can briefly appear unavailable after the previous session
+    released them.
+    """
+    normalized_resource_ids = tuple(resource_ids)
+    for attempt in range(QUELWARE_SESSION_CREATE_MAX_ATTEMPTS):
+        session_cm: AbstractAsyncContextManager[SessionProtocol] | None = None
+        try:
+            session_cm = client.create_session(normalized_resource_ids)
+            session = await session_cm.__aenter__()
+        except Exception as exc:
+            if session_cm is not None:
+                await _close_after_failed_enter(session_cm=session_cm, exc=exc)
+            if (
+                attempt + 1 >= QUELWARE_SESSION_CREATE_MAX_ATTEMPTS
+                or not is_resource_allocation_error(exc)
+            ):
+                raise
+            await asyncio.sleep(_session_create_retry_delay(attempt))
+        else:
+            return session_cm, session
+    raise RuntimeError("unreachable quelware session retry state")
+
+
+async def _close_after_failed_enter(
+    *,
+    session_cm: AbstractAsyncContextManager[SessionProtocol],
+    exc: Exception,
+) -> None:
+    """Close a context manager that failed partway through `__aenter__`."""
+    with suppress(Exception):
+        await session_cm.__aexit__(type(exc), exc, exc.__traceback__)
+
+
+def _session_create_retry_delay(attempt: int) -> float:
+    """Return retry delay for a failed session creation attempt."""
+    delay = QUELWARE_SESSION_CREATE_INITIAL_RETRY_DELAY_SECONDS * (
+        QUELWARE_SESSION_CREATE_RETRY_BACKOFF_FACTOR**attempt
+    )
+    return min(delay, QUELWARE_SESSION_CREATE_MAX_RETRY_DELAY_SECONDS)
+
+
+def _grpc_code_name(exc: BaseException) -> str | None:
+    """Return a gRPC status-code name when the exception exposes one."""
+    code = getattr(exc, "code", None)
+    if not callable(code):
+        return None
+    try:
+        value = code()
+    except Exception:
+        return None
+    name = getattr(value, "name", None)
+    if isinstance(name, str):
+        return name
+    return str(value)

--- a/src/qubex/backend/quel3/managers/session_workarounds.py
+++ b/src/qubex/backend/quel3/managers/session_workarounds.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from collections.abc import Collection
 from contextlib import AbstractAsyncContextManager, suppress
 
@@ -20,6 +21,46 @@ QUELWARE_SESSION_CREATE_RETRY_DELAY_SECONDS = (
     QUELWARE_SESSION_CREATE_INITIAL_RETRY_DELAY_SECONDS
 )
 QUELWARE_SESSION_REQUEST_MAX_ATTEMPTS = 4
+
+logger = logging.getLogger(__name__)
+
+
+class QuelwareSessionError(RuntimeError):
+    """Runtime error annotated with the captured quelware session token."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        session_token: str,
+        cause: BaseException,
+    ) -> None:
+        self.session_token = session_token
+        super().__init__(
+            f"{message}; session_token={session_token}; "
+            f"cause={type(cause).__name__}: {cause}"
+        )
+
+
+def quelware_session_token(session: object | None) -> str:
+    """Return a printable quelware session token for diagnostics."""
+    if session is None:
+        return "<unavailable>"
+    try:
+        token = getattr(session, "token", None)
+    except Exception:
+        return "<unavailable>"
+    if token is None:
+        return "<unavailable>"
+    try:
+        return str(token)
+    except Exception:
+        return "<unprintable>"
+
+
+def quelware_exception_summary(exc: BaseException) -> str:
+    """Return one-line exception context for retry logs."""
+    return f"{type(exc).__name__}: {exc}"
 
 
 def is_resource_allocation_error(exc: BaseException) -> bool:
@@ -68,20 +109,35 @@ async def enter_quelware_session_with_resource_retry(
     released them.
     """
     normalized_resource_ids = tuple(resource_ids)
-    for attempt in range(QUELWARE_SESSION_CREATE_MAX_ATTEMPTS):
+    max_attempts = max(1, int(QUELWARE_SESSION_CREATE_MAX_ATTEMPTS))
+    for attempt in range(max_attempts):
         session_cm: AbstractAsyncContextManager[SessionProtocol] | None = None
         try:
             session_cm = client.create_session(normalized_resource_ids)
             session = await session_cm.__aenter__()
         except Exception as exc:
+            session_token = quelware_session_token(session_cm)
             if session_cm is not None:
                 await _close_after_failed_enter(session_cm=session_cm, exc=exc)
-            if (
-                attempt + 1 >= QUELWARE_SESSION_CREATE_MAX_ATTEMPTS
-                or not is_resource_allocation_error(exc)
-            ):
-                raise
-            await asyncio.sleep(_session_create_retry_delay(attempt))
+            attempt_number = attempt + 1
+            retryable = is_resource_allocation_error(exc)
+            if attempt_number >= max_attempts or not retryable:
+                raise QuelwareSessionError(
+                    "QuEL-3 quelware session creation failed after retries",
+                    session_token=session_token,
+                    cause=exc,
+                ) from exc
+            retry_delay = _session_create_retry_delay(attempt)
+            logger.warning(
+                "QuEL-3 quelware session creation failed; session_token=%s; "
+                "attempt=%d/%d; retrying in %.3g s; cause=%s",
+                session_token,
+                attempt_number,
+                max_attempts,
+                retry_delay,
+                quelware_exception_summary(exc),
+            )
+            await asyncio.sleep(retry_delay)
         else:
             return session_cm, session
     raise RuntimeError("unreachable quelware session retry state")

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -25,6 +25,7 @@ from qubex.backend.quel3 import (
     Quel3Waveform,
     Quel3WaveformEvent,
 )
+from qubex.backend.quel3.managers import execution_manager as execution_manager_module
 from qubex.backend.quel3.managers.execution_manager import Quel3ExecutionManager
 
 
@@ -1033,6 +1034,7 @@ class _FakeSession:
 class _FakeClient:
     def __init__(self, session: _FakeSession) -> None:
         self._session = session
+        self.exit_calls = 0
 
     async def __aenter__(self) -> _FakeClient:
         return self
@@ -1044,10 +1046,351 @@ class _FakeClient:
         tb: object,
     ) -> None:
         del exc_type, exc, tb
+        self.exit_calls += 1
 
     def create_session(self, resource_ids: list[str]) -> _FakeSession:
         del resource_ids
         return self._session
+
+
+class _FlakyTriggerSession(_FakeSession):
+    def __init__(self, *, fail_once: bool) -> None:
+        super().__init__()
+        self._fail_once = fail_once
+        self.exit_calls = 0
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object,
+    ) -> None:
+        del exc_type, exc, tb
+        self.exit_calls += 1
+
+    async def trigger(self, instrument_ids: list[str]) -> None:
+        await super().trigger(instrument_ids)
+        if self._fail_once:
+            self._fail_once = False
+            raise RuntimeError("quelware request failed")
+
+
+class _CloseFailingSession(_FakeSession):
+    def __init__(self, *, fail_trigger: bool = False) -> None:
+        super().__init__()
+        self._fail_trigger = fail_trigger
+        self.exit_calls = 0
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object,
+    ) -> None:
+        del exc_type, exc, tb
+        self.exit_calls += 1
+        raise RuntimeError("quelware close failed")
+
+    async def trigger(self, instrument_ids: list[str]) -> None:
+        await super().trigger(instrument_ids)
+        if self._fail_trigger:
+            raise RuntimeError("quelware request failed")
+
+
+def test_execute_recreates_session_after_transient_request_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given transient quelware request failure, execute should retry with a new session."""
+    payload = _make_payload()
+    manager = Quel3ExecutionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+        sampling_period_ns=0.4,
+        capture_decimation_factor=4,
+    )
+    resolver = _FakeInstrumentResolver(
+        alias_to_info={
+            "alias-rq00": _FakeInstrumentInfo(
+                port_id="quel3-02-a01:trx_p00",
+                definition=_FakeInstrumentDefinition(role="TRANSCEIVER"),
+            )
+        }
+    )
+    sessions = [
+        _FlakyTriggerSession(fail_once=True),
+        _FlakyTriggerSession(fail_once=False),
+    ]
+    clients: list[_FakeClient] = []
+    drivers: list[_FakeInstrumentDriver] = []
+
+    def _create_client(endpoint: str, port: int) -> _FakeClient:
+        del endpoint, port
+        client = _FakeClient(sessions[len(clients)])
+        clients.append(client)
+        return client
+
+    def _create_driver(
+        session: object, instrument_info: object
+    ) -> _FakeInstrumentDriver:
+        del session, instrument_info
+        driver = _FakeInstrumentDriver()
+        drivers.append(driver)
+        return driver
+
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_api",
+        lambda: (
+            _create_client,
+            lambda: resolver,
+            _FakeSequencer,
+            _create_driver,
+            SimpleNamespace(AVERAGED_VALUE="avg"),
+            lambda *, hz: ("frequency", hz),
+            lambda *, mode: ("capture_mode", mode),
+        ),
+    )
+
+    result = asyncio.run(
+        manager.execute_async(request=BackendExecutionRequest(payload=payload))
+    )
+
+    assert len(clients) == 2
+    assert [client.exit_calls for client in clients] == [1, 1]
+    assert [session.exit_calls for session in sessions] == [1, 1]
+    assert sessions[0].trigger_calls == [["alias-rq00"]]
+    assert sessions[1].trigger_calls == [["alias-rq00"]]
+    assert len(drivers) == 2
+    assert np.array_equal(
+        result.data["alias-rq00"][0],
+        np.array([1.0 + 0.0j], dtype=np.complex128),
+    )
+
+
+def test_execute_ignores_session_close_failure_after_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given request succeeds but close fails, execute should preserve the result."""
+    payload = _make_payload()
+    manager = Quel3ExecutionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+        sampling_period_ns=0.4,
+        capture_decimation_factor=4,
+    )
+    resolver = _FakeInstrumentResolver(
+        alias_to_info={
+            "alias-rq00": _FakeInstrumentInfo(
+                port_id="quel3-02-a01:trx_p00",
+                definition=_FakeInstrumentDefinition(role="TRANSCEIVER"),
+            )
+        }
+    )
+    session = _CloseFailingSession()
+    client = _FakeClient(session)
+
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_api",
+        lambda: (
+            lambda endpoint, port: client,
+            lambda: resolver,
+            _FakeSequencer,
+            lambda session, instrument_info: _FakeInstrumentDriver(),
+            SimpleNamespace(AVERAGED_VALUE="avg"),
+            lambda *, hz: ("frequency", hz),
+            lambda *, mode: ("capture_mode", mode),
+        ),
+    )
+
+    result = asyncio.run(
+        manager.execute_async(request=BackendExecutionRequest(payload=payload))
+    )
+
+    assert client.exit_calls == 1
+    assert session.exit_calls == 1
+    assert session.trigger_calls == [["alias-rq00"]]
+    assert np.array_equal(
+        result.data["alias-rq00"][0],
+        np.array([1.0 + 0.0j], dtype=np.complex128),
+    )
+
+
+def test_execute_preserves_request_failure_when_session_close_also_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given request and close both fail, execute should raise the request error."""
+    payload = _make_payload()
+    manager = Quel3ExecutionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+        sampling_period_ns=0.4,
+        capture_decimation_factor=4,
+    )
+    resolver = _FakeInstrumentResolver(
+        alias_to_info={
+            "alias-rq00": _FakeInstrumentInfo(
+                port_id="quel3-02-a01:trx_p00",
+                definition=_FakeInstrumentDefinition(role="TRANSCEIVER"),
+            )
+        }
+    )
+    session = _CloseFailingSession(fail_trigger=True)
+    client = _FakeClient(session)
+
+    monkeypatch.setattr(
+        execution_manager_module,
+        "QUEL3_SESSION_REQUEST_MAX_ATTEMPTS",
+        1,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_api",
+        lambda: (
+            lambda endpoint, port: client,
+            lambda: resolver,
+            _FakeSequencer,
+            lambda session, instrument_info: _FakeInstrumentDriver(),
+            SimpleNamespace(AVERAGED_VALUE="avg"),
+            lambda *, hz: ("frequency", hz),
+            lambda *, mode: ("capture_mode", mode),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="quelware request failed"):
+        asyncio.run(
+            manager.execute_async(request=BackendExecutionRequest(payload=payload))
+        )
+
+    assert client.exit_calls == 1
+    assert session.exit_calls == 1
+    assert session.trigger_calls == [["alias-rq00"]]
+
+
+def test_execute_uses_configured_session_request_retry_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given configured retry limit, execute should stop after that many attempts."""
+    payload = _make_payload()
+    manager = Quel3ExecutionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+        sampling_period_ns=0.4,
+        capture_decimation_factor=4,
+    )
+    resolver = _FakeInstrumentResolver(
+        alias_to_info={
+            "alias-rq00": _FakeInstrumentInfo(
+                port_id="quel3-02-a01:trx_p00",
+                definition=_FakeInstrumentDefinition(role="TRANSCEIVER"),
+            )
+        }
+    )
+    sessions = [
+        _FlakyTriggerSession(fail_once=True),
+        _FlakyTriggerSession(fail_once=True),
+    ]
+    clients: list[_FakeClient] = []
+
+    def _create_client(endpoint: str, port: int) -> _FakeClient:
+        del endpoint, port
+        client = _FakeClient(sessions[len(clients)])
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(
+        execution_manager_module,
+        "QUEL3_SESSION_REQUEST_MAX_ATTEMPTS",
+        2,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_api",
+        lambda: (
+            _create_client,
+            lambda: resolver,
+            _FakeSequencer,
+            lambda session, instrument_info: _FakeInstrumentDriver(),
+            SimpleNamespace(AVERAGED_VALUE="avg"),
+            lambda *, hz: ("frequency", hz),
+            lambda *, mode: ("capture_mode", mode),
+        ),
+    )
+
+    with pytest.raises(RuntimeError, match="quelware request failed"):
+        asyncio.run(
+            manager.execute_async(request=BackendExecutionRequest(payload=payload))
+        )
+
+    assert len(clients) == 2
+    assert [client.exit_calls for client in clients] == [1, 1]
+    assert [session.exit_calls for session in sessions] == [1, 1]
+    assert [session.trigger_calls for session in sessions] == [
+        [["alias-rq00"]],
+        [["alias-rq00"]],
+    ]
+
+
+def test_execute_batch_recreates_session_after_transient_request_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given transient quelware request failure, batch execute should retry the batch."""
+    payload = _make_payload()
+    manager = Quel3ExecutionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+        sampling_period_ns=0.4,
+        capture_decimation_factor=4,
+    )
+    resolver = _FakeInstrumentResolver(
+        alias_to_info={
+            "alias-rq00": _FakeInstrumentInfo(
+                port_id="quel3-02-a01:trx_p00",
+                definition=_FakeInstrumentDefinition(role="TRANSCEIVER"),
+            )
+        }
+    )
+    sessions = [
+        _FlakyTriggerSession(fail_once=True),
+        _FlakyTriggerSession(fail_once=False),
+    ]
+    clients: list[_FakeClient] = []
+
+    def _create_client(endpoint: str, port: int) -> _FakeClient:
+        del endpoint, port
+        client = _FakeClient(sessions[len(clients)])
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_api",
+        lambda: (
+            _create_client,
+            lambda: resolver,
+            _FakeSequencer,
+            lambda session, instrument_info: _FakeInstrumentDriver(),
+            SimpleNamespace(AVERAGED_VALUE="avg"),
+            lambda *, hz: ("frequency", hz),
+            lambda *, mode: ("capture_mode", mode),
+        ),
+    )
+
+    results = asyncio.run(
+        manager.execute_batch_async(
+            requests=(
+                BackendExecutionRequest(payload=payload),
+                BackendExecutionRequest(payload=payload),
+            )
+        )
+    )
+
+    assert len(results) == 2
+    assert len(clients) == 2
+    assert [client.exit_calls for client in clients] == [1, 1]
+    assert [session.exit_calls for session in sessions] == [1, 1]
+    assert sessions[0].trigger_calls == [["alias-rq00"]]
+    assert sessions[1].trigger_calls == [["alias-rq00"], ["alias-rq00"]]
 
 
 def test_execute_batches_capture_mode_with_timeline_directive(

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass, replace
 from types import SimpleNamespace
 from typing import Any, cast
@@ -27,6 +28,7 @@ from qubex.backend.quel3 import (
 )
 from qubex.backend.quel3.managers import execution_manager as execution_manager_module
 from qubex.backend.quel3.managers.execution_manager import Quel3ExecutionManager
+from qubex.backend.quel3.managers.session_workarounds import QuelwareSessionError
 
 
 @dataclass(frozen=True)
@@ -1013,7 +1015,8 @@ class _SerialProbeInstrumentDriver:
 
 
 class _FakeSession:
-    def __init__(self) -> None:
+    def __init__(self, *, session_id: str = "session-id") -> None:
+        self.token = session_id
         self.trigger_calls: list[list[str]] = []
 
     async def __aenter__(self) -> _FakeSession:
@@ -1054,9 +1057,16 @@ class _FakeClient:
 
 
 class _FlakyTriggerSession(_FakeSession):
-    def __init__(self, *, fail_once: bool) -> None:
-        super().__init__()
+    def __init__(
+        self,
+        *,
+        fail_once: bool,
+        session_id: str = "flaky-session-id",
+        failed_session_id: str | None = None,
+    ) -> None:
+        super().__init__(session_id=session_id)
         self._fail_once = fail_once
+        self._failed_session_id = failed_session_id
         self.exit_calls = 0
 
     async def __aexit__(
@@ -1072,12 +1082,19 @@ class _FlakyTriggerSession(_FakeSession):
         await super().trigger(instrument_ids)
         if self._fail_once:
             self._fail_once = False
+            if self._failed_session_id is not None:
+                self.token = self._failed_session_id
             raise RuntimeError("quelware request failed")
 
 
 class _CloseFailingSession(_FakeSession):
-    def __init__(self, *, fail_trigger: bool = False) -> None:
-        super().__init__()
+    def __init__(
+        self,
+        *,
+        fail_trigger: bool = False,
+        session_id: str = "close-failing-session-id",
+    ) -> None:
+        super().__init__(session_id=session_id)
         self._fail_trigger = fail_trigger
         self.exit_calls = 0
 
@@ -1098,9 +1115,14 @@ class _CloseFailingSession(_FakeSession):
 
 
 def test_execute_recreates_session_after_transient_request_failure(
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given transient quelware request failure, execute should retry with a new session."""
+    caplog.set_level(
+        logging.WARNING,
+        logger="qubex.backend.quel3.managers.execution_manager",
+    )
     payload = _make_payload()
     manager = Quel3ExecutionManager(
         quelware_endpoint="localhost",
@@ -1117,8 +1139,12 @@ def test_execute_recreates_session_after_transient_request_failure(
         }
     )
     sessions = [
-        _FlakyTriggerSession(fail_once=True),
-        _FlakyTriggerSession(fail_once=False),
+        _FlakyTriggerSession(
+            fail_once=True,
+            session_id="failed-trigger-session",
+            failed_session_id="mutated-trigger-session",
+        ),
+        _FlakyTriggerSession(fail_once=False, session_id="retry-trigger-session"),
     ]
     clients: list[_FakeClient] = []
     drivers: list[_FakeInstrumentDriver] = []
@@ -1160,6 +1186,12 @@ def test_execute_recreates_session_after_transient_request_failure(
     assert [session.exit_calls for session in sessions] == [1, 1]
     assert sessions[0].trigger_calls == [["alias-rq00"]]
     assert sessions[1].trigger_calls == [["alias-rq00"]]
+    assert "QuEL-3 quelware session request failed" in caplog.text
+    assert "failed-trigger-session" in caplog.text
+    assert "mutated-trigger-session" not in caplog.text
+    assert "retry-trigger-session" not in caplog.text
+    assert "attempt=1/4" in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
     assert len(drivers) == 2
     assert np.array_equal(
         result.data["alias-rq00"][0],
@@ -1168,9 +1200,14 @@ def test_execute_recreates_session_after_transient_request_failure(
 
 
 def test_execute_ignores_session_close_failure_after_success(
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given request succeeds but close fails, execute should preserve the result."""
+    caplog.set_level(
+        logging.WARNING,
+        logger="qubex.backend.quel3.managers.execution_manager",
+    )
     payload = _make_payload()
     manager = Quel3ExecutionManager(
         quelware_endpoint="localhost",
@@ -1186,7 +1223,7 @@ def test_execute_ignores_session_close_failure_after_success(
             )
         }
     )
-    session = _CloseFailingSession()
+    session = _CloseFailingSession(session_id="cleanup-failed-session")
     client = _FakeClient(session)
 
     monkeypatch.setattr(
@@ -1210,6 +1247,9 @@ def test_execute_ignores_session_close_failure_after_success(
     assert client.exit_calls == 1
     assert session.exit_calls == 1
     assert session.trigger_calls == [["alias-rq00"]]
+    assert "QuEL-3 quelware session cleanup failed" in caplog.text
+    assert "cleanup-failed-session" in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
     assert np.array_equal(
         result.data["alias-rq00"][0],
         np.array([1.0 + 0.0j], dtype=np.complex128),
@@ -1219,7 +1259,7 @@ def test_execute_ignores_session_close_failure_after_success(
 def test_execute_preserves_request_failure_when_session_close_also_fails(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Given request and close both fail, execute should raise the request error."""
+    """Given request and close both fail, execute should preserve the request cause."""
     payload = _make_payload()
     manager = Quel3ExecutionManager(
         quelware_endpoint="localhost",
@@ -1235,7 +1275,11 @@ def test_execute_preserves_request_failure_when_session_close_also_fails(
             )
         }
     )
-    session = _CloseFailingSession(fail_trigger=True)
+    expected_session_id = "close-failing-session-id"
+    session = _CloseFailingSession(
+        fail_trigger=True,
+        session_id=expected_session_id,
+    )
     client = _FakeClient(session)
 
     monkeypatch.setattr(
@@ -1257,11 +1301,17 @@ def test_execute_preserves_request_failure_when_session_close_also_fails(
         ),
     )
 
-    with pytest.raises(RuntimeError, match="quelware request failed"):
+    with pytest.raises(
+        QuelwareSessionError,
+        match=f"session_token={expected_session_id}",
+    ) as exc_info:
         asyncio.run(
             manager.execute_async(request=BackendExecutionRequest(payload=payload))
         )
 
+    assert exc_info.value.session_token == expected_session_id
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert str(exc_info.value.__cause__) == "quelware request failed"
     assert client.exit_calls == 1
     assert session.exit_calls == 1
     assert session.trigger_calls == [["alias-rq00"]]
@@ -1286,9 +1336,10 @@ def test_execute_uses_configured_session_request_retry_limit(
             )
         }
     )
+    failed_session_ids = ("failed-trigger-session-1", "failed-trigger-session-2")
     sessions = [
-        _FlakyTriggerSession(fail_once=True),
-        _FlakyTriggerSession(fail_once=True),
+        _FlakyTriggerSession(fail_once=True, session_id=failed_session_ids[0]),
+        _FlakyTriggerSession(fail_once=True, session_id=failed_session_ids[1]),
     ]
     clients: list[_FakeClient] = []
 
@@ -1317,11 +1368,17 @@ def test_execute_uses_configured_session_request_retry_limit(
         ),
     )
 
-    with pytest.raises(RuntimeError, match="quelware request failed"):
+    with pytest.raises(
+        QuelwareSessionError,
+        match=f"session_token={failed_session_ids[1]}",
+    ) as exc_info:
         asyncio.run(
             manager.execute_async(request=BackendExecutionRequest(payload=payload))
         )
 
+    assert exc_info.value.session_token == failed_session_ids[1]
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert str(exc_info.value.__cause__) == "quelware request failed"
     assert len(clients) == 2
     assert [client.exit_calls for client in clients] == [1, 1]
     assert [session.exit_calls for session in sessions] == [1, 1]

--- a/tests/backend/test_quel3_configuration_manager.py
+++ b/tests/backend/test_quel3_configuration_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from dataclasses import dataclass
 
 import pytest
@@ -12,6 +13,7 @@ from qubex.backend.quel3.managers import (
     configuration_manager as configuration_manager_module,
     session_workarounds as session_workarounds_module,
 )
+from qubex.backend.quel3.managers.session_workarounds import QuelwareSessionError
 from qubex.backend.quel3.models import InstrumentDeployRequest
 
 
@@ -163,9 +165,14 @@ def test_deploy_instruments_calls_session_api(
 
 
 def test_deploy_instruments_recreates_session_after_transient_request_failure(
+    caplog: pytest.LogCaptureFixture,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given transient quelware request failure, deploy should retry with a new session."""
+    caplog.set_level(
+        logging.WARNING,
+        logger="qubex.backend.quel3.managers.configuration_manager",
+    )
     manager = Quel3ConfigurationManager(
         quelware_endpoint="localhost",
         quelware_port=50051,
@@ -196,8 +203,16 @@ def test_deploy_instruments_recreates_session_after_transient_request_failure(
         definition: _Definition
 
     class _FakeSession:
-        def __init__(self, *, fail_once: bool) -> None:
+        def __init__(
+            self,
+            *,
+            fail_once: bool,
+            session_id: str,
+            failed_session_id: str | None = None,
+        ) -> None:
+            self.token = session_id
             self._fail_once = fail_once
+            self._failed_session_id = failed_session_id
             self.deploy_calls: list[str] = []
             self.exit_calls = 0
 
@@ -224,6 +239,8 @@ def test_deploy_instruments_recreates_session_after_transient_request_failure(
             self.deploy_calls.append(port_id)
             if self._fail_once:
                 self._fail_once = False
+                if self._failed_session_id is not None:
+                    self.token = self._failed_session_id
                 raise RuntimeError("quelware request failed")
             return [
                 _InstrumentInfo(
@@ -255,8 +272,12 @@ def test_deploy_instruments_recreates_session_after_transient_request_failure(
             return self._session
 
     sessions = [
-        _FakeSession(fail_once=True),
-        _FakeSession(fail_once=False),
+        _FakeSession(
+            fail_once=True,
+            session_id="failed-deploy-session",
+            failed_session_id="mutated-deploy-session",
+        ),
+        _FakeSession(fail_once=False, session_id="retry-deploy-session"),
     ]
     clients: list[_FakeClient] = []
 
@@ -293,7 +314,257 @@ def test_deploy_instruments_recreates_session_after_transient_request_failure(
         ["quel3-02-a01:tx_p02"],
         ["quel3-02-a01:tx_p02"],
     ]
+    assert "QuEL-3 quelware deploy request failed" in caplog.text
+    assert "failed-deploy-session" in caplog.text
+    assert "mutated-deploy-session" not in caplog.text
+    assert "retry-deploy-session" not in caplog.text
+    assert "attempt=1/4" in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
     assert set(deployed) == {"Q00"}
+
+
+def test_deploy_instruments_ignores_session_close_failure_after_success(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given deploy succeeds but close fails, deploy should preserve the result."""
+    caplog.set_level(
+        logging.WARNING,
+        logger="qubex.backend.quel3.managers.configuration_manager",
+    )
+    manager = Quel3ConfigurationManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    class _Profile:
+        def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
+            self.frequency_range_min = frequency_range_min
+            self.frequency_range_max = frequency_range_max
+
+    class _Definition:
+        def __init__(self, *, alias: str, mode: object, role: object, profile: object):
+            self.alias = alias
+            self.mode = mode
+            self.role = role
+            self.profile = profile
+
+    class _Mode:
+        FIXED_TIMELINE = "fixed_timeline"
+
+    class _Role:
+        TRANSMITTER = "transmitter"
+
+    @dataclass(frozen=True)
+    class _InstrumentInfo:
+        id: str
+        port_id: str
+        definition: _Definition
+
+    class _FakeSession:
+        def __init__(self, *, session_id: str) -> None:
+            self.token = session_id
+            self.exit_calls = 0
+
+        async def __aenter__(self) -> _FakeSession:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            _ = (exc_type, exc, tb)
+            self.exit_calls += 1
+            raise RuntimeError("quelware close failed")
+
+        async def deploy_instruments(
+            self,
+            port_id: str,
+            *,
+            definitions: list[_Definition],
+            append: bool = False,
+        ) -> list[_InstrumentInfo]:
+            del append
+            return [
+                _InstrumentInfo(
+                    id=f"id:{port_id}",
+                    port_id=port_id,
+                    definition=definitions[0],
+                )
+            ]
+
+    class _FakeClient:
+        def __init__(self, session: _FakeSession) -> None:
+            self._session = session
+            self.exit_calls = 0
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            _ = (exc_type, exc, tb)
+            self.exit_calls += 1
+
+        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+            assert tuple(resource_ids) == ("quel3-02-a01:tx_p02",)
+            return self._session
+
+    session = _FakeSession(session_id="cleanup-failed-deploy-session")
+    client = _FakeClient(session)
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_client_factory",
+        lambda: lambda endpoint, port: client,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_load_instrument_entities",
+        lambda: (_Profile, _Definition, _Mode, _Role),
+    )
+
+    request = InstrumentDeployRequest(
+        port_id="quel3-02-a01:tx_p02",
+        role="TRANSMITTER",
+        frequency_range_min_hz=4.1e9,
+        frequency_range_max_hz=4.3e9,
+        alias="Q00",
+        target_labels=("Q00",),
+    )
+
+    deployed = manager.deploy_instruments(requests=(request,))
+
+    assert session.exit_calls == 1
+    assert client.exit_calls == 1
+    assert "QuEL-3 quelware deploy session cleanup failed" in caplog.text
+    assert "cleanup-failed-deploy-session" in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+    assert set(deployed) == {"Q00"}
+
+
+def test_deploy_instruments_wraps_final_request_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given retry limit is reached, deploy should raise a token-annotated error."""
+    failed_session_id = "failed-deploy-session"
+    manager = Quel3ConfigurationManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    class _Profile:
+        def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
+            self.frequency_range_min = frequency_range_min
+            self.frequency_range_max = frequency_range_max
+
+    class _Definition:
+        def __init__(self, *, alias: str, mode: object, role: object, profile: object):
+            self.alias = alias
+            self.mode = mode
+            self.role = role
+            self.profile = profile
+
+    class _Mode:
+        FIXED_TIMELINE = "fixed_timeline"
+
+    class _Role:
+        TRANSMITTER = "transmitter"
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.token = failed_session_id
+            self.deploy_calls: list[str] = []
+            self.exit_calls = 0
+
+        async def __aenter__(self) -> _FakeSession:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            _ = (exc_type, exc, tb)
+            self.exit_calls += 1
+
+        async def deploy_instruments(
+            self,
+            port_id: str,
+            *,
+            definitions: list[_Definition],
+            append: bool = False,
+        ) -> list[object]:
+            _ = (definitions, append)
+            self.deploy_calls.append(port_id)
+            raise RuntimeError("quelware request failed")
+
+    class _FakeClient:
+        def __init__(self, session: _FakeSession) -> None:
+            self._session = session
+            self.exit_calls = 0
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            _ = (exc_type, exc, tb)
+            self.exit_calls += 1
+
+        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+            assert tuple(resource_ids) == ("quel3-02-a01:tx_p02",)
+            return self._session
+
+    session = _FakeSession()
+    client = _FakeClient(session)
+    monkeypatch.setattr(
+        configuration_manager_module,
+        "QUELWARE_SESSION_REQUEST_MAX_ATTEMPTS",
+        1,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_client_factory",
+        lambda: lambda endpoint, port: client,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_load_instrument_entities",
+        lambda: (_Profile, _Definition, _Mode, _Role),
+    )
+
+    request = InstrumentDeployRequest(
+        port_id="quel3-02-a01:tx_p02",
+        role="TRANSMITTER",
+        frequency_range_min_hz=4.1e9,
+        frequency_range_max_hz=4.3e9,
+        alias="Q00",
+        target_labels=("Q00",),
+    )
+
+    with pytest.raises(
+        QuelwareSessionError,
+        match=f"session_token={failed_session_id}",
+    ) as exc_info:
+        manager.deploy_instruments(requests=(request,))
+
+    assert exc_info.value.session_token == failed_session_id
+    assert isinstance(exc_info.value.__cause__, RuntimeError)
+    assert str(exc_info.value.__cause__) == "quelware request failed"
+    assert session.deploy_calls == ["quel3-02-a01:tx_p02"]
+    assert session.exit_calls == 1
+    assert client.exit_calls == 1
 
 
 def test_deploy_instruments_retries_resource_allocation_on_session_create(

--- a/tests/backend/test_quel3_configuration_manager.py
+++ b/tests/backend/test_quel3_configuration_manager.py
@@ -10,6 +10,7 @@ import pytest
 from qubex.backend.quel3.managers import (
     Quel3ConfigurationManager,
     configuration_manager as configuration_manager_module,
+    session_workarounds as session_workarounds_module,
 )
 from qubex.backend.quel3.models import InstrumentDeployRequest
 
@@ -159,6 +160,282 @@ def test_deploy_instruments_calls_session_api(
     assert definition.alias == "Q00"
     assert manager.target_alias_map == {"Q00": definition.alias}
     assert definition.alias in deployed
+
+
+def test_deploy_instruments_recreates_session_after_transient_request_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given transient quelware request failure, deploy should retry with a new session."""
+    manager = Quel3ConfigurationManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    class _Profile:
+        def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
+            self.frequency_range_min = frequency_range_min
+            self.frequency_range_max = frequency_range_max
+
+    class _Definition:
+        def __init__(self, *, alias: str, mode: object, role: object, profile: object):
+            self.alias = alias
+            self.mode = mode
+            self.role = role
+            self.profile = profile
+
+    class _Mode:
+        FIXED_TIMELINE = "fixed_timeline"
+
+    class _Role:
+        TRANSMITTER = "transmitter"
+
+    @dataclass(frozen=True)
+    class _InstrumentInfo:
+        id: str
+        port_id: str
+        definition: _Definition
+
+    class _FakeSession:
+        def __init__(self, *, fail_once: bool) -> None:
+            self._fail_once = fail_once
+            self.deploy_calls: list[str] = []
+            self.exit_calls = 0
+
+        async def __aenter__(self) -> _FakeSession:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            _ = (exc_type, exc, tb)
+            self.exit_calls += 1
+
+        async def deploy_instruments(
+            self,
+            port_id: str,
+            *,
+            definitions: list[_Definition],
+            append: bool = False,
+        ) -> list[_InstrumentInfo]:
+            del append
+            self.deploy_calls.append(port_id)
+            if self._fail_once:
+                self._fail_once = False
+                raise RuntimeError("quelware request failed")
+            return [
+                _InstrumentInfo(
+                    id=f"id:{port_id}",
+                    port_id=port_id,
+                    definition=definitions[0],
+                )
+            ]
+
+    class _FakeClient:
+        def __init__(self, session: _FakeSession) -> None:
+            self._session = session
+            self.exit_calls = 0
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            _ = (exc_type, exc, tb)
+            self.exit_calls += 1
+
+        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+            assert tuple(resource_ids) == ("quel3-02-a01:tx_p02",)
+            return self._session
+
+    sessions = [
+        _FakeSession(fail_once=True),
+        _FakeSession(fail_once=False),
+    ]
+    clients: list[_FakeClient] = []
+
+    def _create_client(endpoint: str, port: int) -> _FakeClient:
+        del endpoint, port
+        client = _FakeClient(sessions[len(clients)])
+        clients.append(client)
+        return client
+
+    monkeypatch.setattr(
+        manager, "_load_quelware_client_factory", lambda: _create_client
+    )
+    monkeypatch.setattr(
+        manager,
+        "_load_instrument_entities",
+        lambda: (_Profile, _Definition, _Mode, _Role),
+    )
+
+    request = InstrumentDeployRequest(
+        port_id="quel3-02-a01:tx_p02",
+        role="TRANSMITTER",
+        frequency_range_min_hz=4.1e9,
+        frequency_range_max_hz=4.3e9,
+        alias="Q00",
+        target_labels=("Q00",),
+    )
+
+    deployed = manager.deploy_instruments(requests=(request,))
+
+    assert len(clients) == 2
+    assert [client.exit_calls for client in clients] == [1, 1]
+    assert [session.exit_calls for session in sessions] == [1, 1]
+    assert [session.deploy_calls for session in sessions] == [
+        ["quel3-02-a01:tx_p02"],
+        ["quel3-02-a01:tx_p02"],
+    ]
+    assert set(deployed) == {"Q00"}
+
+
+def test_deploy_instruments_retries_resource_allocation_on_session_create(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given transient resource allocation failure, deploy should retry session creation."""
+    manager = Quel3ConfigurationManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    async def _skip_sleep(delay: float) -> None:
+        del delay
+
+    monkeypatch.setattr(session_workarounds_module.asyncio, "sleep", _skip_sleep)
+
+    class _Profile:
+        def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
+            self.frequency_range_min = frequency_range_min
+            self.frequency_range_max = frequency_range_max
+
+    class _Definition:
+        def __init__(self, *, alias: str, mode: object, role: object, profile: object):
+            self.alias = alias
+            self.mode = mode
+            self.role = role
+            self.profile = profile
+
+    class _Mode:
+        FIXED_TIMELINE = "fixed_timeline"
+
+    class _Role:
+        TRANSMITTER = "transmitter"
+
+    @dataclass(frozen=True)
+    class _InstrumentInfo:
+        id: str
+        port_id: str
+        definition: _Definition
+
+    class _FailingSessionContext:
+        def __init__(self) -> None:
+            self.exit_calls = 0
+
+        async def __aenter__(self) -> object:
+            raise RuntimeError("resource is not available yet")
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            _ = (exc_type, exc, tb)
+            self.exit_calls += 1
+
+    class _FakeSession:
+        def __init__(self) -> None:
+            self.exit_calls = 0
+
+        async def __aenter__(self) -> _FakeSession:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            _ = (exc_type, exc, tb)
+            self.exit_calls += 1
+
+        async def deploy_instruments(
+            self,
+            port_id: str,
+            *,
+            definitions: list[_Definition],
+            append: bool = False,
+        ) -> list[_InstrumentInfo]:
+            del append
+            return [
+                _InstrumentInfo(
+                    id=f"id:{port_id}",
+                    port_id=port_id,
+                    definition=definitions[0],
+                )
+            ]
+
+    class _FakeClient:
+        def __init__(self, session: _FakeSession) -> None:
+            self._session = session
+            self.failing_context = _FailingSessionContext()
+            self.create_session_calls: list[tuple[str, ...]] = []
+
+        async def __aenter__(self) -> _FakeClient:
+            return self
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            _ = (exc_type, exc, tb)
+
+        def create_session(self, resource_ids: list[str]) -> object:
+            self.create_session_calls.append(tuple(resource_ids))
+            if len(self.create_session_calls) == 1:
+                return self.failing_context
+            return self._session
+
+    session = _FakeSession()
+    client = _FakeClient(session)
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_client_factory",
+        lambda: lambda endpoint, port: client,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_load_instrument_entities",
+        lambda: (_Profile, _Definition, _Mode, _Role),
+    )
+
+    request = InstrumentDeployRequest(
+        port_id="quel3-02-a01:tx_p02",
+        role="TRANSMITTER",
+        frequency_range_min_hz=4.1e9,
+        frequency_range_max_hz=4.3e9,
+        alias="Q00",
+        target_labels=("Q00",),
+    )
+
+    deployed = manager.deploy_instruments(requests=(request,))
+
+    assert client.create_session_calls == [
+        ("quel3-02-a01:tx_p02",),
+        ("quel3-02-a01:tx_p02",),
+    ]
+    assert client.failing_context.exit_calls == 1
+    assert session.exit_calls == 1
+    assert set(deployed) == {"Q00"}
 
 
 def test_deploy_instruments_accepts_unit_prefixed_returned_alias(

--- a/tests/backend/test_quel3_session_manager.py
+++ b/tests/backend/test_quel3_session_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import logging
 from typing import Any, cast
 
 import pytest
@@ -12,12 +13,15 @@ from qubex.backend.quel3.managers import (
     session_workarounds as session_workarounds_module,
 )
 from qubex.backend.quel3.managers.session_workarounds import (
+    QuelwareSessionError,
     is_resource_allocation_error,
+    quelware_session_token,
 )
 
 
 class _SuccessfulSession:
-    def __init__(self) -> None:
+    def __init__(self, *, session_id: str = "successful-session") -> None:
+        self.token = session_id
         self.enter_calls = 0
         self.exit_calls = 0
 
@@ -36,7 +40,8 @@ class _SuccessfulSession:
 
 
 class _FailingSessionContext:
-    def __init__(self, exc: Exception) -> None:
+    def __init__(self, exc: Exception, *, session_id: str) -> None:
+        self.token = session_id
         self._exc = exc
         self.exit_calls = 0
 
@@ -71,7 +76,8 @@ class _FakeClient:
         self.create_session_calls.append(tuple(resource_ids))
         if len(self.create_session_calls) <= self._failures_before_success:
             context = _FailingSessionContext(
-                self._failure or RuntimeError("resource is not available yet")
+                self._failure or RuntimeError("resource is not available yet"),
+                session_id=f"failed-create-session-{len(self.create_session_calls)}",
             )
             self.failing_contexts.append(context)
             return context
@@ -80,6 +86,12 @@ class _FakeClient:
 
 class _InvalidUnitStatusError(Exception):
     pass
+
+
+class _UnopenedSession:
+    @property
+    def token(self) -> str:
+        raise ValueError("Token not found. Session may not opened.")
 
 
 class _FakeClientContext:
@@ -109,6 +121,11 @@ def _patch_session_retry_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
 
     monkeypatch.setattr(session_workarounds_module.asyncio, "sleep", _record_sleep)
     return delays
+
+
+def test_session_token_helper_handles_unopened_session_property() -> None:
+    """Given unopened session token raises, token helper should return unavailable."""
+    assert quelware_session_token(_UnopenedSession()) == "<unavailable>"
 
 
 def test_open_retries_transient_resource_allocation_failure(
@@ -141,6 +158,134 @@ def test_open_retries_transient_resource_allocation_failure(
     assert session.enter_calls == 1
     assert session.exit_calls == 1
     assert client_context.exit_calls == 1
+
+
+def test_open_retries_when_failed_session_token_is_unavailable(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given failed session has no token yet, open should preserve the original failure."""
+    caplog.set_level(
+        logging.WARNING,
+        logger="qubex.backend.quel3.managers.session_workarounds",
+    )
+    session = _SuccessfulSession()
+    failure = RuntimeError("resource is not available yet")
+
+    class _FailingUnopenedSession(_UnopenedSession):
+        def __init__(self) -> None:
+            self.exit_calls = 0
+
+        async def __aenter__(self) -> object:
+            raise failure
+
+        async def __aexit__(
+            self,
+            exc_type: type[BaseException] | None,
+            exc: BaseException | None,
+            tb: object | None,
+        ) -> None:
+            del exc_type, exc, tb
+            self.exit_calls += 1
+
+    class _FakeClientWithUnopenedFailure:
+        def __init__(self) -> None:
+            self.failing_context = _FailingUnopenedSession()
+            self.create_session_calls: list[tuple[str, ...]] = []
+
+        def create_session(self, resource_ids: tuple[str, ...]) -> object:
+            self.create_session_calls.append(tuple(resource_ids))
+            if len(self.create_session_calls) == 1:
+                return self.failing_context
+            return session
+
+    client = _FakeClientWithUnopenedFailure()
+    client_context = _FakeClientContext(cast(Any, client))
+    _patch_session_retry_sleep(monkeypatch)
+    manager = Quel3SessionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    async def _run() -> object:
+        opened_session = await manager.open(
+            ("inst-a",),
+            client_factory=cast(Any, lambda endpoint, port: client_context),
+        )
+        await manager.close()
+        return opened_session
+
+    opened_session = asyncio.run(_run())
+
+    assert opened_session is session
+    assert client.create_session_calls == [("inst-a",), ("inst-a",)]
+    assert client.failing_context.exit_calls == 1
+    assert "session_token=<unavailable>" in caplog.text
+    assert "resource is not available yet" in caplog.text
+    assert "Token not found" not in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+def test_open_logs_session_token_on_session_create_failure(
+    caplog: pytest.LogCaptureFixture,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given session creation fails, open should log the failed session token."""
+    caplog.set_level(
+        logging.WARNING,
+        logger="qubex.backend.quel3.managers.session_workarounds",
+    )
+    session = _SuccessfulSession()
+    client = _FakeClient(successful_session=session, failures_before_success=1)
+    client_context = _FakeClientContext(client)
+    _patch_session_retry_sleep(monkeypatch)
+    manager = Quel3SessionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    async def _run() -> None:
+        await manager.open(
+            ("inst-a",),
+            client_factory=cast(Any, lambda endpoint, port: client_context),
+        )
+        await manager.close()
+
+    asyncio.run(_run())
+
+    assert "QuEL-3 quelware session creation failed" in caplog.text
+    assert "failed-create-session-1" in caplog.text
+    assert "attempt=1/4" in caplog.text
+    assert all(record.exc_info is None for record in caplog.records)
+
+
+def test_open_captures_session_token_on_success(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given session opens, manager should store its token immediately."""
+    session = _SuccessfulSession(session_id="opened-session")
+    client = _FakeClient(successful_session=session, failures_before_success=0)
+    client_context = _FakeClientContext(client)
+    manager = Quel3SessionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    async def _run() -> tuple[str | None, str | None]:
+        await manager.open(
+            ("inst-a",),
+            client_factory=cast(Any, lambda endpoint, port: client_context),
+        )
+        captured_session_id = manager.session_token
+        changed_session_id = "mutated-session"
+        session.token = changed_session_id
+        await manager.close()
+        return captured_session_id, manager.session_token
+
+    captured_session_id, closed_session_id = asyncio.run(_run())
+
+    assert captured_session_id == "opened-session"
+    assert closed_session_id is None
 
 
 @pytest.mark.parametrize(
@@ -211,21 +356,28 @@ def test_open_stops_after_session_create_retry_limit(
     )
     client_context = _FakeClientContext(client)
     sleep_delays = _patch_session_retry_sleep(monkeypatch)
+    expected_session_id = "failed-create-session-4"
     manager = Quel3SessionManager(
         quelware_endpoint="localhost",
         quelware_port=50051,
     )
 
-    async def _run() -> None:
-        with pytest.raises(_InvalidUnitStatusError):
+    async def _run() -> QuelwareSessionError:
+        with pytest.raises(
+            QuelwareSessionError,
+            match=f"session_token={expected_session_id}",
+        ) as exc_info:
             await manager.open(
                 ("inst-a",),
                 client_factory=cast(Any, lambda endpoint, port: client_context),
             )
         await manager.close()
+        return exc_info.value
 
-    asyncio.run(_run())
+    error = asyncio.run(_run())
 
+    assert error.session_token == expected_session_id
+    assert isinstance(error.__cause__, _InvalidUnitStatusError)
     assert client.create_session_calls == [("inst-a",)] * 4
     assert [context.exit_calls for context in client.failing_contexts] == [
         1,

--- a/tests/backend/test_quel3_session_manager.py
+++ b/tests/backend/test_quel3_session_manager.py
@@ -1,0 +1,279 @@
+"""Tests for QuEL-3 session manager behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from typing import Any, cast
+
+import pytest
+
+from qubex.backend.quel3.managers import (
+    Quel3SessionManager,
+    session_workarounds as session_workarounds_module,
+)
+from qubex.backend.quel3.managers.session_workarounds import (
+    is_resource_allocation_error,
+)
+
+
+class _SuccessfulSession:
+    def __init__(self) -> None:
+        self.enter_calls = 0
+        self.exit_calls = 0
+
+    async def __aenter__(self) -> _SuccessfulSession:
+        self.enter_calls += 1
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> None:
+        del exc_type, exc, tb
+        self.exit_calls += 1
+
+
+class _FailingSessionContext:
+    def __init__(self, exc: Exception) -> None:
+        self._exc = exc
+        self.exit_calls = 0
+
+    async def __aenter__(self) -> object:
+        raise self._exc
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> None:
+        del exc_type, exc, tb
+        self.exit_calls += 1
+
+
+class _FakeClient:
+    def __init__(
+        self,
+        successful_session: _SuccessfulSession,
+        *,
+        failure: Exception | None = None,
+        failures_before_success: int = 2,
+    ) -> None:
+        self._successful_session = successful_session
+        self._failure = failure
+        self._failures_before_success = failures_before_success
+        self.failing_contexts: list[_FailingSessionContext] = []
+        self.create_session_calls: list[tuple[str, ...]] = []
+
+    def create_session(self, resource_ids: tuple[str, ...]) -> object:
+        self.create_session_calls.append(tuple(resource_ids))
+        if len(self.create_session_calls) <= self._failures_before_success:
+            context = _FailingSessionContext(
+                self._failure or RuntimeError("resource is not available yet")
+            )
+            self.failing_contexts.append(context)
+            return context
+        return self._successful_session
+
+
+class _InvalidUnitStatusError(Exception):
+    pass
+
+
+class _FakeClientContext:
+    def __init__(self, client: _FakeClient) -> None:
+        self._client = client
+        self.exit_calls = 0
+
+    async def __aenter__(self) -> _FakeClient:
+        return self._client
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> None:
+        del exc_type, exc, tb
+        self.exit_calls += 1
+
+
+def _patch_session_retry_sleep(monkeypatch: pytest.MonkeyPatch) -> list[float]:
+    """Patch session retry sleep and return recorded delays."""
+    delays: list[float] = []
+
+    async def _record_sleep(delay: float) -> None:
+        delays.append(delay)
+
+    monkeypatch.setattr(session_workarounds_module.asyncio, "sleep", _record_sleep)
+    return delays
+
+
+def test_open_retries_transient_resource_allocation_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given transient resource allocation failure, open should retry session creation."""
+    session = _SuccessfulSession()
+    client = _FakeClient(successful_session=session)
+    client_context = _FakeClientContext(client)
+    sleep_delays = _patch_session_retry_sleep(monkeypatch)
+    manager = Quel3SessionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    async def _run() -> object:
+        opened_session = await manager.open(
+            ("inst-a",),
+            client_factory=cast(Any, lambda endpoint, port: client_context),
+        )
+        await manager.close()
+        return opened_session
+
+    opened_session = asyncio.run(_run())
+
+    assert opened_session is session
+    assert client.create_session_calls == [("inst-a",), ("inst-a",), ("inst-a",)]
+    assert [context.exit_calls for context in client.failing_contexts] == [1, 1]
+    assert sleep_delays == pytest.approx([0.5, 0.75])
+    assert session.enter_calls == 1
+    assert session.exit_calls == 1
+    assert client_context.exit_calls == 1
+
+
+@pytest.mark.parametrize(
+    "exc",
+    [
+        RuntimeError("resource is not available yet"),
+        _InvalidUnitStatusError(
+            "Some units are not ready to open new session. "
+            "status: ({'quel3-02-a01': 'UnitStatus.UNAVAILABLE'})"
+        ),
+    ],
+)
+def test_session_error_classifier_accepts_transient_quelware_open_failures(
+    exc: Exception,
+) -> None:
+    """Given known transient quelware open failures, classifier should accept them."""
+    assert is_resource_allocation_error(exc) is True
+
+
+def test_open_retries_transient_unit_unavailable_failure(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given transient unit unavailable failure, open should retry session creation."""
+    session = _SuccessfulSession()
+    client = _FakeClient(
+        successful_session=session,
+        failure=_InvalidUnitStatusError(
+            "Some units are not ready to open new session. "
+            "status: ({'quel3-02-a01': 'UnitStatus.UNAVAILABLE'})"
+        ),
+    )
+    client_context = _FakeClientContext(client)
+    sleep_delays = _patch_session_retry_sleep(monkeypatch)
+    manager = Quel3SessionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    async def _run() -> object:
+        opened_session = await manager.open(
+            ("inst-a",),
+            client_factory=cast(Any, lambda endpoint, port: client_context),
+        )
+        await manager.close()
+        return opened_session
+
+    opened_session = asyncio.run(_run())
+
+    assert opened_session is session
+    assert client.create_session_calls == [("inst-a",), ("inst-a",), ("inst-a",)]
+    assert [context.exit_calls for context in client.failing_contexts] == [1, 1]
+    assert sleep_delays == pytest.approx([0.5, 0.75])
+    assert session.exit_calls == 1
+
+
+def test_open_stops_after_session_create_retry_limit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given sustained unit unavailable failure, open should stop at retry limit."""
+    session = _SuccessfulSession()
+    client = _FakeClient(
+        successful_session=session,
+        failure=_InvalidUnitStatusError(
+            "Some units are not ready to open new session. "
+            "status: ({'quel3-02-a01': 'UnitStatus.UNAVAILABLE'})"
+        ),
+        failures_before_success=5,
+    )
+    client_context = _FakeClientContext(client)
+    sleep_delays = _patch_session_retry_sleep(monkeypatch)
+    manager = Quel3SessionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    async def _run() -> None:
+        with pytest.raises(_InvalidUnitStatusError):
+            await manager.open(
+                ("inst-a",),
+                client_factory=cast(Any, lambda endpoint, port: client_context),
+            )
+        await manager.close()
+
+    asyncio.run(_run())
+
+    assert client.create_session_calls == [("inst-a",)] * 4
+    assert [context.exit_calls for context in client.failing_contexts] == [
+        1,
+        1,
+        1,
+        1,
+    ]
+    assert sleep_delays == pytest.approx([0.5, 0.75, 1.125])
+    assert session.exit_calls == 0
+    assert client_context.exit_calls == 1
+
+
+def test_open_succeeds_on_final_session_create_retry(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given final retry succeeds, open should return the session."""
+    session = _SuccessfulSession()
+    client = _FakeClient(
+        successful_session=session,
+        failure=_InvalidUnitStatusError(
+            "Some units are not ready to open new session. "
+            "status: ({'quel3-02-a01': 'UnitStatus.UNAVAILABLE'})"
+        ),
+        failures_before_success=3,
+    )
+    client_context = _FakeClientContext(client)
+    sleep_delays = _patch_session_retry_sleep(monkeypatch)
+    manager = Quel3SessionManager(
+        quelware_endpoint="localhost",
+        quelware_port=50051,
+    )
+
+    async def _run() -> object:
+        opened_session = await manager.open(
+            ("inst-a",),
+            client_factory=cast(Any, lambda endpoint, port: client_context),
+        )
+        await manager.close()
+        return opened_session
+
+    opened_session = asyncio.run(_run())
+
+    assert opened_session is session
+    assert client.create_session_calls == [("inst-a",)] * 4
+    assert [context.exit_calls for context in client.failing_contexts] == [
+        1,
+        1,
+        1,
+    ]
+    assert sleep_delays == pytest.approx([0.5, 0.75, 1.125])
+    assert session.exit_calls == 1


### PR DESCRIPTION
## Summary

- Retry transient QuEL-3 session creation/resource-allocation failures with a bounded backoff.
- Recreate quelware client/session state after execution or deploy request failures instead of reusing a possibly invalid session.
- Capture session tokens when sessions open, add concise retry diagnostics, and wrap final failures with a token-annotated `RuntimeError` while preserving the original exception as `__cause__`.
- Keep cleanup failures from masking successful requests or the original request failure.

## Notes

- Retry logs are intentionally one-line warnings with attempt counts and cause summaries; traceback is left to final escaping failures.
- `session_token=<unavailable>` is expected when `open_session` fails before quelware returns a token.
- No docs update was made because this is currently QuEL-3 session retry/error handling behavior without existing user-guide coverage.

## Validation

- `uv run pytest tests/backend/test_quel3_session_manager.py tests/backend/test_quel3_backend_controller.py tests/backend/test_quel3_configuration_manager.py`
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest` (`1004 passed`)
