### PR TITLE
fix(quel3): avoid NCO-based filtering in direct frequency sweeps

### DIFF
--- a/src/qubex/experiment/experiment_context.py
+++ b/src/qubex/experiment/experiment_context.py
@@ -519,6 +519,9 @@ class ExperimentContext:
     @property
     def available_targets(self) -> dict[str, Target]:
         """Return available targets keyed by label."""
+        if self.config_loader.backend_kind == BACKEND_KIND_QUEL3:
+            return dict(self.targets)
+
         return {
             label: target
             for label, target in self.targets.items()

--- a/src/qubex/experiment/services/characterization_service.py
+++ b/src/qubex/experiment/services/characterization_service.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 from collections import defaultdict
 from collections.abc import Callable, Collection
+from contextlib import nullcontext
 from copy import deepcopy
 from typing import Any, Literal
 
@@ -27,6 +28,7 @@ from typing_extensions import deprecated
 
 import qubex.visualization as viz
 from qubex.analysis import FitStatus, fitting
+from qubex.backend.backend_controller import BACKEND_KIND_QUEL3
 from qubex.experiment.experiment_constants import (
     CALIBRATION_SHOTS,
     DEFAULT_INTERVAL,
@@ -167,6 +169,11 @@ class CharacterizationService:
     def calibration_service(self) -> CalibrationService:
         """Return the calibration service."""
         return self._calibration_service
+
+    def _uses_quel3_frequency_directives(self) -> bool:
+        """Return whether spectroscopy should use QuEL-3 frequency directives."""
+        system_manager = getattr(self.ctx, "system_manager", None)
+        return getattr(system_manager, "backend_kind", None) == BACKEND_KIND_QUEL3
 
     @staticmethod
     def _is_valid_chevron_rabi_param(param: Any) -> bool:
@@ -1884,9 +1891,13 @@ class CharacterizationService:
         read_label = self.ctx.resolve_read_label(target)
         qubit_label = self.ctx.resolve_qubit_label(target)
         mux = self.ctx.experiment_system.get_mux_by_qubit(qubit_label)
-        ssb = self.ctx.targets[read_label].sideband
         read_box = self.ctx.experiment_system.get_readout_box_for_qubit(qubit_label)
-        f_nco = self.ctx.targets[read_label].fine_frequency
+        use_quel3_frequency_directives = self._uses_quel3_frequency_directives()
+        if use_quel3_frequency_directives:
+            current_frequency = self.ctx.targets[read_label].frequency
+        else:
+            ssb = self.ctx.targets[read_label].sideband
+            f_nco = self.ctx.targets[read_label].fine_frequency
 
         if df is None:
             df = DEFAULT_ELECTRICAL_DELAY_STEP_GHZ
@@ -1895,7 +1906,10 @@ class CharacterizationService:
         if readout_amplitude is None:
             readout_amplitude = DEFAULT_ELECTRICAL_DELAY_READOUT_AMPLITUDE
         if f_start is None:
-            f_start = f_nco
+            if use_quel3_frequency_directives:
+                f_start = current_frequency
+            else:
+                f_start = f_nco
         frequency_range = np.arange(f_start, f_start + df * n_samples, df)
 
         def _execute(*, reset_awg_and_capunits: bool = True):
@@ -1918,7 +1932,9 @@ class CharacterizationService:
                     phases.append(phase)
             return phases
 
-        if abs(f_start - f_nco) > 0.2:
+        if use_quel3_frequency_directives:
+            phases = _execute(reset_awg_and_capunits=False)
+        elif abs(f_start - f_nco) > 0.2:
             # if the frequency is far from the NCO frequency, we need to change the LO/NCO frequency
             if confirm:
                 confirmed = Confirm.ask(
@@ -2070,22 +2086,28 @@ class CharacterizationService:
         idx = 0
         phase_offset = 0.0
 
-        ssb = read_box.traits.readout_ssb
-        cnco_center = read_box.traits.readout_cnco_center
+        use_quel3_frequency_directives = self._uses_quel3_frequency_directives()
+        if not use_quel3_frequency_directives:
+            ssb = read_box.traits.readout_ssb
+            cnco_center = read_box.traits.readout_cnco_center
 
         for subrange in subranges:
-            f_center = (subrange[0] + subrange[-1]) / 2
-            lo, cnco, _ = MixingUtil.calc_lo_cnco(
-                f_center * 1e9,
-                ssb=ssb,
-                cnco_center=cnco_center,
-            )
-            with self.ctx.system_manager.modified_backend_settings(
-                label=read_label,
-                lo_freq=lo,
-                cnco_freq=cnco,
-                fnco_freq=0,
-            ):
+            if use_quel3_frequency_directives:
+                backend_settings = nullcontext()
+            else:
+                f_center = (subrange[0] + subrange[-1]) / 2
+                lo, cnco, _ = MixingUtil.calc_lo_cnco(
+                    f_center * 1e9,
+                    ssb=ssb,
+                    cnco_center=cnco_center,
+                )
+                backend_settings = self.ctx.system_manager.modified_backend_settings(
+                    label=read_label,
+                    lo_freq=lo,
+                    cnco_freq=cnco,
+                    fnco_freq=0,
+                )
+            with backend_settings:
                 for sub_idx, freq in enumerate(subrange):
                     if idx > 0 and sub_idx == 0:
                         prev_freq = frequency_range[idx - 1]
@@ -2680,24 +2702,30 @@ class CharacterizationService:
         # result buffer
         signals = []
 
-        ssb = ctrl_box.traits.ctrl_ssb
-        cnco_center = CNCO_CENTER_CTRL_HZ
+        use_quel3_frequency_directives = self._uses_quel3_frequency_directives()
+        if not use_quel3_frequency_directives:
+            ssb = ctrl_box.traits.ctrl_ssb
+            cnco_center = CNCO_CENTER_CTRL_HZ
 
         # measure the phase and amplitude
         idx = 0
         for subrange in subranges:
-            f_center = (subrange[0] + subrange[-1]) / 2
-            lo, cnco, _ = MixingUtil.calc_lo_cnco(
-                f_center * 1e9,
-                ssb=ssb,
-                cnco_center=cnco_center,
-            )
-            with self.ctx.system_manager.modified_backend_settings(
-                label=qubit,
-                lo_freq=lo,
-                cnco_freq=cnco,
-                fnco_freq=0,
-            ):
+            if use_quel3_frequency_directives:
+                backend_settings = nullcontext()
+            else:
+                f_center = (subrange[0] + subrange[-1]) / 2
+                lo, cnco, _ = MixingUtil.calc_lo_cnco(
+                    f_center * 1e9,
+                    ssb=ssb,
+                    cnco_center=cnco_center,
+                )
+                backend_settings = self.ctx.system_manager.modified_backend_settings(
+                    label=qubit,
+                    lo_freq=lo,
+                    cnco_freq=cnco,
+                    fnco_freq=0,
+                )
+            with backend_settings:
                 self.ctx.reset_awg_and_capunits(qubits=[qubit])
                 for control_frequency in subrange:
                     with self.ctx.modified_frequencies(

--- a/tests/experiment/test_characterization_service_electrical_delay.py
+++ b/tests/experiment/test_characterization_service_electrical_delay.py
@@ -71,6 +71,94 @@ class _FakeContext:
         yield
 
 
+class _Quel3SystemManager:
+    """QuEL-3 system-manager stub that rejects QuEL-1 backend retunes."""
+
+    backend_kind = "quel3"
+
+    @contextmanager
+    def modified_backend_settings(self, *_args, **_kwargs):
+        """Given QuEL-3 spectroscopy, backend-settings retunes must not be used."""
+        raise AssertionError("QuEL-3 spectroscopy must not retune backend settings")
+        yield
+
+
+class _FakeFigure:
+    """Plotly-like no-op figure for characterization tests."""
+
+    def set_subplots(self, **_kwargs) -> None:
+        """Given subplot setup, ignore it."""
+        return
+
+    def add_scatter(self, **_kwargs) -> None:
+        """Given plotted data, ignore it."""
+        return
+
+    def add_vline(self, **_kwargs) -> None:
+        """Given vertical marker, ignore it."""
+        return
+
+    def add_annotation(self, **_kwargs) -> None:
+        """Given annotation, ignore it."""
+        return
+
+    def update_xaxes(self, **_kwargs) -> None:
+        """Given x-axis update, ignore it."""
+        return
+
+    def update_yaxes(self, **_kwargs) -> None:
+        """Given y-axis update, ignore it."""
+        return
+
+    def update_layout(self, **_kwargs) -> None:
+        """Given layout update, ignore it."""
+        return
+
+    def show(self) -> None:
+        """Given show request, ignore it."""
+        return
+
+
+class _Quel3Context(_FakeContext):
+    """Experiment-context stub for QuEL-3 spectroscopy tests."""
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.params = SimpleNamespace(
+            control_amplitude={"Q00": 0.1},
+            readout_amplitude={"Q00": 0.1},
+        )
+        self.targets = {
+            "Q00": SimpleNamespace(frequency=4.9),
+            "R00": SimpleNamespace(
+                frequency=6.2,
+                sideband=None,
+                fine_frequency=6.2,
+            ),
+        }
+        self.system_manager = _Quel3SystemManager()
+        read_box = SimpleNamespace(
+            id="BOX0",
+            traits=SimpleNamespace(
+                default_readout_frequency_range=(6.15, 6.25, 0.01),
+                readout_cnco_center=None,
+                readout_ssb=None,
+            ),
+        )
+        ctrl_box = SimpleNamespace(
+            id="BOX0",
+            traits=SimpleNamespace(
+                default_control_frequency_range=(4.8, 5.0, 0.01),
+                ctrl_ssb=None,
+            ),
+        )
+        self.experiment_system = SimpleNamespace(
+            get_mux_by_qubit=lambda _qubit: SimpleNamespace(label="MUX0"),
+            get_readout_box_for_qubit=lambda _qubit: read_box,
+            get_control_box_for_qubit=lambda _qubit: ctrl_box,
+        )
+
+
 def test_measure_electrical_delay_skips_redundant_reset_when_backend_settings_change(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -109,6 +197,36 @@ def test_measure_electrical_delay_skips_redundant_reset_when_backend_settings_ch
     assert ctx.reset_calls == []
 
 
+def test_measure_electrical_delay_quel3_uses_direct_frequency_sweep() -> None:
+    """Given QuEL-3 backend, electrical-delay measurement avoids LO/CNCO retunes."""
+    service = cast(Any, object.__new__(CharacterizationService))
+    ctx = _Quel3Context()
+    service.__dict__["_experiment_context"] = ctx
+
+    def _fake_measure(*_args, **_kwargs):
+        signal = np.exp(-1j * 2 * np.pi * ctx.current_frequency)
+        return SimpleNamespace(data={"Q00": SimpleNamespace(kerneled=signal)})
+
+    service.__dict__["_measurement_service"] = SimpleNamespace(measure=_fake_measure)
+    service.__dict__["_calibration_service"] = SimpleNamespace()
+    service.__dict__["_pulse_service"] = SimpleNamespace()
+
+    tau = service.measure_electrical_delay(
+        target="Q00",
+        f_start=6.5,
+        df=0.0001,
+        n_samples=4,
+        readout_amplitude=0.1,
+        shots=1,
+        interval=0,
+        plot=False,
+        confirm=False,
+    )
+
+    assert isinstance(tau, float)
+    assert ctx.reset_calls == []
+
+
 def test_scan_resonator_frequencies_avoids_duplicate_reset_per_subrange(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -124,28 +242,6 @@ def test_scan_resonator_frequencies_avoids_duplicate_reset_per_subrange(
     service.__dict__["_measurement_service"] = SimpleNamespace(measure=_fake_measure)
     service.__dict__["_calibration_service"] = SimpleNamespace()
     service.__dict__["_pulse_service"] = SimpleNamespace()
-
-    class _FakeFigure:
-        def set_subplots(self, **_kwargs) -> None:
-            return
-
-        def add_scatter(self, **_kwargs) -> None:
-            return
-
-        def add_vline(self, **_kwargs) -> None:
-            return
-
-        def add_annotation(self, **_kwargs) -> None:
-            return
-
-        def update_xaxes(self, **_kwargs) -> None:
-            return
-
-        def update_yaxes(self, **_kwargs) -> None:
-            return
-
-        def update_layout(self, **_kwargs) -> None:
-            return
 
     monkeypatch.setattr(
         "qubex.experiment.services.characterization_service.ExperimentUtil.split_frequency_range",
@@ -182,3 +278,85 @@ def test_scan_resonator_frequencies_avoids_duplicate_reset_per_subrange(
     assert "peaks" in result.data
     assert ctx.system_manager.modified_backend_settings_calls == 2
     assert ctx.reset_calls == []
+
+
+def test_scan_resonator_frequencies_quel3_uses_direct_frequency_sweep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given QuEL-3 backend, resonator spectroscopy avoids LO/CNCO retunes."""
+    service = cast(Any, object.__new__(CharacterizationService))
+    ctx = _Quel3Context()
+    service.__dict__["_experiment_context"] = ctx
+
+    def _fake_measure(*_args, **_kwargs):
+        signal = np.exp(-1j * 2 * np.pi * ctx.current_frequency)
+        return SimpleNamespace(data={"Q00": SimpleNamespace(kerneled=signal)})
+
+    service.__dict__["_measurement_service"] = SimpleNamespace(measure=_fake_measure)
+    service.__dict__["_calibration_service"] = SimpleNamespace()
+    service.__dict__["_pulse_service"] = SimpleNamespace()
+
+    monkeypatch.setattr(
+        "qubex.experiment.services.characterization_service.viz.make_figure",
+        lambda **_kwargs: _FakeFigure(),
+    )
+    monkeypatch.setattr(
+        "scipy.signal.find_peaks",
+        lambda values, **_kwargs: (np.array([], dtype=int), {}),
+    )
+
+    result = service.scan_resonator_frequencies(
+        target="Q00",
+        frequency_range=np.array([6.15, 6.16, 6.17]),
+        electrical_delay=0.0,
+        readout_amplitude=0.1,
+        plot=False,
+        save_image=False,
+        subrange_width=0.02,
+        shots=1,
+        interval=0,
+    )
+
+    assert result.data["peaks"].size == 0
+
+
+def test_scan_qubit_frequencies_quel3_uses_direct_frequency_sweep(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given QuEL-3 backend, qubit spectroscopy avoids LO/CNCO retunes."""
+    service = cast(Any, object.__new__(CharacterizationService))
+    ctx = _Quel3Context()
+    service.__dict__["_experiment_context"] = ctx
+
+    def _fake_execute(*_args, **_kwargs):
+        signal = np.exp(-1j * 2 * np.pi * ctx.current_frequency)
+        return SimpleNamespace(data={"Q00": [SimpleNamespace(kerneled=signal)]})
+
+    service.__dict__["_measurement_service"] = SimpleNamespace(execute=_fake_execute)
+    service.__dict__["_calibration_service"] = SimpleNamespace()
+    service.__dict__["_pulse_service"] = SimpleNamespace()
+
+    monkeypatch.setattr(
+        "qubex.experiment.services.characterization_service.viz.make_figure",
+        lambda **_kwargs: _FakeFigure(),
+    )
+    monkeypatch.setattr(
+        "scipy.signal.find_peaks",
+        lambda values, **_kwargs: (np.array([], dtype=int), {}),
+    )
+
+    result = service.scan_qubit_frequencies(
+        target="Q00",
+        frequency_range=np.array([4.85, 4.86, 4.87]),
+        control_amplitude=0.1,
+        readout_amplitude=0.1,
+        readout_frequency=6.2,
+        subrange_width=0.02,
+        shots=1,
+        interval=0,
+        plot=False,
+        save_image=False,
+    )
+
+    assert result.data["peaks"].size == 0
+    assert result.data["frequency_guess"]["f_ge"] is None

--- a/tests/experiment/test_experiment_context_targets.py
+++ b/tests/experiment/test_experiment_context_targets.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 from types import SimpleNamespace
 from typing import Literal
 
+from qubex.backend.backend_controller import BACKEND_KIND_QUEL1, BACKEND_KIND_QUEL3
 from qubex.experiment.experiment_context import ExperimentContext
 from qubex.system import Qubit, Target
 from qubex.system.control_system import GenChannel, GenPort, PortType
@@ -151,3 +152,47 @@ def test_get_edge_labels_can_include_cross_mux_edges(monkeypatch) -> None:
 
     assert context.get_edge_labels(in_same_mux=False) == ["Q00-Q01", "Q00-Q02"]
     assert recorded == [False]
+
+
+def test_available_targets_filter_unavailable_targets_for_quel1(monkeypatch) -> None:
+    """Given QuEL-1 backend, when listing available targets, then unavailable targets are filtered."""
+    context = object.__new__(ExperimentContext)
+    targets = {
+        "Q00": SimpleNamespace(is_available=True),
+        "Q01": SimpleNamespace(is_available=False),
+    }
+
+    monkeypatch.setattr(
+        ExperimentContext,
+        "config_loader",
+        property(lambda self: SimpleNamespace(backend_kind=BACKEND_KIND_QUEL1)),
+    )
+    monkeypatch.setattr(
+        ExperimentContext,
+        "targets",
+        property(lambda self: targets),
+    )
+
+    assert set(context.available_targets) == {"Q00"}
+
+
+def test_available_targets_keep_unavailable_targets_for_quel3(monkeypatch) -> None:
+    """Given QuEL-3 backend, when listing available targets, then all targets are retained."""
+    context = object.__new__(ExperimentContext)
+    targets = {
+        "Q00": SimpleNamespace(is_available=True),
+        "Q01": SimpleNamespace(is_available=False),
+    }
+
+    monkeypatch.setattr(
+        ExperimentContext,
+        "config_loader",
+        property(lambda self: SimpleNamespace(backend_kind=BACKEND_KIND_QUEL3)),
+    )
+    monkeypatch.setattr(
+        ExperimentContext,
+        "targets",
+        property(lambda self: targets),
+    )
+
+    assert set(context.available_targets) == {"Q00", "Q01"}


### PR DESCRIPTION
## Background

QuEL-3 frequency sweeps should not depend on the QuEL-1 NCO/fine-frequency availability model. This PR is an interim workaround: it keeps configured QuEL-3 targets visible and uses direct target-frequency overrides in the spectroscopy paths that were still relying on LO/CNCO retuning behavior.

A fuller QuEL-3 availability model based on deployed instrument frequency ranges is intentionally left as follow-up work.

## Changes

- Keep configured targets available for QuEL-3 instead of filtering them through `Target.is_available`.
- Avoid QuEL-1 LO/CNCO retuning in QuEL-3 electrical delay, resonator spectroscopy, and qubit spectroscopy scans.
- Use `modified_frequencies` for QuEL-3 direct frequency sweep behavior.
- Add focused tests covering QuEL-3 target visibility and direct sweep paths.

## Compatibility

- QuEL-1 behavior remains unchanged.
- QuEL-3 behavior changes only where the old code was applying QuEL-1 NCO assumptions.
- This does not yet validate target availability against deployed Instrument frequency ranges.

## Validation

Previously run on this branch:

- `uv run pytest tests/experiment/test_characterization_service_electrical_delay.py tests/experiment/test_experiment_context_targets.py`
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`
