### PR TITLE
Fix qxpulse sampling-grid and padding behavior

### DIFF
--- a/packages/qxpulse/src/qxpulse/library/cpmg.py
+++ b/packages/qxpulse/src/qxpulse/library/cpmg.py
@@ -6,7 +6,7 @@ from typing import Final
 
 from qxpulse.blank import Blank
 from qxpulse.pulse_array import PulseArray
-from qxpulse.waveform import Waveform, _is_sampling_period_multiple
+from qxpulse.waveform import Waveform, is_sampling_period_multiple
 
 
 class CPMG(PulseArray):
@@ -53,7 +53,7 @@ class CPMG(PulseArray):
         self.n: Final = n
         self.alternating: Final = alternating
 
-        if not _is_sampling_period_multiple(tau, self.SAMPLING_PERIOD):
+        if not is_sampling_period_multiple(tau, self.SAMPLING_PERIOD):
             raise ValueError(
                 f"Tau must be a multiple of the sampling period ({self.SAMPLING_PERIOD} ns)."
             )

--- a/packages/qxpulse/src/qxpulse/library/cpmg.py
+++ b/packages/qxpulse/src/qxpulse/library/cpmg.py
@@ -6,7 +6,7 @@ from typing import Final
 
 from qxpulse.blank import Blank
 from qxpulse.pulse_array import PulseArray
-from qxpulse.waveform import Waveform
+from qxpulse.waveform import Waveform, _is_sampling_period_multiple
 
 
 class CPMG(PulseArray):
@@ -53,7 +53,7 @@ class CPMG(PulseArray):
         self.n: Final = n
         self.alternating: Final = alternating
 
-        if tau % self.SAMPLING_PERIOD != 0:
+        if not _is_sampling_period_multiple(tau, self.SAMPLING_PERIOD):
             raise ValueError(
                 f"Tau must be a multiple of the sampling period ({self.SAMPLING_PERIOD} ns)."
             )

--- a/packages/qxpulse/src/qxpulse/library/flat_top.py
+++ b/packages/qxpulse/src/qxpulse/library/flat_top.py
@@ -9,6 +9,7 @@ from numpy.typing import ArrayLike, NDArray
 from typing_extensions import override
 
 from qxpulse.pulse import Pulse
+from qxpulse.waveform import _floor_to_sampling_period
 
 from .bump import Bump
 from .gaussian import Gaussian
@@ -183,8 +184,12 @@ class FlatTop(Pulse):
                 **kwargs,
             )
 
-        if beta is not None:
+        dI = None
+        if beta is not None or correction_type is not None:
             dI = np.gradient(I, t)
+        if beta is not None:
+            if dI is None:
+                raise RuntimeError("DRAG correction requires an envelope derivative.")
             if correction_type is None and correction_factor is None:
                 Q = beta * dI
                 return I + 1j * Q
@@ -199,6 +204,8 @@ class FlatTop(Pulse):
             correction_factor = 1.0
 
         Q = np.zeros_like(t, dtype=np.complex128)
+        if dI is None:
+            raise RuntimeError("Pulse correction requires an envelope derivative.")
         if correction_type == "DRAG":
             Q = -(correction_factor / delta) * dI
         elif correction_type == "CD":
@@ -259,7 +266,10 @@ def _ramp_func(
             t=t,
             duration=duration,
             amplitude=amplitude,
-            tau=(duration * 0.5) // Pulse.SAMPLING_PERIOD * Pulse.SAMPLING_PERIOD,
+            tau=_floor_to_sampling_period(
+                duration * 0.5,
+                Pulse.SAMPLING_PERIOD,
+            ),
             delta=delta,
             factor=0,
             **kwargs,

--- a/packages/qxpulse/src/qxpulse/library/flat_top.py
+++ b/packages/qxpulse/src/qxpulse/library/flat_top.py
@@ -9,7 +9,7 @@ from numpy.typing import ArrayLike, NDArray
 from typing_extensions import override
 
 from qxpulse.pulse import Pulse
-from qxpulse.waveform import _floor_to_sampling_period
+from qxpulse.waveform import floor_to_sampling_period
 
 from .bump import Bump
 from .gaussian import Gaussian
@@ -266,7 +266,7 @@ def _ramp_func(
             t=t,
             duration=duration,
             amplitude=amplitude,
-            tau=_floor_to_sampling_period(
+            tau=floor_to_sampling_period(
                 duration * 0.5,
                 Pulse.SAMPLING_PERIOD,
             ),

--- a/packages/qxpulse/src/qxpulse/library/sintegral.py
+++ b/packages/qxpulse/src/qxpulse/library/sintegral.py
@@ -9,6 +9,7 @@ from numpy.typing import ArrayLike, NDArray
 from typing_extensions import override
 
 from qxpulse.pulse import Pulse
+from qxpulse.waveform import _floor_to_sampling_period
 
 
 class Sintegral(Pulse):
@@ -123,7 +124,10 @@ class Sintegral(Pulse):
             np.where(
                 (
                     t
-                    <= (duration * 0.5) // Pulse.SAMPLING_PERIOD * Pulse.SAMPLING_PERIOD
+                    <= _floor_to_sampling_period(
+                        duration * 0.5,
+                        Pulse.SAMPLING_PERIOD,
+                    )
                 ),
                 values,
                 values if is_odd else 2 * amplitude - values,
@@ -354,7 +358,10 @@ class MultiDerivativeSintegral(Pulse):
             np.where(
                 (
                     t
-                    <= (duration * 0.5) // Pulse.SAMPLING_PERIOD * Pulse.SAMPLING_PERIOD
+                    <= _floor_to_sampling_period(
+                        duration * 0.5,
+                        Pulse.SAMPLING_PERIOD,
+                    )
                 ),
                 values,
                 values if is_odd else 2 * amplitude - values,

--- a/packages/qxpulse/src/qxpulse/library/sintegral.py
+++ b/packages/qxpulse/src/qxpulse/library/sintegral.py
@@ -9,7 +9,7 @@ from numpy.typing import ArrayLike, NDArray
 from typing_extensions import override
 
 from qxpulse.pulse import Pulse
-from qxpulse.waveform import _floor_to_sampling_period
+from qxpulse.waveform import floor_to_sampling_period
 
 
 class Sintegral(Pulse):
@@ -124,7 +124,7 @@ class Sintegral(Pulse):
             np.where(
                 (
                     t
-                    <= _floor_to_sampling_period(
+                    <= floor_to_sampling_period(
                         duration * 0.5,
                         Pulse.SAMPLING_PERIOD,
                     )
@@ -358,7 +358,7 @@ class MultiDerivativeSintegral(Pulse):
             np.where(
                 (
                     t
-                    <= _floor_to_sampling_period(
+                    <= floor_to_sampling_period(
                         duration * 0.5,
                         Pulse.SAMPLING_PERIOD,
                     )

--- a/packages/qxpulse/src/qxpulse/library/xy4.py
+++ b/packages/qxpulse/src/qxpulse/library/xy4.py
@@ -6,7 +6,7 @@ from typing import Final
 
 from qxpulse.blank import Blank
 from qxpulse.pulse_array import PulseArray
-from qxpulse.waveform import Waveform
+from qxpulse.waveform import Waveform, _is_sampling_period_multiple
 
 
 class XY4(PulseArray):
@@ -57,7 +57,7 @@ class XY4(PulseArray):
         self.pi_y: Final = pi_y
         self.n: Final = n
 
-        if tau % self.SAMPLING_PERIOD != 0:
+        if not _is_sampling_period_multiple(tau, self.SAMPLING_PERIOD):
             raise ValueError(
                 f"Tau must be a multiple of the sampling period ({self.SAMPLING_PERIOD} ns)."
             )

--- a/packages/qxpulse/src/qxpulse/library/xy4.py
+++ b/packages/qxpulse/src/qxpulse/library/xy4.py
@@ -6,7 +6,7 @@ from typing import Final
 
 from qxpulse.blank import Blank
 from qxpulse.pulse_array import PulseArray
-from qxpulse.waveform import Waveform, _is_sampling_period_multiple
+from qxpulse.waveform import Waveform, is_sampling_period_multiple
 
 
 class XY4(PulseArray):
@@ -57,7 +57,7 @@ class XY4(PulseArray):
         self.pi_y: Final = pi_y
         self.n: Final = n
 
-        if not _is_sampling_period_multiple(tau, self.SAMPLING_PERIOD):
+        if not is_sampling_period_multiple(tau, self.SAMPLING_PERIOD):
             raise ValueError(
                 f"Tau must be a multiple of the sampling period ({self.SAMPLING_PERIOD} ns)."
             )

--- a/packages/qxpulse/src/qxpulse/pulse_array.py
+++ b/packages/qxpulse/src/qxpulse/pulse_array.py
@@ -17,7 +17,7 @@ from qxvisualizer.style import COLORS
 from .blank import Blank
 from .phase_shift import PhaseShift, VirtualZ
 from .pulse import Pulse
-from .waveform import Waveform
+from .waveform import Waveform, is_zero_within_sampling_grid
 
 logger = logging.getLogger(__name__)
 
@@ -203,6 +203,8 @@ class PulseArray(Waveform):
             Side of the zero padding.
         """
         duration = total_duration - self.duration
+        if is_zero_within_sampling_grid(duration, self.sampling_period):
+            duration = 0.0
         if duration < 0:
             raise ValueError(
                 f"Total duration ({total_duration}) must be greater than the current duration ({self.duration})."
@@ -240,6 +242,8 @@ class PulseArray(Waveform):
             pulse-array container.
         """
         duration = total_duration - self.duration
+        if is_zero_within_sampling_grid(duration, self.sampling_period):
+            duration = 0.0
         if duration < 0:
             raise ValueError(
                 f"Total duration ({total_duration}) must be greater than the current duration ({self.duration})."

--- a/packages/qxpulse/src/qxpulse/pulse_array.py
+++ b/packages/qxpulse/src/qxpulse/pulse_array.py
@@ -209,7 +209,7 @@ class PulseArray(Waveform):
             raise ValueError(
                 f"Total duration ({total_duration}) must be greater than the current duration ({self.duration})."
             )
-        blank = Blank(duration)
+        blank = Blank(duration, sampling_period=self.sampling_period)
         if pad_side == "right":
             self._elements.append(blank)
         elif pad_side == "left":
@@ -252,7 +252,7 @@ class PulseArray(Waveform):
             new_array = copy.deepcopy(self)
         else:
             new_array = copy.copy(self)
-        blank = Blank(duration=duration)
+        blank = Blank(duration=duration, sampling_period=self.sampling_period)
         if pad_side == "right":
             new_elements = [*new_array._elements, blank]
         elif pad_side == "left":

--- a/packages/qxpulse/src/qxpulse/pulse_schedule.py
+++ b/packages/qxpulse/src/qxpulse/pulse_schedule.py
@@ -307,24 +307,20 @@ class PulseSchedule:
             If False, reuse nested waveform objects while detaching schedule
             and sequence containers.
         """
-        duration = total_duration - self.duration
-        if is_zero_within_sampling_grid(duration, self._resolve_sampling_period()):
-            duration = 0.0
-        if duration < 0:
-            raise ValueError(
-                f"Total duration ({total_duration}) must be greater than the current duration ({self.duration})."
-            )
+        self._validate_padding_total_duration(total_duration)
         with PulseSchedule() as new_sched:
             for label, channel in self._channels.items():
+                new_sequence = channel.sequence.padded(
+                    total_duration,
+                    pad_side,
+                    deepcopy=deepcopy,
+                )
                 new_sched.add(
                     label,
-                    channel.sequence.padded(
-                        total_duration,
-                        pad_side,
-                        deepcopy=deepcopy,
-                    ),
+                    new_sequence,
                 )
                 new_channel = new_sched._channels[label]
+                new_channel.sequence._sampling_period = new_sequence.sampling_period
                 new_channel.frequency = channel.frequency
                 new_channel.target = channel.target
                 new_channel.frame = channel.frame
@@ -345,13 +341,7 @@ class PulseSchedule:
         pad_side : {"right", "left"}, optional
             Side of the zero padding.
         """
-        duration = total_duration - self.duration
-        if is_zero_within_sampling_grid(duration, self._resolve_sampling_period()):
-            duration = 0.0
-        if duration < 0:
-            raise ValueError(
-                f"Total duration ({total_duration}) must be greater than the current duration ({self.duration})."
-            )
+        self._validate_padding_total_duration(total_duration)
         for channel in self._channels.values():
             channel.sequence.pad(total_duration, pad_side)
             self._offsets[channel.label] = total_duration
@@ -1002,6 +992,24 @@ class PulseSchedule:
         if len(sampling_periods) != 1:
             raise ValueError("Inconsistent sampling periods across channels.")
         return next(iter(sampling_periods))
+
+    def _validate_padding_total_duration(self, total_duration: float) -> None:
+        """Validate padding target duration against each channel sampling grid."""
+        if len(self._channels) == 0 and total_duration < 0:
+            raise ValueError(
+                f"Total duration ({total_duration}) must be greater than the current duration ({self.duration})."
+            )
+        for label, channel in self._channels.items():
+            duration = total_duration - self._offsets[label]
+            if is_zero_within_sampling_grid(
+                duration,
+                channel.sequence.sampling_period,
+            ):
+                duration = 0.0
+            if duration < 0:
+                raise ValueError(
+                    f"Total duration ({total_duration}) must be greater than the current duration ({self.duration})."
+                )
 
     @staticmethod
     def _downsample(

--- a/packages/qxpulse/src/qxpulse/pulse_schedule.py
+++ b/packages/qxpulse/src/qxpulse/pulse_schedule.py
@@ -31,7 +31,7 @@ from .blank import Blank
 from .phase_shift import PhaseShift
 from .pulse import Arbitrary
 from .pulse_array import PulseArray
-from .waveform import Waveform
+from .waveform import Waveform, is_zero_within_sampling_grid
 
 logger = logging.getLogger(__name__)
 
@@ -173,13 +173,8 @@ class PulseSchedule:
             return 0
         if not self.is_valid():
             raise ValueError("Inconsistent sequence lengths.")
-        sampling_periods = {
-            channel.sequence.sampling_period for channel in self._channels.values()
-        }
-        if len(sampling_periods) != 1:
-            raise ValueError("Inconsistent sampling periods across channels.")
         # Bind length computation to schedule-contained sampling periods, not mutable global defaults.
-        sampling_period = next(iter(sampling_periods))
+        sampling_period = self._resolve_sampling_period()
         # NOTE:
         #   Using floor division (//) with floating point numbers can lead to an off-by-one
         #   error due to binary representation (e.g. 100 // 0.1 -> 999.0 instead of 1000.0).
@@ -313,6 +308,8 @@ class PulseSchedule:
             and sequence containers.
         """
         duration = total_duration - self.duration
+        if is_zero_within_sampling_grid(duration, self._resolve_sampling_period()):
+            duration = 0.0
         if duration < 0:
             raise ValueError(
                 f"Total duration ({total_duration}) must be greater than the current duration ({self.duration})."
@@ -349,6 +346,8 @@ class PulseSchedule:
             Side of the zero padding.
         """
         duration = total_duration - self.duration
+        if is_zero_within_sampling_grid(duration, self._resolve_sampling_period()):
+            duration = 0.0
         if duration < 0:
             raise ValueError(
                 f"Total duration ({total_duration}) must be greater than the current duration ({self.duration})."
@@ -992,6 +991,17 @@ class PulseSchedule:
         max_offset = max(offsets, default=0.0)
 
         return max_offset
+
+    def _resolve_sampling_period(self) -> float:
+        """Return the unique schedule-contained sampling period."""
+        if len(self._channels) == 0:
+            return Waveform.SAMPLING_PERIOD
+        sampling_periods = {
+            channel.sequence.sampling_period for channel in self._channels.values()
+        }
+        if len(sampling_periods) != 1:
+            raise ValueError("Inconsistent sampling periods across channels.")
+        return next(iter(sampling_periods))
 
     @staticmethod
     def _downsample(

--- a/packages/qxpulse/src/qxpulse/waveform.py
+++ b/packages/qxpulse/src/qxpulse/waveform.py
@@ -35,7 +35,7 @@ def _nearest_sampling_period_sample_count(
     return None
 
 
-def _is_sampling_period_multiple(
+def is_sampling_period_multiple(
     duration: float,
     sampling_period: float,
     *,
@@ -52,7 +52,7 @@ def _is_sampling_period_multiple(
     )
 
 
-def _floor_to_sampling_period(
+def floor_to_sampling_period(
     duration: float,
     sampling_period: float,
     *,

--- a/packages/qxpulse/src/qxpulse/waveform.py
+++ b/packages/qxpulse/src/qxpulse/waveform.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 # Default sampling period in ns
 DEFAULT_SAMPLING_PERIOD = 2.0
-SAMPLING_PERIOD_TOLERANCE = 1e-9
+SAMPLING_PERIOD_TOLERANCE = 1e-8
 
 
 def _nearest_sampling_period_sample_count(
@@ -63,6 +63,23 @@ def floor_to_sampling_period(
     # Multiplication can round slightly above `duration` (for example 3 * 0.1),
     # so clamp the snapped value to keep the floor contract.
     return min(sample_count * sampling_period, duration)
+
+
+def is_zero_within_sampling_grid(
+    duration: float,
+    sampling_period: float,
+    *,
+    tolerance: float = SAMPLING_PERIOD_TOLERANCE,
+) -> bool:
+    """Return whether `duration` is zero samples within sampling-grid tolerance."""
+    return (
+        _nearest_sampling_period_sample_count(
+            duration,
+            sampling_period,
+            tolerance=tolerance,
+        )
+        == 0
+    )
 
 
 class Waveform(ABC):

--- a/packages/qxpulse/src/qxpulse/waveform.py
+++ b/packages/qxpulse/src/qxpulse/waveform.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import math
 from abc import ABC, abstractmethod
 from functools import cached_property
 from typing import Literal, cast
@@ -17,6 +18,51 @@ logger = logging.getLogger(__name__)
 
 # Default sampling period in ns
 DEFAULT_SAMPLING_PERIOD = 2.0
+SAMPLING_PERIOD_TOLERANCE = 1e-9
+
+
+def _nearest_sampling_period_sample_count(
+    duration: float,
+    sampling_period: float,
+    *,
+    tolerance: float = SAMPLING_PERIOD_TOLERANCE,
+) -> int | None:
+    """Return the nearest sample count when `duration` is on the sampling grid."""
+    samples = duration / sampling_period
+    sample_count = round(samples)
+    if abs(samples - sample_count) <= tolerance:
+        return sample_count
+    return None
+
+
+def _is_sampling_period_multiple(
+    duration: float,
+    sampling_period: float,
+    *,
+    tolerance: float = SAMPLING_PERIOD_TOLERANCE,
+) -> bool:
+    """Return whether `duration` is an integer multiple of the sampling period."""
+    return (
+        _nearest_sampling_period_sample_count(
+            duration,
+            sampling_period,
+            tolerance=tolerance,
+        )
+        is not None
+    )
+
+
+def _floor_to_sampling_period(
+    duration: float,
+    sampling_period: float,
+    *,
+    tolerance: float = SAMPLING_PERIOD_TOLERANCE,
+) -> float:
+    """Return `duration` floored to the sampling grid."""
+    sample_count = math.floor(duration / sampling_period + tolerance)
+    # Multiplication can round slightly above `duration` (for example 3 * 0.1),
+    # so clamp the snapped value to keep the floor contract.
+    return min(sample_count * sampling_period, duration)
 
 
 class Waveform(ABC):
@@ -180,11 +226,8 @@ class Waveform(ABC):
         if duration < 0:
             raise ValueError("Duration must be positive.")
 
-        # Tolerance for floating point comparison
-        tolerance = 1e-9
-        frac = duration / dt
-        N = round(frac)
-        if abs(frac - N) > tolerance:
+        N = _nearest_sampling_period_sample_count(duration, dt)
+        if N is None:
             raise ValueError(
                 f"Duration must be a multiple of the sampling period ({dt} ns)."
             )

--- a/tests/pulse/test_cpmg.py
+++ b/tests/pulse/test_cpmg.py
@@ -1,0 +1,32 @@
+"""Tests for the CPMG dynamical decoupling sequence."""
+
+import pytest
+from qxpulse.blank import Blank
+from qxpulse.library.cpmg import CPMG
+from qxpulse.pulse import Pulse
+from qxpulse.waveform import Waveform
+
+
+def test_cpmg_requires_multiple_of_sampling_period():
+    """Given tau not divisible by the sampling period, then CPMG rejects the value."""
+    with pytest.raises(
+        ValueError,
+        match=r"Tau must be a multiple of the sampling period",
+    ):
+        CPMG(
+            tau=Pulse.SAMPLING_PERIOD + 1,
+            pi=Blank(duration=Pulse.SAMPLING_PERIOD),
+        )
+
+
+def test_cpmg_accepts_float_multiple_of_sampling_period(monkeypatch):
+    """Given a float multiple of dt, then CPMG accepts tau despite float remainder noise."""
+    monkeypatch.setattr(Waveform, "SAMPLING_PERIOD", 0.4)
+
+    cpmg = CPMG(
+        tau=1.2,
+        pi=Blank(duration=0.4),
+    )
+
+    # Default n=2 creates two (tau, pi, tau) blocks: 2 * (3 + 1 + 3) samples.
+    assert cpmg.length == 14

--- a/tests/pulse/test_flat_top.py
+++ b/tests/pulse/test_flat_top.py
@@ -2,6 +2,7 @@
 
 import pytest
 from qxpulse import FlatTop, Pulse
+from qxpulse.waveform import Waveform
 
 import qubex as qx
 
@@ -75,3 +76,36 @@ def test_shape_kwargs_do_not_leak_pulse_init_parameters(monkeypatch):
     assert captured["window"] == "hann"
     assert "sampling_period" not in captured
     assert "lazy" not in captured
+
+
+def test_squad_ramp_snaps_half_duration_to_float_sampling_grid(monkeypatch):
+    """Given a float dt grid, then Squad ramps keep near-grid half durations stable."""
+    monkeypatch.setattr(Waveform, "SAMPLING_PERIOD", 0.4)
+
+    values = FlatTop.func(
+        [1.0],
+        duration=4.0,
+        amplitude=1.0,
+        tau=1.2,
+        delta=0.4,
+        type="Squad",
+    )
+
+    assert 0.0 < values[0].real < 1.0
+
+
+def test_cd_correction_without_beta_returns_complex_values():
+    """Given CD correction without beta, when sampling FlatTop, then values are complex."""
+    pulse = FlatTop(
+        duration=8 * dt,
+        amplitude=1.0,
+        tau=2 * dt,
+        delta=0.2,
+        correction_type="CD",
+        correction_factor=1.0,
+    )
+
+    values = pulse.values
+
+    assert len(values) == pulse.length
+    assert any(value.imag != 0.0 for value in values)

--- a/tests/pulse/test_pulse_array.py
+++ b/tests/pulse/test_pulse_array.py
@@ -4,7 +4,7 @@ import numpy as np
 import pytest
 
 import qubex as qx
-from qubex.pulse import Arbitrary, PulseArray, Waveform
+from qubex.pulse import Arbitrary, Blank, PulseArray, Waveform
 
 dt = qx.pulse.get_sampling_period()
 
@@ -76,6 +76,39 @@ def test_paddded():
 
     padded_left = arr.padded(10 * dt, "left")
     assert padded_left.values == pytest.approx([0, 0, 0, 0, 0, 0, 1, 1, 2, 2])
+
+
+@pytest.mark.parametrize("method_name", ["pad", "padded"])
+def test_padding_accepts_float_equivalent_total_duration(method_name):
+    """PulseArray padding should accept total duration equal within float roundoff."""
+    original_dt = qx.pulse.get_sampling_period()
+    try:
+        qx.pulse.set_sampling_period(0.4)
+        arr = PulseArray([Blank(duration=183.2)])
+
+        if method_name == "pad":
+            result = arr
+            arr.pad(183.2)
+        else:
+            result = arr.padded(183.2)
+
+        assert result.length == 458
+        assert result.duration == pytest.approx(183.2, abs=1e-12)
+    finally:
+        qx.pulse.set_sampling_period(original_dt)
+
+
+def test_padding_rejects_total_duration_below_float_tolerance():
+    """PulseArray padding should reject meaningfully shorter total duration."""
+    original_dt = qx.pulse.get_sampling_period()
+    try:
+        qx.pulse.set_sampling_period(0.4)
+        arr = PulseArray([Blank(duration=183.2)])
+
+        with pytest.raises(ValueError, match="Total duration"):
+            arr.padded(183.2 - 1e-6)
+    finally:
+        qx.pulse.set_sampling_period(original_dt)
 
 
 def test_scaled():

--- a/tests/pulse/test_pulse_schedule.py
+++ b/tests/pulse/test_pulse_schedule.py
@@ -142,6 +142,58 @@ def test_padding_accepts_float_equivalent_total_duration(method_name):
         qx.pulse.set_sampling_period(original_dt)
 
 
+@pytest.mark.parametrize("method_name", ["pad", "padded"])
+def test_padding_accepts_channel_sampling_periods(method_name):
+    """PulseSchedule padding should preserve channel-local sampling periods."""
+    original_dt = qx.pulse.get_sampling_period()
+    try:
+        schedule = PulseSchedule()
+        qx.pulse.set_sampling_period(0.4)
+        schedule.add("Q00", Blank(duration=4.0))
+        qx.pulse.set_sampling_period(0.8)
+        schedule.add("RQ00", Blank(duration=8.0))
+        qx.pulse.set_sampling_period(original_dt)
+
+        if method_name == "pad":
+            result = schedule
+            schedule.pad(8.0)
+        else:
+            result = schedule.padded(8.0)
+
+        q_sequence = result.get_sequence("Q00", copy=False)
+        readout_sequence = result.get_sequence("RQ00", copy=False)
+        assert q_sequence.sampling_period == pytest.approx(0.4)
+        assert readout_sequence.sampling_period == pytest.approx(0.8)
+        assert q_sequence.duration == pytest.approx(8.0)
+        assert readout_sequence.duration == pytest.approx(8.0)
+        assert q_sequence.length == 20
+        assert readout_sequence.length == 10
+        assert result.duration == pytest.approx(8.0)
+    finally:
+        qx.pulse.set_sampling_period(original_dt)
+
+
+def test_padding_rejects_shorter_channel_duration_without_mutation():
+    """PulseSchedule padding should reject shorter duration before mutating channels."""
+    original_dt = qx.pulse.get_sampling_period()
+    try:
+        schedule = PulseSchedule()
+        qx.pulse.set_sampling_period(0.4)
+        schedule.add("Q00", Blank(duration=4.0))
+        qx.pulse.set_sampling_period(0.8)
+        schedule.add("RQ00", Blank(duration=8.0))
+        qx.pulse.set_sampling_period(original_dt)
+
+        with pytest.raises(ValueError, match="Total duration"):
+            schedule.pad(7.2)
+
+        assert schedule.get_sequence("Q00", copy=False).duration == pytest.approx(4.0)
+        assert schedule.get_sequence("RQ00", copy=False).duration == pytest.approx(8.0)
+        assert schedule.duration == pytest.approx(8.0)
+    finally:
+        qx.pulse.set_sampling_period(original_dt)
+
+
 def test_scaled():
     """PulseSchedule should be scaled by a given parameter."""
     with PulseSchedule() as ps:

--- a/tests/pulse/test_pulse_schedule.py
+++ b/tests/pulse/test_pulse_schedule.py
@@ -121,6 +121,27 @@ def test_padded_can_skip_deepcopy_without_mutating_original_schedule() -> None:
     )
 
 
+@pytest.mark.parametrize("method_name", ["pad", "padded"])
+def test_padding_accepts_float_equivalent_total_duration(method_name):
+    """PulseSchedule padding should accept total duration equal within float roundoff."""
+    original_dt = qx.pulse.get_sampling_period()
+    try:
+        qx.pulse.set_sampling_period(0.4)
+        with PulseSchedule(["Q00"]) as schedule:
+            schedule.add("Q00", Blank(duration=183.2))
+
+        if method_name == "pad":
+            result = schedule
+            schedule.pad(183.2)
+        else:
+            result = schedule.padded(183.2)
+
+        assert result.length == 458
+        assert result.duration == pytest.approx(183.2, abs=1e-12)
+    finally:
+        qx.pulse.set_sampling_period(original_dt)
+
+
 def test_scaled():
     """PulseSchedule should be scaled by a given parameter."""
     with PulseSchedule() as ps:

--- a/tests/pulse/test_sintegral.py
+++ b/tests/pulse/test_sintegral.py
@@ -12,6 +12,7 @@ from qxpulse.library.sintegral import (
     sin_pow_integral,
 )
 from qxpulse.pulse import Pulse
+from qxpulse.waveform import Waveform
 
 
 def test_sin_pow_integral_derivative_matches():
@@ -80,6 +81,15 @@ def test_sintegral_func_requires_positive_duration():
     """Given a zero duration, then Sintegral.func raises ValueError."""
     with pytest.raises(ValueError, match=r"Duration cannot be zero\."):
         Sintegral.func([0.0], duration=0, amplitude=1.0, power=2)
+
+
+def test_sintegral_func_snaps_half_threshold_to_float_sampling_grid(monkeypatch):
+    """Given a float dt grid, then Sintegral keeps near-grid midpoints stable."""
+    monkeypatch.setattr(Waveform, "SAMPLING_PERIOD", 0.4)
+
+    values = Sintegral.func([1.0], duration=2.4, amplitude=1.0, power=2)
+
+    assert 0.0 < values[0].real < 1.0
 
 
 def test_multiderivative_sintegral_even_odd_contributions():

--- a/tests/pulse/test_xy4.py
+++ b/tests/pulse/test_xy4.py
@@ -4,6 +4,7 @@ import pytest
 from qxpulse.blank import Blank
 from qxpulse.library.xy4 import XY4
 from qxpulse.pulse import Pulse
+from qxpulse.waveform import Waveform
 
 
 def test_xy4_requires_multiple_of_sampling_period():
@@ -17,6 +18,20 @@ def test_xy4_requires_multiple_of_sampling_period():
             pi_x=Blank(duration=Pulse.SAMPLING_PERIOD),
             pi_y=Blank(duration=Pulse.SAMPLING_PERIOD),
         )
+
+
+def test_xy4_accepts_float_multiple_of_sampling_period(monkeypatch):
+    """Given a float multiple of dt, then XY4 accepts tau despite float remainder noise."""
+    monkeypatch.setattr(Waveform, "SAMPLING_PERIOD", 0.4)
+
+    xy4 = XY4(
+        tau=1.2,
+        pi_x=Blank(duration=0.4),
+        pi_y=Blank(duration=0.4),
+    )
+
+    # One XY4 cycle creates eight tau blanks and four pi pulses: 8 * 3 + 4 samples.
+    assert xy4.length == 28
 
 
 def test_xy4_requires_positive_cycle_count():


### PR DESCRIPTION
## Summary

- Tolerate floating-point roundoff when sampling pulse durations onto the qxpulse sampling grid.
- Expose shared sampling-grid helpers and use them across pulse library implementations.
- Tolerate near-zero padding duration deltas and preserve channel-local sampling periods while padding schedules.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`