### PR TITLE
Update skew adjustment logic and documentation

### DIFF
--- a/docs/examples/system/quel1_skew_adjustment.ja.md
+++ b/docs/examples/system/quel1_skew_adjustment.ja.md
@@ -75,7 +75,7 @@ figure = result.figure
 ## 目標 skew 値を設定する
 
 `check_skew(...)` で現在の pulse index を推定したあと、
-各 measured port の index が共通 target に揃うように `port_wait` をずらすには
+各 measured port の index が共通 target に揃うように `wait` と `port_wait` を更新するには
 `exp.tool.update_skew(...)` を使います。
 
 ```python
@@ -84,7 +84,7 @@ exp.tool.update_skew(250, ["S87R", "S89R"], backup=True)
 
 この helper は次を行います。
 
-- `skew.yaml` の `box_setting.<box>.port_wait` を更新する
+- `skew.yaml` の `box_setting.<box>.wait` と `port_wait` を更新する
 - `backup=True` なら `skew.yaml.bak.20260520_124900` のような timestamp 付き backup を作る
 - 更新後の skew file を有効な QuEL-1 backend に再読込する
 

--- a/docs/examples/system/quel1_skew_adjustment.ja.md
+++ b/docs/examples/system/quel1_skew_adjustment.ja.md
@@ -48,7 +48,7 @@ time_to_start: 0
 trigger_nport: 10
 ```
 
-`box_setting.*.port_wait` が skew 調整時に更新する値です。
+`box_setting.*.wait` が box 共通の wait、`box_setting.*.port_wait` が port ごとの差分です。
 
 ## 現在の skew を確認する
 

--- a/docs/examples/system/quel1_skew_adjustment.md
+++ b/docs/examples/system/quel1_skew_adjustment.md
@@ -78,8 +78,8 @@ figure = result.figure
 ## Update the target skew value
 
 After `check_skew(...)` estimates the current pulse indices, call
-`exp.tool.update_skew(...)` to shift each measured `port_wait` so the indices
-align to a common target.
+`exp.tool.update_skew(...)` to update `wait` and `port_wait` so the measured
+indices align to a common target.
 
 ```python
 exp.tool.update_skew(250, ["S87R", "S89R"], backup=True)
@@ -87,7 +87,7 @@ exp.tool.update_skew(250, ["S87R", "S89R"], backup=True)
 
 This helper:
 
-- updates `box_setting.<box>.port_wait` in `skew.yaml`
+- updates `box_setting.<box>.wait` and `port_wait` in `skew.yaml`
 - writes a timestamped backup file such as `skew.yaml.bak.20260520_124900`
   when `backup=True`
 - reloads the updated skew file into the active QuEL-1 backend

--- a/docs/examples/system/quel1_skew_adjustment.md
+++ b/docs/examples/system/quel1_skew_adjustment.md
@@ -51,7 +51,8 @@ time_to_start: 0
 trigger_nport: 10
 ```
 
-`box_setting.*.port_wait` is the value updated during skew correction.
+`box_setting.*.wait` is the box-common wait, and `box_setting.*.port_wait`
+stores per-port residuals.
 
 ## Check the current skew
 

--- a/docs/user-guide/getting-started/system-configuration.ja.md
+++ b/docs/user-guide/getting-started/system-configuration.ja.md
@@ -197,7 +197,7 @@ result = exp.tool.check_skew(["BOX_A", "BOX_B"])
 
 `exp.tool.update_skew(target, ...)` は直前の `check_skew(...)` の推定結果を使い、
 各 measured port の実効 wait を `target - measured_idx` だけずらし、
-box 共通部分を `wait`、port ごとの差分を `port_wait` に入れてから
+box 共通部分を `wait`、測定した port の差分を `port_wait` に入れてから
 `skew.yaml` を上書きします。更新前のファイルを残したい場合は
 `backup=True` を指定してください。`skew.yaml.bak.20260520_124900` のような
 timestamp 付き backup が作られます。

--- a/docs/user-guide/getting-started/system-configuration.ja.md
+++ b/docs/user-guide/getting-started/system-configuration.ja.md
@@ -182,7 +182,8 @@ trigger_nport: 10
 ```
 
 - `box_setting.<box>.slot` は各 box の粗いタイミング slot を表します。
-- `box_setting.<box>.port_wait` は skew 調整時に更新する port ごとの wait 値です。
+- `box_setting.<box>.wait` は box 共通の wait 値です。
+- `box_setting.<box>.port_wait` は port ごとの差分 wait 値です。
 - `reference_port` は基準信号源を選びます。
 - `monitor_port` と `trigger_nport` は monitor capture 経路を定義します。
 - `target_port` は skew scan に含める port を列挙します。

--- a/docs/user-guide/getting-started/system-configuration.ja.md
+++ b/docs/user-guide/getting-started/system-configuration.ja.md
@@ -196,7 +196,8 @@ result = exp.tool.check_skew(["BOX_A", "BOX_B"])
 ```
 
 `exp.tool.update_skew(target, ...)` は直前の `check_skew(...)` の推定結果を使い、
-各 measured port の `port_wait` を `target - measured_idx` だけずらしてから
+各 measured port の実効 wait を `target - measured_idx` だけずらし、
+box 共通部分を `wait`、port ごとの差分を `port_wait` に入れてから
 `skew.yaml` を上書きします。更新前のファイルを残したい場合は
 `backup=True` を指定してください。`skew.yaml.bak.20260520_124900` のような
 timestamp 付き backup が作られます。

--- a/docs/user-guide/getting-started/system-configuration.md
+++ b/docs/user-guide/getting-started/system-configuration.md
@@ -198,8 +198,8 @@ trigger_nport: 10
 ```
 
 - `box_setting.<box>.slot` defines the coarse timing slot for each box.
-- `box_setting.<box>.port_wait` defines the per-port wait value you tune during
-  skew correction.
+- `box_setting.<box>.wait` defines the box-common wait value.
+- `box_setting.<box>.port_wait` defines the per-port residual wait value.
 - `reference_port` selects the reference signal source.
 - `monitor_port` and `trigger_nport` define the monitor capture path.
 - `target_port` lists the ports included in the skew scan.

--- a/docs/user-guide/getting-started/system-configuration.md
+++ b/docs/user-guide/getting-started/system-configuration.md
@@ -215,7 +215,7 @@ result = exp.tool.check_skew(["BOX_A", "BOX_B"])
 
 `exp.tool.update_skew(target, ...)` shifts each measured effective wait by
 `target - measured_idx` based on the previous `check_skew(...)` result, then
-writes the box-common part to `wait` and per-port residuals to `port_wait`.
+writes the box-common part to `wait` and measured-port residuals to `port_wait`.
 Set `backup=True` when you want to save the previous file as a timestamped
 backup such as `skew.yaml.bak.20260520_124900`.
 

--- a/docs/user-guide/getting-started/system-configuration.md
+++ b/docs/user-guide/getting-started/system-configuration.md
@@ -213,10 +213,11 @@ exp.tool.update_skew(250, ["BOX_A", "BOX_B"], backup=True)
 result = exp.tool.check_skew(["BOX_A", "BOX_B"])
 ```
 
-`exp.tool.update_skew(target, ...)` shifts each measured `port_wait` by
+`exp.tool.update_skew(target, ...)` shifts each measured effective wait by
 `target - measured_idx` based on the previous `check_skew(...)` result, then
-overwrites `skew.yaml`. Set `backup=True` when you want to save the previous
-file as a timestamped backup such as `skew.yaml.bak.20260520_124900`.
+writes the box-common part to `wait` and per-port residuals to `port_wait`.
+Set `backup=True` when you want to save the previous file as a timestamped
+backup such as `skew.yaml.bak.20260520_124900`.
 
 For a full walkthrough, see [QuEL-1 skew adjustment workflow](../../examples/system/quel1_skew_adjustment.md).
 

--- a/src/qubex/backend/quel1/managers/skew_manager.py
+++ b/src/qubex/backend/quel1/managers/skew_manager.py
@@ -127,8 +127,6 @@ class Quel1SkewManager:
 
             common_wait = min(adjusted_waits.values())
             setting["wait"] = common_wait
-            for port in port_wait:
-                port_wait[port] = 0
             for port, adjusted_wait in adjusted_waits.items():
                 port_wait[port] = adjusted_wait - common_wait
 

--- a/src/qubex/backend/quel1/managers/skew_manager.py
+++ b/src/qubex/backend/quel1/managers/skew_manager.py
@@ -108,6 +108,8 @@ class Quel1SkewManager:
         for box_name, port, idx in estimated_indices:
             estimated_by_box.setdefault(box_name, []).append((port, idx))
 
+        updated_ports: dict[str, list[int]] = {}
+        unmeasured_ports: dict[str, list[int]] = {}
         for box_name, estimated_ports in estimated_by_box.items():
             setting = box_setting[box_name]
             if not isinstance(setting, dict):
@@ -116,6 +118,14 @@ class Quel1SkewManager:
             port_wait = setting.setdefault("port_wait", {})
             if not isinstance(port_wait, dict):
                 raise TypeError(f"box_setting.{box_name}.port_wait must be a mapping")
+            measured_ports = {port for port, _ in estimated_ports}
+            existing_ports = {
+                port
+                for port in port_wait
+                if isinstance(port, int) and not isinstance(port, bool)
+            }
+            updated_ports[box_name] = sorted(measured_ports)
+            unmeasured_ports[box_name] = sorted(existing_ports - measured_ports)
             adjusted_waits = {}
             for port, idx in estimated_ports:
                 current_port_wait = port_wait.get(port, 0)
@@ -140,6 +150,8 @@ class Quel1SkewManager:
             "backup_path": backup_path,
             "box_names": resolved_box_names,
             "wait": wait,
+            "updated_ports": updated_ports,
+            "unmeasured_ports": unmeasured_ports,
         }
 
     @staticmethod

--- a/src/qubex/backend/quel1/managers/skew_manager.py
+++ b/src/qubex/backend/quel1/managers/skew_manager.py
@@ -63,8 +63,8 @@ class Quel1SkewManager:
         file_path : str | Path
             Path to the skew calibration YAML file.
         wait : int
-            Target skew index. Existing `port_wait` values are shifted by
-            `wait - measured_idx` for each measured port.
+            Target skew index. Measured effective waits are shifted by
+            `wait - measured_idx`, then normalized into `wait` and `port_wait`.
         box_names : list[str] | None, optional
             Box names to update. When omitted, all boxes in `box_setting` are
             updated.
@@ -104,16 +104,31 @@ class Quel1SkewManager:
         estimated_indices = self._require_estimated_indices(
             box_names=resolved_box_names,
         )
+        estimated_by_box: dict[str, list[tuple[int, int]]] = {}
         for box_name, port, idx in estimated_indices:
-            port_wait = self._require_port_wait(
-                box_setting[box_name],
-                box_name=box_name,
-            )
-            if port not in port_wait:
-                raise ValueError(f"box_setting.{box_name}.port_wait.{port} is required")
-            current_wait = port_wait[port]
-            self._validate_wait_value(current_wait, box_name=box_name)
-            port_wait[port] = max(self._WAIT_MIN, current_wait + (wait - idx))
+            estimated_by_box.setdefault(box_name, []).append((port, idx))
+
+        for box_name, estimated_ports in estimated_by_box.items():
+            setting = box_setting[box_name]
+            if not isinstance(setting, dict):
+                raise TypeError(f"box_setting.{box_name} must be a mapping")
+            box_wait = self._require_box_wait(setting, box_name=box_name)
+            port_wait = self._require_port_wait(setting, box_name=box_name)
+            adjusted_waits = {}
+            for port, idx in estimated_ports:
+                current_port_wait = port_wait.get(port, 0)
+                self._validate_wait_value(current_port_wait, box_name=box_name)
+                adjusted_waits[port] = max(
+                    self._WAIT_MIN,
+                    box_wait + current_port_wait + (wait - idx),
+                )
+
+            common_wait = min(adjusted_waits.values())
+            setting["wait"] = common_wait
+            for port in port_wait:
+                port_wait[port] = 0
+            for port, adjusted_wait in adjusted_waits.items():
+                port_wait[port] = adjusted_wait - common_wait
 
         self._validate_wait_values(payload)
         with path.open("w", encoding="utf-8") as file:
@@ -158,15 +173,15 @@ class Quel1SkewManager:
         for box_name, setting in box_setting.items():
             if not isinstance(setting, dict):
                 raise TypeError(f"box_setting.{box_name} must be a mapping")
-            cls._validate_box_wait(setting, box_name=box_name)
+            cls._require_box_wait(setting, box_name=box_name)
             port_wait = cls._require_port_wait(setting, box_name=box_name)
             for port, wait in port_wait.items():
                 cls._validate_port_wait_key(port, box_name=box_name)
                 cls._validate_wait_value(wait, box_name=box_name)
 
     @classmethod
-    def _validate_box_wait(cls, setting: dict[Any, Any], *, box_name: str) -> None:
-        """Validate one `box_setting.<box>.wait` value required by the driver."""
+    def _require_box_wait(cls, setting: dict[Any, Any], *, box_name: str) -> int:
+        """Return one `box_setting.<box>.wait` value required by the driver."""
         if "wait" not in setting:
             raise KeyError(f"box_setting.{box_name}.wait is required")
         wait = setting["wait"]
@@ -174,6 +189,7 @@ class Quel1SkewManager:
             raise TypeError(f"box_setting.{box_name}.wait must be an integer")
         if wait < cls._WAIT_MIN:
             raise ValueError(f"wait must be non-negative (box={box_name}, wait={wait})")
+        return wait
 
     @staticmethod
     def _require_port_wait(

--- a/src/qubex/backend/quel1/quel1_backend_controller.py
+++ b/src/qubex/backend/quel1/quel1_backend_controller.py
@@ -785,8 +785,8 @@ class Quel1BackendController(BackendController):
         file_path : str | Path
             Path to the skew calibration YAML file.
         wait : int
-            Target skew index. Existing `port_wait` values are shifted by
-            `wait - measured_idx` for each measured port.
+            Target skew index. Measured effective waits are shifted by
+            `wait - measured_idx`, then normalized into `wait` and `port_wait`.
         box_names : list[str] | None, optional
             Box names to update. When omitted, all boxes in the file are
             updated.

--- a/src/qubex/experiment/experiment_tool.py
+++ b/src/qubex/experiment/experiment_tool.py
@@ -151,7 +151,7 @@ def update_skew(
     skew_file: str | None = None,
     backup: bool | None = None,
 ) -> Result:
-    """Shift skew `port_wait` values so measured indices match the target wait."""
+    """Shift measured skew waits to the target and normalize `wait`/`port_wait`."""
     if skew_file is None:
         skew_file = "skew.yaml"
     if backup is None:

--- a/tests/backend/test_quel1_backend_controller_qubecalib_delegation.py
+++ b/tests/backend/test_quel1_backend_controller_qubecalib_delegation.py
@@ -215,7 +215,8 @@ time_to_start: 0
     assert len(backup_path.name.removeprefix("skew.yaml.bak.")) == 15
     assert result["box_names"] == ["Q01"]
     assert payload["box_setting"]["Q00"]["port_wait"] == {1: 0}
-    assert payload["box_setting"]["Q01"]["port_wait"] == {8: 11}
+    assert payload["box_setting"]["Q01"]["wait"] == 11
+    assert payload["box_setting"]["Q01"]["port_wait"] == {8: 0}
     assert qubecalib.sysdb.load_skew_yaml_calls == [str(path)]
 
 

--- a/tests/backend/test_quel1_backend_controller_qubecalib_delegation.py
+++ b/tests/backend/test_quel1_backend_controller_qubecalib_delegation.py
@@ -214,6 +214,8 @@ time_to_start: 0
     assert backup_path.name.startswith("skew.yaml.bak.")
     assert len(backup_path.name.removeprefix("skew.yaml.bak.")) == 15
     assert result["box_names"] == ["Q01"]
+    assert result["updated_ports"] == {"Q01": [8]}
+    assert result["unmeasured_ports"] == {"Q01": []}
     assert payload["box_setting"]["Q00"]["port_wait"] == {1: 0}
     assert payload["box_setting"]["Q01"]["wait"] == 11
     assert payload["box_setting"]["Q01"]["port_wait"] == {8: 0}

--- a/tests/backend/test_quel1_skew_manager.py
+++ b/tests/backend/test_quel1_skew_manager.py
@@ -355,10 +355,11 @@ box_setting:
       1: 0
   B:
     slot: 1
-    wait: 0
+    wait: 5
     port_wait:
       8: 1
-      9: 2
+      9: 4
+      10: 7
 time_to_start: 0
 """.strip()
         + "\n",
@@ -366,7 +367,7 @@ time_to_start: 0
     )
     _FakeSkewClass.estimated_indices = {
         ("B", 8): _FakeEstimatedPulseParams(idx=70),
-        ("B", 9): _FakeEstimatedPulseParams(idx=90),
+        ("B", 9): _FakeEstimatedPulseParams(idx=80),
     }
     manager.run_skew_measurement(
         skew_yaml_path=path,
@@ -396,9 +397,11 @@ time_to_start: 0
         "wait": 80,
     }
     assert payload["box_setting"]["A"]["port_wait"] == {1: 0}
-    assert payload["box_setting"]["B"]["port_wait"] == {8: 11, 9: 0}
+    assert payload["box_setting"]["B"]["wait"] == 9
+    assert payload["box_setting"]["B"]["port_wait"] == {8: 7, 9: 0, 10: 0}
     assert backup_payload["box_setting"]["A"]["port_wait"] == {1: 0}
-    assert backup_payload["box_setting"]["B"]["port_wait"] == {8: 1, 9: 2}
+    assert backup_payload["box_setting"]["B"]["wait"] == 5
+    assert backup_payload["box_setting"]["B"]["port_wait"] == {8: 1, 9: 4, 10: 7}
     assert sysdb.load_skew_yaml_calls == [str(path)]
     with pytest.raises(RuntimeError, match="Run check_skew before update_skew"):
         manager.update_skew(file_path=path, wait=80, box_names=["B"])

--- a/tests/backend/test_quel1_skew_manager.py
+++ b/tests/backend/test_quel1_skew_manager.py
@@ -398,7 +398,7 @@ time_to_start: 0
     }
     assert payload["box_setting"]["A"]["port_wait"] == {1: 0}
     assert payload["box_setting"]["B"]["wait"] == 9
-    assert payload["box_setting"]["B"]["port_wait"] == {8: 7, 9: 0, 10: 0}
+    assert payload["box_setting"]["B"]["port_wait"] == {8: 7, 9: 0, 10: 7}
     assert backup_payload["box_setting"]["A"]["port_wait"] == {1: 0}
     assert backup_payload["box_setting"]["B"]["wait"] == 5
     assert backup_payload["box_setting"]["B"]["port_wait"] == {8: 1, 9: 4, 10: 7}

--- a/tests/backend/test_quel1_skew_manager.py
+++ b/tests/backend/test_quel1_skew_manager.py
@@ -395,6 +395,8 @@ time_to_start: 0
         "backup_path": backup_path,
         "box_names": ["B"],
         "wait": 80,
+        "updated_ports": {"B": [8, 9]},
+        "unmeasured_ports": {"B": [10]},
     }
     assert payload["box_setting"]["A"]["port_wait"] == {1: 0}
     assert payload["box_setting"]["B"]["wait"] == 9


### PR DESCRIPTION
port_wait だけを更新していた skew 調整を、64Q への対応を念頭に、
- skew の共通部分を wait:
- 残りの差分を port_wait:
に入れるように変更しました。合わせてドキュメントも修正しました。
また、未測定の port_wait を 0 にしていたのを戻し、変更しないこととしました。