### PR TITLE
Close IQPlotter widgets after final display

### DIFF
--- a/src/qubex/analysis/iq_plotter.py
+++ b/src/qubex/analysis/iq_plotter.py
@@ -52,6 +52,7 @@ class IQPlotter:
         )
         self._max_val_center = 0.0
         self._state_trace_count = 0
+        self._closed = False
 
         if len(self._state_centers) > 0:
             colors = get_colors(alpha=0.1)
@@ -153,14 +154,23 @@ class IQPlotter:
                     trace.y = np.imag(values)
 
     def clear(self) -> None:
-        """Clear and close the widget output."""
+        """Clear and close the live widget output."""
         self._output.clear_output()
+        if self._closed:
+            return
         self._output.close()
+        self._widget.close()
+        self._closed = True
+
+    def close(self) -> None:
+        """Close the live widget resources."""
+        self.clear()
 
     def show(self) -> None:
-        """Show the plot widget."""
-        self.clear()
-        self._widget.show(config=get_config())
+        """Show a static Plotly figure copied from the live widget."""
+        fig = self.to_figure()
+        self.close()
+        fig.show(config=get_config())
 
     def to_figure(self) -> go.Figure:
         """Return a detached Plotly figure copied from the current widget state."""
@@ -176,6 +186,7 @@ class IQPlotterPolar:
         self._normalize = normalize
         self._num_scatters: int | None = None
         self._widget = go.FigureWidget()
+        self._closed = False
         self._widget.update_layout(
             template="qubex",
             title="I/Q plane",
@@ -237,3 +248,26 @@ class IQPlotterPolar:
             if isinstance(trace, go.Scatterpolar):
                 trace.r = np.abs(signals[qubit])
                 trace.theta = np.angle(signals[qubit], deg=True)
+
+    def clear(self) -> None:
+        """Close the live widget."""
+        if self._closed:
+            return
+        self._widget.close()
+        self._closed = True
+
+    def close(self) -> None:
+        """Close the live widget resources."""
+        self.clear()
+
+    def show(self) -> None:
+        """Show a static Plotly figure copied from the live widget."""
+        fig = self.to_figure()
+        self.close()
+        fig.show(config=get_config())
+
+    def to_figure(self) -> go.Figure:
+        """Return a detached Plotly figure copied from the current widget state."""
+        fig = go.Figure(self._widget)
+        fig.update_layout(template="qubex")
+        return fig

--- a/src/qubex/contrib/experiment/measurement_induced_decay.py
+++ b/src/qubex/contrib/experiment/measurement_induced_decay.py
@@ -423,8 +423,7 @@ def measurement_induced_decay_experiment(
                     plotter.update({measurement_target: np.asarray(signals)})
 
             if plot:
-                plotter.clear()
-                plotter.to_figure().show()
+                plotter.show()
 
             iq_values = np.asarray(signals, dtype=np.complex128)
             sweep_data = SweepData(

--- a/src/qubex/experiment/services/measurement_service.py
+++ b/src/qubex/experiment/services/measurement_service.py
@@ -1174,8 +1174,7 @@ class MeasurementService:
                     )
 
         if plot:
-            plotter.clear()
-            plotter.to_figure().show()
+            plotter.show()
 
         measured_targets = [target for target, values in signals.items() if values]
         rabi_params = self._get_sweep_rabi_params(

--- a/tests/analysis/test_iq_plotter.py
+++ b/tests/analysis/test_iq_plotter.py
@@ -131,3 +131,46 @@ def test_iq_plotter_flattens_non_1d_inputs(monkeypatch) -> None:
 
     assert np.array_equal(np.asarray(trace.x), np.array([1.0, 3.0]))
     assert np.array_equal(np.asarray(trace.y), np.array([2.0, 4.0]))
+
+
+def test_iq_plotter_show_displays_detached_figure_and_closes_widget(
+    monkeypatch,
+) -> None:
+    """Given a live widget, when showing final output, then a detached Figure is shown."""
+    monkeypatch.setattr(iq_plotter, "display", lambda *_args, **_kwargs: None)
+
+    shown_figures = []
+
+    def _record_figure_show(self, **kwargs) -> None:
+        shown_figures.append((self, kwargs))
+
+    def _fail_widget_show(self, **_kwargs) -> None:
+        raise AssertionError("FigureWidget.show should not be used for final output")
+
+    monkeypatch.setattr(iq_plotter.go.Figure, "show", _record_figure_show)
+    monkeypatch.setattr(iq_plotter.go.FigureWidget, "show", _fail_widget_show)
+
+    plotter = IQPlotter()
+    plotter.update({"Q00": np.array([1.0 + 2.0j])})
+
+    plotter.show()
+
+    assert len(shown_figures) == 1
+    shown_figure, kwargs = shown_figures[0]
+    assert isinstance(shown_figure, iq_plotter.go.Figure)
+    assert not isinstance(shown_figure, iq_plotter.go.FigureWidget)
+    assert kwargs == {"config": iq_plotter.get_config()}
+    assert plotter.__dict__["_closed"] is True
+
+
+def test_iq_plotter_clear_closes_widget_once(monkeypatch) -> None:
+    """Given a live widget, when clearing repeatedly, then widget resources close once."""
+    plotter = IQPlotter()
+    closed = []
+
+    monkeypatch.setattr(plotter.__dict__["_widget"], "close", lambda: closed.append(True))
+
+    plotter.clear()
+    plotter.clear()
+
+    assert closed == [True]


### PR DESCRIPTION
## Summary

Close live Plotly `FigureWidget` resources after rendering final IQ plots.

## Why

Follow-up to #283. Pinning Plotly below 6 avoids the immediate `anywidget` `_esm` metadata blow-up, but the plotting code should still release live widget resources once measurement plotting is finalized.

## Changes

- Add idempotent `clear()` / `close()` behavior that calls `FigureWidget.close()` for `IQPlotter` and `IQPlotterPolar`.
- Change `IQPlotter.show()` to copy the live widget to a detached `go.Figure`, close the widget, then show the static figure.
- Replace remaining `plotter.clear(); plotter.to_figure().show()` call sites with `plotter.show()` so the copy happens before closing.
- Add tests that assert final display uses `go.Figure.show()` rather than `FigureWidget.show()` and closes the widget only once.

## Validation

- `qubex/.venv/bin/python -m pytest qubex/tests/analysis/test_iq_plotter.py qubex/tests/experiment/test_measurement_service_async_delegation.py -q` -> `18 passed`
- `PYTHONPATH=/tmp/qubex-plotly5-target:/home/machino/paper-qube-qubex-exp/qubex/src qubex/.venv/bin/python -m pytest qubex/tests/analysis/test_iq_plotter.py qubex/tests/experiment/test_experiment_tool.py qubex/tests/analysis/test_visualization_compat.py qubex/tests/measurement/test_measurement_visualization.py qubex/tests/experiment/test_measurement_service_async_delegation.py -q` -> `39 passed`