### PR TITLE
Fix port_wait handling in skew manager

### DIFF
--- a/src/qubex/backend/quel1/managers/skew_manager.py
+++ b/src/qubex/backend/quel1/managers/skew_manager.py
@@ -105,13 +105,10 @@ class Quel1SkewManager:
             box_names=resolved_box_names,
         )
         for box_name, port, idx in estimated_indices:
-            port_wait = self._require_port_wait(
-                box_setting[box_name],
-                box_name=box_name,
-            )
-            if port not in port_wait:
-                raise ValueError(f"box_setting.{box_name}.port_wait.{port} is required")
-            current_wait = port_wait[port]
+            port_wait = box_setting[box_name].setdefault("port_wait", {})
+            if not isinstance(port_wait, dict):
+                raise TypeError(f"box_setting.{box_name}.port_wait must be a mapping")
+            current_wait = port_wait.get(port, self._WAIT_MIN)
             self._validate_wait_value(current_wait, box_name=box_name)
             port_wait[port] = max(self._WAIT_MIN, current_wait + (wait - idx))
 
@@ -183,6 +180,8 @@ class Quel1SkewManager:
     ) -> dict[Any, Any]:
         """Return the `port_wait` mapping from one box skew setting."""
         port_wait = setting.get("port_wait")
+        if port_wait is None:
+            return {}
         if not isinstance(port_wait, dict):
             raise TypeError(f"box_setting.{box_name}.port_wait must be a mapping")
         return port_wait

--- a/src/qubex/backend/quel1/managers/skew_manager.py
+++ b/src/qubex/backend/quel1/managers/skew_manager.py
@@ -181,6 +181,8 @@ class Quel1SkewManager:
         """Return the `port_wait` mapping from one box skew setting."""
         port_wait = setting.get("port_wait")
         if port_wait is None:
+            # TODO: Replace this fallback when the full port_wait initialization
+            # path is defined.
             return {}
         if not isinstance(port_wait, dict):
             raise TypeError(f"box_setting.{box_name}.port_wait must be a mapping")


### PR DESCRIPTION
This patch relaxes the strict requirement for port_wait.

In the current behavior introduced by #270 , the entire flow fails when port_wait is missing. This change adds a temporary fallback to avoid breaking existing configurations until the full port_wait initialization path is properly defined.