### PR TITLE
Pin Plotly below 6

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,9 @@ dependencies = [
     "networkx >= 2.7",
     "nbformat >= 5.0",
     "numpy >= 1.22",
-    "plotly >= 5.23",
+    # Plotly v6 FigureWidget uses anywidget and can persist a multi-MB _esm bundle
+    # per widget in notebook metadata.widgets, making saved .ipynb files very large.
+    "plotly >= 5.23, <6",
     "pydantic >= 2.0",
     "pyserial >= 3.5",
     "pyyaml >= 6.0",

--- a/uv.lock
+++ b/uv.lock
@@ -2294,15 +2294,6 @@ wheels = [
 ]
 
 [[package]]
-name = "narwhals"
-version = "2.19.0"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/4e/1a/bd3317c0bdbcd9ffb710ddf5250b32898f8f2c240be99494fe137feb77a7/narwhals-2.19.0.tar.gz", hash = "sha256:14fd7040b5ff211d415a82e4827b9d04c354e213e72a6d0730205ffd72e3b7ff", size = 623698, upload-time = "2026-04-06T15:50:58.786Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/37/72/e61e3091e0e00fae9d3a8ef85ece9d2cd4b5966058e1f2901ce42679eebf/narwhals-2.19.0-py3-none-any.whl", hash = "sha256:1f8dfa4a33a6dbff878c3e9be4c3b455dfcaf2a9322f1357db00e4e92e95b84b", size = 446991, upload-time = "2026-04-06T15:50:57.046Z" },
-]
-
-[[package]]
 name = "nbclient"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -2753,15 +2744,15 @@ wheels = [
 
 [[package]]
 name = "plotly"
-version = "6.6.0"
+version = "5.24.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "narwhals" },
     { name = "packaging" },
+    { name = "tenacity" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/24/fb/41efe84970cfddefd4ccf025e2cbfafe780004555f583e93dba3dac2cdef/plotly-6.6.0.tar.gz", hash = "sha256:b897f15f3b02028d69f755f236be890ba950d0a42d7dfc619b44e2d8cea8748c", size = 7027956, upload-time = "2026-03-02T21:10:25.321Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/79/4f/428f6d959818d7425a94c190a6b26fbc58035cbef40bf249be0b62a9aedd/plotly-5.24.1.tar.gz", hash = "sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae", size = 9479398, upload-time = "2024-09-12T15:36:31.068Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/d2/c6e44dba74f17c6216ce1b56044a9b93a929f1c2d5bdaff892512b260f5e/plotly-6.6.0-py3-none-any.whl", hash = "sha256:8d6daf0f87412e0c0bfe72e809d615217ab57cc715899a1e5145135a7800d1d0", size = 9910315, upload-time = "2026-03-02T21:10:18.131Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/ae/580600f441f6fc05218bd6c9d5794f4aef072a7d9093b291f1c50a9db8bc/plotly-5.24.1-py3-none-any.whl", hash = "sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089", size = 19054220, upload-time = "2024-09-12T15:36:24.08Z" },
 ]
 
 [[package]]
@@ -3502,7 +3493,7 @@ requires-dist = [
     { name = "nbformat", specifier = ">=5.0" },
     { name = "networkx", specifier = ">=2.7" },
     { name = "numpy", specifier = ">=1.22" },
-    { name = "plotly", specifier = ">=5.23" },
+    { name = "plotly", specifier = ">=5.23,<6" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyyaml", specifier = ">=6.0" },
@@ -4363,6 +4354,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/83/d3/803453b36afefb7c2bb238361cd4ae6125a569b4db67cd9e79846ba2d68c/sympy-1.14.0.tar.gz", hash = "sha256:d3d3fe8df1e5a0b42f0e7bdf50541697dbe7d23746e894990c030e2b05e72517", size = 7793921, upload-time = "2025-04-27T18:05:01.611Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/a2/09/77d55d46fd61b4a135c444fc97158ef34a095e5681d0a6c10b75bf356191/sympy-1.14.0-py3-none-any.whl", hash = "sha256:e091cc3e99d2141a0ba2847328f5479b05d94a6635cb96148ccb3f34671bd8f5", size = 6299353, upload-time = "2025-04-27T18:04:59.103Z" },
+]
+
+[[package]]
+name = "tenacity"
+version = "9.1.4"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/47/c6/ee486fd809e357697ee8a44d3d69222b344920433d3b6666ccd9b374630c/tenacity-9.1.4.tar.gz", hash = "sha256:adb31d4c263f2bd041081ab33b498309a57c77f9acf2db65aadf0898179cf93a", size = 49413, upload-time = "2026-02-07T10:45:33.841Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d7/c1/eb8f9debc45d3b7918a32ab756658a0904732f75e555402972246b0b8e71/tenacity-9.1.4-py3-none-any.whl", hash = "sha256:6095a360c919085f28c6527de529e76a06ad89b23659fa881ae0649b867a9d55", size = 28926, upload-time = "2026-02-07T10:45:32.24Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Pin Plotly to `>=5.23,<6` and update `uv.lock` to resolve Plotly 5.24.1.

## Why

Plotly v6 `FigureWidget` uses `anywidget`, which can persist a multi-MB `_esm` bundle per widget in notebook `metadata.widgets`. In calibration notebooks with many live widgets this caused saved `.ipynb` files to grow by more than 100 MB even after clearing cell outputs.

Measured with Plotly 6.6.0, the widget metadata grew roughly linearly with each `go.FigureWidget`:

```text
figures= 1  metadata.widgets=  4.884 MB  _esm=  4.774 MB
figures= 2  metadata.widgets=  9.769 MB  _esm=  9.548 MB
figures= 5  metadata.widgets= 24.421 MB  _esm= 23.870 MB
figures=10  metadata.widgets= 48.843 MB  _esm= 47.740 MB
figures=23  metadata.widgets=112.338 MB  _esm=109.803 MB
```

Also verified that clearing cell outputs does not remove this metadata because the large payload lives in notebook-level `metadata.widgets`, not in `cells[*].outputs`:

```text
before clear outputs: 112.339 MB
after clear outputs:  112.339 MB
metadata.widgets present: True
metadata.widgets: 112.338 MB
```

## Scope

This is a workaround, not the root fix. Pinning Plotly to v5 avoids the v6 `anywidget` `_esm` duplication for now, but we should still decide on a long-term notebook strategy. Possible root fixes include avoiding `FigureWidget` for saved notebooks, adding an explicit live/static plotting option, closing/replacing live widgets at the end of measurements, or stripping `metadata.widgets` on save.

## Validation

- Verified with Plotly 5.24.1 that creating 23 `FigureWidget` instances produced about 0.188 MB of widget manager state and no `anywidget` / `_esm` entries.
- Ran:
  `PYTHONPATH=/tmp/qubex-plotly5-target:/home/machino/paper-qube-qubex-exp/qubex/src qubex/.venv/bin/python -m pytest qubex/tests/analysis/test_iq_plotter.py qubex/tests/experiment/test_experiment_tool.py qubex/tests/analysis/test_visualization_compat.py qubex/tests/measurement/test_measurement_visualization.py -q`

Result: `25 passed`.
