### PR TITLE
Record IRB trial curves in results

### DIFF
--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -5138,6 +5138,7 @@ class Experiment:
         xaxis_type: Literal["linear", "log"] | None = None,
         n_shots: int | None = None,
         shot_interval: float | None = None,
+        time_integration: bool | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
     ) -> Result:
@@ -5154,6 +5155,7 @@ class Experiment:
             xaxis_type=xaxis_type,
             shots=n_shots,
             interval=shot_interval,
+            time_integration=time_integration,
             plot=plot,
             save_image=save_image,
         )
@@ -5175,6 +5177,7 @@ class Experiment:
         in_parallel: bool | None = None,
         n_shots: int | None = None,
         shot_interval: float | None = None,
+        time_integration: bool | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
     ) -> Result:
@@ -5192,6 +5195,7 @@ class Experiment:
             in_parallel=in_parallel,
             shots=n_shots,
             interval=shot_interval,
+            time_integration=time_integration,
             plot=plot,
             save_image=save_image,
         )

--- a/src/qubex/experiment/services/benchmarking_service.py
+++ b/src/qubex/experiment/services/benchmarking_service.py
@@ -55,6 +55,15 @@ def _shared_n_cliffords_range(
     return None
 
 
+def _rb_curve_data(entry: Mapping[str, object]) -> dict[str, object]:
+    """Return RB curve payload fields that should be preserved in IRB results."""
+    return {
+        key: entry[key]
+        for key in ("n_cliffords", "mean", "std", "trials", "seeds")
+        if key in entry
+    }
+
+
 class BenchmarkingService:
     """Service for randomized benchmarking workflows."""
 
@@ -292,6 +301,7 @@ class BenchmarkingService:
         in_parallel: bool | None = None,
         shots: int | None = None,
         interval: float | None = None,
+        time_integration: bool | None = None,
         xaxis_type: Literal["linear", "log"] | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
@@ -336,6 +346,9 @@ class BenchmarkingService:
         if interval is None:
             interval = DEFAULT_INTERVAL
 
+        if time_integration is None:
+            time_integration = True
+
         if xaxis_type is None:
             xaxis_type = "linear"
 
@@ -376,6 +389,7 @@ class BenchmarkingService:
             sweep_range = []
             mean_data = defaultdict(list)
             std_data = defaultdict(list)
+            trial_matrix_data = defaultdict(list)
             while True:
                 if n_cliffords_range is None:
                     n_clifford = 0 if idx == 0 else 2 ** (idx - 1)
@@ -401,6 +415,7 @@ class BenchmarkingService:
                         mode="avg",
                         shots=shots,
                         interval=interval,
+                        time_integration=time_integration,
                         reset_awg_and_capunits=reset_awg_and_capunits,
                         plot=False,
                     )
@@ -412,8 +427,10 @@ class BenchmarkingService:
                 check_vals = {}
 
                 for target in target_group:
-                    mean = np.mean(trial_data[target])
-                    std = np.std(trial_data[target])
+                    trial_values = np.asarray(trial_data[target], dtype=float)
+                    mean = np.mean(trial_values)
+                    std = np.std(trial_values)
+                    trial_matrix_data[target].append(trial_values)
                     mean_data[target].append(mean)
                     std_data[target].append(std)
                     check_vals[target] = mean - std * 0.5
@@ -426,6 +443,9 @@ class BenchmarkingService:
 
             mean_data = {target: np.array(data) for target, data in mean_data.items()}
             std_data = {target: np.array(data) for target, data in std_data.items()}
+            trial_matrix_data = {
+                target: np.vstack(data) for target, data in trial_matrix_data.items()
+            }
 
             for target in target_group:
                 mean = mean_data[target]
@@ -456,6 +476,8 @@ class BenchmarkingService:
                     "n_cliffords": sweep_range,
                     "mean": mean,
                     "std": std,
+                    "trials": trial_matrix_data[target],
+                    "seeds": np.asarray(seeds, dtype=int),
                     **fit_result,
                 }
 
@@ -480,6 +502,7 @@ class BenchmarkingService:
         mitigate_readout: bool | None = None,
         shots: int | None = None,
         interval: float | None = None,
+        time_integration: bool | None = None,
         xaxis_type: Literal["linear", "log"] | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
@@ -545,6 +568,9 @@ class BenchmarkingService:
         if xaxis_type is None:
             xaxis_type = "linear"
 
+        if time_integration is None:
+            time_integration = True
+
         if in_parallel:
             target_groups = [targets]
         else:
@@ -592,6 +618,7 @@ class BenchmarkingService:
             sweep_range = []
             mean_data = defaultdict(list)
             std_data = defaultdict(list)
+            trial_matrix_data = defaultdict(list)
             while True:
                 if n_cliffords_range is None:
                     n_clifford = 0 if idx == 0 else 2 ** (idx - 1)
@@ -617,6 +644,7 @@ class BenchmarkingService:
                         mode="single",
                         shots=shots,
                         interval=interval,
+                        time_integration=time_integration,
                         reset_awg_and_capunits=reset_awg_and_capunits,
                         plot=False,
                     )
@@ -636,8 +664,10 @@ class BenchmarkingService:
                 check_vals = {}
 
                 for target in target_group:
-                    mean = np.mean(trial_data[target])
-                    std = np.std(trial_data[target])
+                    trial_values = np.asarray(trial_data[target], dtype=float)
+                    mean = np.mean(trial_values)
+                    std = np.std(trial_values)
+                    trial_matrix_data[target].append(trial_values)
                     mean_data[target].append(mean)
                     std_data[target].append(std)
                     check_vals[target] = mean - std * 0.5
@@ -650,6 +680,9 @@ class BenchmarkingService:
 
             mean_data = {target: np.array(data) for target, data in mean_data.items()}
             std_data = {target: np.array(data) for target, data in std_data.items()}
+            trial_matrix_data = {
+                target: np.vstack(data) for target, data in trial_matrix_data.items()
+            }
 
             for target in target_group:
                 mean = mean_data[target]
@@ -680,6 +713,8 @@ class BenchmarkingService:
                     "n_cliffords": sweep_range,
                     "mean": mean,
                     "std": std,
+                    "trials": trial_matrix_data[target],
+                    "seeds": np.asarray(seeds, dtype=int),
                     **fit_result,
                 }
 
@@ -705,6 +740,7 @@ class BenchmarkingService:
         in_parallel: bool | None = None,
         shots: int | None = None,
         interval: float | None = None,
+        time_integration: bool | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
     ) -> Result:
@@ -720,6 +756,8 @@ class BenchmarkingService:
             plot = True
         if save_image is None:
             save_image = True
+        if time_integration is None:
+            time_integration = True
 
         if isinstance(interleaved_clifford, str):
             clifford = self.clifford.get(interleaved_clifford)
@@ -754,6 +792,7 @@ class BenchmarkingService:
                 in_parallel=in_parallel,
                 shots=shots,
                 interval=interval,
+                time_integration=time_integration,
                 plot=False,
                 save_image=False,
                 reset_awg_and_capunits=False,
@@ -780,6 +819,7 @@ class BenchmarkingService:
                         in_parallel=False,
                         shots=shots,
                         interval=interval,
+                        time_integration=time_integration,
                         plot=False,
                         save_image=False,
                         reset_awg_and_capunits=False,
@@ -800,6 +840,7 @@ class BenchmarkingService:
                     in_parallel=in_parallel,
                     shots=shots,
                     interval=interval,
+                    time_integration=time_integration,
                     plot=False,
                     save_image=False,
                     reset_awg_and_capunits=False,
@@ -816,6 +857,7 @@ class BenchmarkingService:
                 in_parallel=in_parallel,
                 shots=shots,
                 interval=interval,
+                time_integration=time_integration,
                 plot=False,
                 save_image=False,
                 reset_awg_and_capunits=False,
@@ -841,6 +883,7 @@ class BenchmarkingService:
                         in_parallel=False,
                         shots=shots,
                         interval=interval,
+                        time_integration=time_integration,
                         plot=False,
                         save_image=False,
                         reset_awg_and_capunits=False,
@@ -860,6 +903,7 @@ class BenchmarkingService:
                     in_parallel=in_parallel,
                     shots=shots,
                     interval=interval,
+                    time_integration=time_integration,
                     plot=False,
                     save_image=False,
                     reset_awg_and_capunits=False,
@@ -969,6 +1013,8 @@ class BenchmarkingService:
                 "gate_fidelity_err": gate_fidelity_err,
                 "rb_fit_result": rb_fit_result,
                 "irb_fit_result": irb_fit_result,
+                "rb_data": _rb_curve_data(rb_result[target]),
+                "irb_data": _rb_curve_data(irb_result[target]),
                 # TODO: Remove this legacy payload key after callers migrate to result.figures.
                 "fig": fig,
             }
@@ -991,6 +1037,7 @@ class BenchmarkingService:
         xaxis_type: Literal["linear", "log"] | None = None,
         shots: int | None = None,
         interval: float | None = None,
+        time_integration: bool | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
     ) -> Result:
@@ -1015,6 +1062,7 @@ class BenchmarkingService:
                 in_parallel=in_parallel,
                 shots=shots,
                 interval=interval,
+                time_integration=time_integration,
                 xaxis_type=xaxis_type,
                 plot=plot,
                 save_image=save_image,
@@ -1030,6 +1078,7 @@ class BenchmarkingService:
                 in_parallel=in_parallel,
                 shots=shots,
                 interval=interval,
+                time_integration=time_integration,
                 xaxis_type=xaxis_type,
                 plot=plot,
                 save_image=save_image,
@@ -1052,6 +1101,7 @@ class BenchmarkingService:
         in_parallel: bool | None = None,
         shots: int | None = None,
         interval: float | None = None,
+        time_integration: bool | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
     ) -> Result:
@@ -1078,6 +1128,7 @@ class BenchmarkingService:
                 in_parallel=in_parallel,
                 shots=shots,
                 interval=interval,
+                time_integration=time_integration,
                 plot=plot,
                 save_image=save_image,
             )
@@ -1097,6 +1148,7 @@ class BenchmarkingService:
                     in_parallel=in_parallel,
                     shots=shots,
                     interval=interval,
+                    time_integration=time_integration,
                     plot=plot,
                     save_image=save_image,
                 )

--- a/tests/experiment/test_benchmarking_service_irb_awg_reset.py
+++ b/tests/experiment/test_benchmarking_service_irb_awg_reset.py
@@ -43,12 +43,16 @@ def _rb_payload(targets: list[str]) -> Result:
 
 def _rb_payload_with_range(targets: list[str], n_cliffords: np.ndarray) -> Result:
     """Build minimal RB-like payload with a specific Clifford sweep range."""
+    mean = np.linspace(1.0, 0.9, len(n_cliffords), dtype=float)
+    std = np.linspace(0.0, 0.01, len(n_cliffords), dtype=float)
     return Result(
         data={
             target: {
                 "n_cliffords": n_cliffords,
-                "mean": np.linspace(1.0, 0.9, len(n_cliffords), dtype=float),
-                "std": np.linspace(0.0, 0.01, len(n_cliffords), dtype=float),
+                "mean": mean,
+                "std": std,
+                "trials": np.column_stack((mean, mean - 0.01)),
+                "seeds": np.array([11, 22], dtype=int),
             }
             for target in targets
         }
@@ -61,6 +65,7 @@ def test_irb_experiment_resets_awg_once_for_1q(monkeypatch: Any) -> None:
 
     reset_calls: list[set[str]] = []
     reset_flags: list[bool | None] = []
+    time_integration_flags: list[bool | None] = []
 
     service = cast(Any, object.__new__(BenchmarkingService))
     service.__dict__["_experiment_context"] = SimpleNamespace(
@@ -82,6 +87,7 @@ def test_irb_experiment_resets_awg_once_for_1q(monkeypatch: Any) -> None:
         **kwargs: object,
     ) -> Result:
         reset_flags.append(kwargs.get("reset_awg_and_capunits"))  # type: ignore[arg-type]
+        time_integration_flags.append(kwargs.get("time_integration"))  # type: ignore[arg-type]
         labels = [targets] if isinstance(targets, str) else list(targets)
         return _rb_payload(labels)
 
@@ -96,6 +102,7 @@ def test_irb_experiment_resets_awg_once_for_1q(monkeypatch: Any) -> None:
 
     assert reset_calls == [{"Q17"}]
     assert reset_flags == [False, False]
+    assert time_integration_flags == [True, True]
 
 
 def test_irb_experiment_resets_awg_once_for_2q(monkeypatch: Any) -> None:
@@ -104,6 +111,7 @@ def test_irb_experiment_resets_awg_once_for_2q(monkeypatch: Any) -> None:
 
     reset_calls: list[set[str]] = []
     reset_flags: list[bool | None] = []
+    time_integration_flags: list[bool | None] = []
 
     service = cast(Any, object.__new__(BenchmarkingService))
     service.__dict__["_experiment_context"] = SimpleNamespace(
@@ -125,6 +133,7 @@ def test_irb_experiment_resets_awg_once_for_2q(monkeypatch: Any) -> None:
         **kwargs: object,
     ) -> Result:
         reset_flags.append(kwargs.get("reset_awg_and_capunits"))  # type: ignore[arg-type]
+        time_integration_flags.append(kwargs.get("time_integration"))  # type: ignore[arg-type]
         labels = [targets] if isinstance(targets, str) else list(targets)
         return _rb_payload(labels)
 
@@ -139,6 +148,7 @@ def test_irb_experiment_resets_awg_once_for_2q(monkeypatch: Any) -> None:
 
     assert reset_calls == [{"Q17", "Q18"}]
     assert reset_flags == [False, False]
+    assert time_integration_flags == [True, True]
 
 
 def test_irb_experiment_reuses_auto_reference_sweep_for_1q(
@@ -241,3 +251,56 @@ def test_irb_experiment_reuses_auto_reference_sweep_for_2q(
     assert calls[0] is None
     assert calls[1] is not None
     np.testing.assert_array_equal(calls[1], reference_range)
+
+
+def test_irb_experiment_includes_reference_and_interleaved_trial_data(
+    monkeypatch: Any,
+) -> None:
+    """Given IRB, final result includes per-trial reference and interleaved curve data."""
+    _patch_fit_helpers(monkeypatch)
+
+    reference_range = np.array([0, 1, 2], dtype=int)
+    interleaved_range = np.array([0, 1, 2], dtype=int)
+
+    service = cast(Any, object.__new__(BenchmarkingService))
+    service.__dict__["_experiment_context"] = SimpleNamespace(
+        experiment_system=SimpleNamespace(
+            get_target=lambda _label: SimpleNamespace(is_cr=False)
+        ),
+        resolve_qubit_label=lambda label: label,
+        reset_awg_and_capunits=lambda *, qubits: None,
+    )
+    service.__dict__["_measurement_service"] = SimpleNamespace()
+    service.__dict__["_pulse_service"] = SimpleNamespace()
+    service.__dict__["_clifford_generator"] = SimpleNamespace(
+        cliffords={"X90": Clifford.X90()}
+    )
+
+    def _rb_experiment_1q(
+        self: BenchmarkingService,
+        targets: list[str] | str,
+        **kwargs: object,
+    ) -> Result:
+        labels = [targets] if isinstance(targets, str) else list(targets)
+        if kwargs.get("interleaved_clifford") is None:
+            return _rb_payload_with_range(labels, reference_range)
+        return _rb_payload_with_range(labels, interleaved_range)
+
+    service.__dict__["rb_experiment_1q"] = MethodType(_rb_experiment_1q, service)
+
+    result = service.irb_experiment(
+        targets=["Q17"],
+        interleaved_clifford="X90",
+        n_trials=2,
+        plot=False,
+        save_image=False,
+    )
+
+    rb_data = result["Q17"]["rb_data"]
+    irb_data = result["Q17"]["irb_data"]
+    np.testing.assert_array_equal(rb_data["n_cliffords"], reference_range)
+    np.testing.assert_array_equal(irb_data["n_cliffords"], interleaved_range)
+    np.testing.assert_array_equal(rb_data["seeds"], np.array([11, 22], dtype=int))
+    np.testing.assert_array_equal(irb_data["seeds"], np.array([11, 22], dtype=int))
+    assert rb_data["trials"].shape == (3, 2)
+    assert irb_data["trials"].shape == (3, 2)


### PR DESCRIPTION
## Summary
- Store per-trial RB values in `rb_experiment_1q()` and `rb_experiment_2q()` results as `trials` with matching `seeds`.
- Include both reference RB and interleaved RB curve payloads in final IRB results under `rb_data` and `irb_data`.
- Keep RB/IRB `time_integration` defaulting to `True` and expose the option through the Experiment facade.

## Result shape
For each target in an IRB result, `rb_data` and `irb_data` now include:
- `n_cliffords`
- `mean`
- `std`
- `trials` with shape `(n_clifford_points, n_trials)`
- `seeds`

The trial values use the same normalized signal/probability units as the fitted curves.

## Validation
- `.venv/bin/python -m pytest tests/experiment/test_benchmarking_service_irb_awg_reset.py -q`
- `.venv/bin/python -m pytest tests/experiment/test_experiment_facade_delegation.py tests/experiment/test_benchmarking_service_irb_awg_reset.py -q`
- `.venv/bin/python -m ruff check src/qubex/experiment/services/benchmarking_service.py src/qubex/experiment/experiment.py tests/experiment/test_benchmarking_service_irb_awg_reset.py tests/experiment/test_experiment_facade_delegation.py`
- `.venv/bin/python -m ruff format --check src/qubex/experiment/services/benchmarking_service.py src/qubex/experiment/experiment.py tests/experiment/test_benchmarking_service_irb_awg_reset.py`