### PR TITLE
Fix QuEL-3 fixed-timeline execution payloads

### DIFF
--- a/src/qubex/backend/quel3/builders/sequencer_builder.py
+++ b/src/qubex/backend/quel3/builders/sequencer_builder.py
@@ -15,6 +15,7 @@ _QUEL3_CLOCK_FREQUENCY_HZ = 312_500_000
 _TRIGGER_GRID_TICKS = 32
 _TRIGGER_GRID_NS = _TRIGGER_GRID_TICKS * (1e9 / _QUEL3_CLOCK_FREQUENCY_HZ)
 _MIN_SHOT_INTERVAL_NS = 1_024.0
+_TIME_GRID_SAMPLE_ATOL = 1e-3
 
 
 class Quel3SequencerBuilder:
@@ -26,6 +27,21 @@ class Quel3SequencerBuilder:
         return (
             math.ceil(effective_shot_interval_ns / _TRIGGER_GRID_NS) * _TRIGGER_GRID_NS
         )
+
+    @staticmethod
+    def _ceil_to_sampling_grid_ns(time_ns: float, sampling_period_fs: int) -> float:
+        """Return time ceiled to the alias sampling grid in ns."""
+        sampling_period_ns = sampling_period_fs / 1e6
+        samples = time_ns / sampling_period_ns
+        rounded_samples = round(samples)
+        if math.isclose(
+            samples,
+            rounded_samples,
+            rel_tol=0.0,
+            abs_tol=_TIME_GRID_SAMPLE_ATOL,
+        ):
+            return float(rounded_samples) * sampling_period_ns
+        return float(math.ceil(samples)) * sampling_period_ns
 
     def build(
         self,
@@ -80,6 +96,7 @@ class Quel3SequencerBuilder:
             )
 
         for instrument_alias, timeline in payload.fixed_timelines.items():
+            sampling_period_fs = alias_bindings[instrument_alias][0]
             for event in timeline.events:
                 if event.waveform_name not in payload.waveform_library:
                     raise ValueError(
@@ -88,7 +105,10 @@ class Quel3SequencerBuilder:
                 sequencer.add_event(
                     instrument_alias,
                     event.waveform_name,
-                    start_offset_ns=event.start_offset_ns,
+                    start_offset_ns=self._ceil_to_sampling_grid_ns(
+                        event.start_offset_ns,
+                        sampling_period_fs,
+                    ),
                     gain=event.gain,
                     phase_offset_deg=event.phase_offset_deg,
                 )
@@ -97,8 +117,14 @@ class Quel3SequencerBuilder:
                 sequencer.add_capture_window(
                     instrument_alias,
                     capture_window.name,
-                    start_offset_ns=capture_window.start_offset_ns,
-                    length_ns=capture_window.length_ns,
+                    start_offset_ns=self._ceil_to_sampling_grid_ns(
+                        capture_window.start_offset_ns,
+                        sampling_period_fs,
+                    ),
+                    length_ns=self._ceil_to_sampling_grid_ns(
+                        capture_window.length_ns,
+                        sampling_period_fs,
+                    ),
                 )
 
         if payload.shot_interval_ns > 0:

--- a/src/qubex/measurement/adapters/quel3_backend_adapter.py
+++ b/src/qubex/measurement/adapters/quel3_backend_adapter.py
@@ -95,10 +95,6 @@ class Quel3MeasurementBackendAdapter:
                     )
                 if capture.duration <= 0:
                     raise ValueError(f"Capture duration must be positive: {channel}.")
-                if capture.start_time + capture.duration > pulse_schedule.duration:
-                    raise ValueError(
-                        f"Capture exceeds pulse schedule duration: {channel}."
-                    )
 
     def build_execution_request(
         self,
@@ -145,15 +141,24 @@ class Quel3MeasurementBackendAdapter:
                 target=target,
                 target_type=target_type,
             )
-            capture_windows = tuple(
-                Quel3CaptureWindow(
-                    name=f"{target}:{index}",
-                    start_offset_ns=capture.start_time + capture_delay_ns,
-                    length_ns=capture.duration,
+            capture_windows = []
+            for index, capture in enumerate(captures):
+                capture_windows.append(
+                    Quel3CaptureWindow(
+                        name=f"{target}:{index}",
+                        start_offset_ns=capture.start_time + capture_delay_ns,
+                        length_ns=capture.duration,
+                    )
                 )
-                for index, capture in enumerate(captures)
-            )
             timeline_length_ns = pulse_schedule.duration
+            if len(events) > 0:
+                timeline_length_ns = max(
+                    timeline_length_ns,
+                    self._resolve_event_end_ns(
+                        events=events,
+                        waveform_library=waveform_library,
+                    ),
+                )
             if len(capture_windows) > 0:
                 timeline_length_ns = max(
                     timeline_length_ns,
@@ -164,7 +169,7 @@ class Quel3MeasurementBackendAdapter:
                 )
             fixed_timelines[target] = Quel3FixedTimeline(
                 events=events,
-                capture_windows=capture_windows,
+                capture_windows=tuple(capture_windows),
                 length_ns=timeline_length_ns,
                 frequency_hz=self._resolve_timeline_frequency_hz(
                     target=target,
@@ -335,6 +340,25 @@ class Quel3MeasurementBackendAdapter:
             return shots
         return 1
 
+    @staticmethod
+    def _resolve_event_end_ns(
+        *,
+        events: tuple[Quel3WaveformEvent, ...],
+        waveform_library: Mapping[str, Quel3Waveform],
+    ) -> float:
+        """Resolve the latest hardware event end time in ns."""
+        latest_end_ns = 0.0
+        for event in events:
+            waveform_def = waveform_library[event.waveform_name]
+            sampling_period_ns = waveform_def.sampling_period_ns
+            if sampling_period_ns is None:
+                continue
+            latest_end_ns = max(
+                latest_end_ns,
+                event.start_offset_ns + len(waveform_def.iq_array) * sampling_period_ns,
+            )
+        return latest_end_ns
+
     def _resolve_timeline_frequency_hz(
         self,
         *,
@@ -442,6 +466,8 @@ class Quel3MeasurementBackendAdapter:
                     shape=shape,
                     sampling_period_ns=sampling_period_ns,
                 )
+                if not np.all(np.isfinite(shape.real) & np.isfinite(shape.imag)):
+                    raise ValueError("Waveform IQ values must be finite.")
                 shape_key = (
                     waveform.shape_hash,
                     round(float(sampling_period_ns) * 1e6),

--- a/tests/backend/test_quel3_sequencer_builder.py
+++ b/tests/backend/test_quel3_sequencer_builder.py
@@ -212,6 +212,91 @@ def test_builder_registers_waveforms_and_forwards_events() -> None:
     assert sequencer.iterations == 16
 
 
+def test_builder_aligns_timeline_items_to_alias_sampling_grid() -> None:
+    """Given off-grid resolved timeline items, builder should align them to the alias grid."""
+    waveform_name = "wf_shared_0000"
+    timeline = Quel3FixedTimeline(
+        events=(
+            Quel3WaveformEvent(
+                waveform_name=waveform_name,
+                start_offset_ns=2484.4,
+            ),
+        ),
+        capture_windows=(
+            Quel3CaptureWindow(
+                name="capture_0",
+                start_offset_ns=2484.4,
+                length_ns=0.4,
+            ),
+        ),
+        length_ns=2484.8,
+    )
+    payload = _make_payload(
+        waveform_library={
+            waveform_name: Quel3Waveform(
+                iq_array=np.array([1.0 + 0.0j], dtype=np.complex128),
+                sampling_period_ns=0.8,
+            )
+        },
+        fixed_timelines={"alias-RQ00": timeline},
+    )
+
+    builder = Quel3SequencerBuilder()
+    sequencer = builder.build(
+        payload=payload,
+        sequencer_factory=_RecordingSequencer,
+        default_sampling_period_ns=0.4,
+        alias_bindings={"alias-RQ00": (800_000, 64)},
+    )
+
+    assert sequencer.events[0].start_offset_ns == pytest.approx(2484.8)
+    assert sequencer.capture_windows[0].start_offset_ns == pytest.approx(2484.8)
+    assert sequencer.capture_windows[0].length_ns == pytest.approx(0.8)
+
+
+def test_builder_accepts_near_grid_timing_roundoff() -> None:
+    """Given sub-millisample timing roundoff, builder should keep the nearest grid time."""
+    waveform_name = "wf_shared_0000"
+    sample_roundoff_ns = 0.8 * 5e-4
+    timeline = Quel3FixedTimeline(
+        events=(
+            Quel3WaveformEvent(
+                waveform_name=waveform_name,
+                start_offset_ns=2484.8 + sample_roundoff_ns,
+            ),
+        ),
+        capture_windows=(
+            Quel3CaptureWindow(
+                name="capture_0",
+                start_offset_ns=2484.8 + sample_roundoff_ns,
+                length_ns=0.8 + sample_roundoff_ns,
+            ),
+        ),
+        length_ns=2485.6,
+    )
+    payload = _make_payload(
+        waveform_library={
+            waveform_name: Quel3Waveform(
+                iq_array=np.array([1.0 + 0.0j], dtype=np.complex128),
+                sampling_period_ns=0.8,
+            )
+        },
+        fixed_timelines={"alias-RQ00": timeline},
+    )
+
+    builder = Quel3SequencerBuilder()
+    sequencer = builder.build(
+        payload=payload,
+        sequencer_factory=_RecordingSequencer,
+        default_sampling_period_ns=0.4,
+        alias_bindings={"alias-RQ00": (800_000, 64)},
+    )
+
+    assert sequencer.events[0].start_offset_ns == pytest.approx(2484.8)
+    assert sequencer.capture_windows[0].start_offset_ns == pytest.approx(2484.8)
+    assert sequencer.capture_windows[0].length_ns == pytest.approx(0.8)
+
+
 def test_builder_reuses_payload_waveform_across_targets() -> None:
     """Given shared waveform name in payload, when building, both targets reuse one registered waveform."""
     waveform_name = "wf_shared_0000"

--- a/tests/measurement/test_quel3_measurement_backend_adapter.py
+++ b/tests/measurement/test_quel3_measurement_backend_adapter.py
@@ -28,7 +28,7 @@ from qubex.measurement.models import (
     MeasurementSchedule,
 )
 from qubex.measurement.models.capture_schedule import Capture, CaptureSchedule
-from qubex.pulse import Arbitrary, PulseArray
+from qubex.pulse import Arbitrary, Blank, PulseArray
 from qubex.system import TargetRegistry
 from qubex.system.target_type import TargetType
 from qubex.typing import MeasurementMode
@@ -203,9 +203,10 @@ def test_quel3_adapter_accepts_relaxed_schedule() -> None:
     assert result is None
 
 
-def test_quel3_adapter_rejects_capture_outside_pulse_duration() -> None:
-    """Given out-of-range capture, when validating, then ValueError is raised."""
+def test_quel3_adapter_allows_capture_beyond_pulse_duration() -> None:
+    """Given capture beyond pulses, payload timeline extends to capture end."""
     target = "RQ00"
+    alias = "alias-RQ00"
     schedule = MeasurementSchedule.model_construct(
         pulse_schedule=_FakePulseSchedule(
             duration=10.0,
@@ -224,10 +225,17 @@ def test_quel3_adapter_rejects_capture_outside_pulse_duration() -> None:
     adapter = Quel3MeasurementBackendAdapter(
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
+        constraint_profile=MeasurementConstraintProfile.quel3(0.4),
+        instrument_alias_map={target: alias},
     )
 
-    with pytest.raises(ValueError, match="exceeds pulse schedule duration"):
-        adapter.validate_schedule(schedule)
+    result = adapter.validate_schedule(schedule)
+    request = adapter.build_execution_request(schedule=schedule, config=_make_config())
+
+    payload = request.payload
+    assert result is None
+    assert isinstance(payload, Quel3ExecutionPayload)
+    assert payload.fixed_timelines[target].length_ns == pytest.approx(11.0)
 
 
 def test_quel3_adapter_builds_fixed_timeline_payload() -> None:
@@ -281,7 +289,7 @@ def test_quel3_adapter_builds_fixed_timeline_payload() -> None:
         waveform_def.iq_array,
         np.array([0.5 + 0.0j, 0.0 + 0.0j], dtype=np.complex128),
     )
-    assert timeline.length_ns == pytest.approx(1.2)
+    assert timeline.length_ns == pytest.approx(1.6)
     assert len(timeline.capture_windows) == 1
     assert timeline.capture_windows[0].name == f"{target}:0"
     assert timeline.capture_windows[0].start_offset_ns == pytest.approx(0.4)
@@ -504,6 +512,7 @@ def test_quel3_adapter_applies_mux_capture_delay_to_capture_windows() -> None:
 
     timeline = request.payload.fixed_timelines[target]
     assert timeline.capture_windows[0].start_offset_ns == pytest.approx(1.2)
+    assert timeline.capture_windows[0].length_ns == pytest.approx(0.4)
     assert timeline.length_ns == pytest.approx(1.6)
 
 
@@ -826,12 +835,127 @@ def test_quel3_adapter_downsamples_readout_waveforms_to_0p8ns() -> None:
     payload = request.payload
     assert isinstance(payload, Quel3ExecutionPayload)
     timeline = payload.fixed_timelines[target]
+    event = timeline.events[0]
     waveform_def = payload.waveform_library[timeline.events[0].waveform_name]
     assert waveform_def.sampling_period_ns == pytest.approx(0.8)
     assert np.array_equal(
         waveform_def.iq_array,
         np.array([2.0 + 0.0j, 6.0 + 0.0j], dtype=np.complex128),
     )
+    assert event.gain == pytest.approx(1.0)
+
+
+def test_quel3_adapter_registers_waveform_iq_without_gain_normalization() -> None:
+    """Given over-range waveform shape, payload should register waveform IQ directly."""
+    target = "Q00"
+    schedule = MeasurementSchedule.model_construct(
+        pulse_schedule=_FakePulseSchedule(
+            duration=0.8,
+            sequences={
+                target: _pulse_array(
+                    values=np.array([0.0 + 0.0j, 0.0 + 2.0j], dtype=np.complex128),
+                    sampling_period=0.4,
+                    scale=0.5,
+                    phase=np.deg2rad(30.0),
+                )
+            },
+        ),
+        capture_schedule=CaptureSchedule(captures=[]),
+    )
+    adapter = Quel3MeasurementBackendAdapter(
+        backend_controller=_make_backend_controller(),
+        experiment_system=cast(Any, _FakeExperimentSystem()),
+        constraint_profile=MeasurementConstraintProfile.quel3(0.4),
+        instrument_alias_map={target: "alias-Q00"},
+    )
+
+    request = adapter.build_execution_request(schedule=schedule, config=_make_config())
+
+    payload = request.payload
+    assert isinstance(payload, Quel3ExecutionPayload)
+    event = payload.fixed_timelines[target].events[0]
+    waveform_def = payload.waveform_library[event.waveform_name]
+    assert np.array_equal(
+        waveform_def.iq_array,
+        np.array([0.0 + 0.0j, 0.0 + 2.0j], dtype=np.complex128),
+    )
+    assert event.gain == pytest.approx(0.5)
+    assert event.phase_offset_deg == pytest.approx(30.0)
+
+
+def test_quel3_adapter_rejects_nonfinite_waveform_iq() -> None:
+    """Given non-finite waveform IQ, payload building should fail fast."""
+    target = "Q00"
+    schedule = MeasurementSchedule.model_construct(
+        pulse_schedule=_FakePulseSchedule(
+            duration=0.8,
+            sequences={
+                target: _pulse_array(
+                    values=np.array([0.0 + 0.0j, np.nan + 0.0j], dtype=np.complex128),
+                    sampling_period=0.4,
+                )
+            },
+        ),
+        capture_schedule=CaptureSchedule(captures=[]),
+    )
+    adapter = Quel3MeasurementBackendAdapter(
+        backend_controller=_make_backend_controller(),
+        experiment_system=cast(Any, _FakeExperimentSystem()),
+        constraint_profile=MeasurementConstraintProfile.quel3(0.4),
+        instrument_alias_map={target: "alias-Q00"},
+    )
+
+    with pytest.raises(ValueError, match="Waveform IQ values must be finite"):
+        adapter.build_execution_request(schedule=schedule, config=_make_config())
+
+
+def test_quel3_adapter_keeps_readout_timing_unrounded_in_payload() -> None:
+    """Given half-readout-grid timings, payload should keep logical timing."""
+    target = "RQ00"
+    schedule = MeasurementSchedule.model_construct(
+        pulse_schedule=_FakePulseSchedule(
+            duration=207.2,
+            sequences={
+                target: PulseArray(
+                    [
+                        Blank(duration=206.0, sampling_period=0.4),
+                        Arbitrary(
+                            values=np.array(
+                                [1.0 + 0.0j, 3.0 + 0.0j],
+                                dtype=np.complex128,
+                            ),
+                            sampling_period=0.4,
+                        ),
+                    ]
+                )
+            },
+        ),
+        capture_schedule=CaptureSchedule(
+            captures=[
+                Capture(
+                    channels=[target],
+                    start_time=206.0,
+                    duration=0.4,
+                ),
+            ]
+        ),
+    )
+    adapter = Quel3MeasurementBackendAdapter(
+        backend_controller=_make_backend_controller(),
+        experiment_system=cast(Any, _FakeExperimentSystem()),
+        constraint_profile=MeasurementConstraintProfile.quel3(0.4),
+        instrument_alias_map={target: "alias-RQ00"},
+    )
+
+    request = adapter.build_execution_request(schedule=schedule, config=_make_config())
+
+    payload = request.payload
+    assert isinstance(payload, Quel3ExecutionPayload)
+    timeline = payload.fixed_timelines[target]
+    assert timeline.events[0].start_offset_ns == pytest.approx(206.0)
+    assert timeline.capture_windows[0].start_offset_ns == pytest.approx(206.0)
+    assert timeline.capture_windows[0].length_ns == pytest.approx(0.4)
+    assert timeline.length_ns == pytest.approx(207.2)
 
 
 def test_quel3_adapter_omits_empty_waveforms_from_payload() -> None:


### PR DESCRIPTION
## Summary

- Allow QuEL-3 capture windows to extend beyond the pulse schedule duration and size fixed timelines to the latest event or capture endpoint.
- Register waveform shapes directly while preserving waveform.shape_hash-based reuse.
- Snap QuEL-3 sequencer event and capture timings to alias-specific sampling grids.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`