### PR TITLE
Improve adaptive chevron search efficiency and outputs

### DIFF
--- a/src/qubex/contrib/experiment/chevron_matched_transform.py
+++ b/src/qubex/contrib/experiment/chevron_matched_transform.py
@@ -264,6 +264,7 @@ def estimate_qubit_frequency_from_chevron_adaptive(
     amplitudes: dict[str, float] | None = None,
     omega_rabi_range: ArrayLike | None = None,
     target_omega_rabi: float | None = None,
+    target_amplitude_scale_bounds: tuple[float, float] | None = None,
     n_shots: int | None = None,
     search_n_shots: int | None = None,
     shot_interval: float | None = None,
@@ -295,8 +296,8 @@ def estimate_qubit_frequency_from_chevron_adaptive(
         [-search_detuning_width / 2, search_detuning_width / 2].
         Default: 0.2.
     search_duration_max : float, optional
-        Maximum pulse duration in ns for search measurements.
-        The minimum duration is 0.
+        Nominal maximum pulse duration in ns for search measurements.
+        The generated axis is rounded to the qxpulse sampling period.
         Default: 400.0.
     search_detuning_points_per_half : int, optional
         Number of detuning intervals per half-width in the initial search.
@@ -307,7 +308,7 @@ def estimate_qubit_frequency_from_chevron_adaptive(
     search_duration_points : int, optional
         Number of duration intervals in the initial search.
         The generated duration axis has search_duration_points + 1 samples
-        before sampling-period rounding and de-duplication.
+        before sampling-period rounding.
         Default: 15.
     search_duration_alpha : float, optional
         Exponent for nonlinear search duration spacing:
@@ -335,6 +336,11 @@ def estimate_qubit_frequency_from_chevron_adaptive(
         Target resonant Rabi frequency (GHz) used to rescale the final
         measurement amplitude from the coarse-search estimate.
         Default: 0.0125.
+    target_amplitude_scale_bounds : tuple[float, float], optional
+        Lower and upper clipping bounds for amplitude rescaling.
+        Used both for the search-to-final amplitude update and for the
+        clipped target_amplitudes recommendation.
+        Default: (0.1, 10.0).
     n_shots : int, optional
         Number of shots for the final regular chevron measurement.
         Default: max(1, DEFAULT_SHOTS // 4).
@@ -377,8 +383,8 @@ def estimate_qubit_frequency_from_chevron_adaptive(
                 "detuning_range": final detuning axis (GHz),
                 "resonant_frequencies": final estimated qubit frequencies,
                 "target_amplitudes":
-                    amplitudes estimated to realize target_omega_rabi from
-                    the final measurement,
+                    clipped amplitudes estimated to realize target_omega_rabi
+                    from the final measurement,
                 "peak_background_rms_ratios":
                     final peak-to-background-RMS ratios for each target,
                 "search_results":
@@ -399,7 +405,8 @@ def estimate_qubit_frequency_from_chevron_adaptive(
         measured on the outer detuning bands of the doubled detuning range.
     - The final drive frequency is set to the search omega_q estimate.
     - The final drive amplitude is multiplied by
-        target_omega_rabi / omega_rabi_est, clipped to [0.1, 10.0].
+        target_omega_rabi / omega_rabi_est, clipped to
+        target_amplitude_scale_bounds.
     """
     if targets is None:
         targets = exp.ctx.qubit_labels
@@ -428,6 +435,8 @@ def estimate_qubit_frequency_from_chevron_adaptive(
         omega_rabi_range = 0.1 * (10 ** np.linspace(0, 1, 256) - 1) / 9
     if target_omega_rabi is None:
         target_omega_rabi = 0.0125
+    if target_amplitude_scale_bounds is None:
+        target_amplitude_scale_bounds = (0.1, 10.0)
     if n_shots is None:
         n_shots = max(1, DEFAULT_SHOTS // 4)
     if search_n_shots is None:
@@ -449,6 +458,12 @@ def estimate_qubit_frequency_from_chevron_adaptive(
     search_duration_points = int(search_duration_points)
     search_duration_alpha = float(search_duration_alpha)
     peak_background_rms_threshold = float(peak_background_rms_threshold)
+    if len(target_amplitude_scale_bounds) != 2:
+        raise ValueError("target_amplitude_scale_bounds must contain two values.")
+    target_amplitude_scale_bounds = (
+        float(target_amplitude_scale_bounds[0]),
+        float(target_amplitude_scale_bounds[1]),
+    )
     final_detuning_range = np.asarray(final_detuning_range, dtype=float)
     final_time_range = np.asarray(final_time_range, dtype=float)
     if final_time_range.size < 2:
@@ -464,6 +479,14 @@ def estimate_qubit_frequency_from_chevron_adaptive(
         raise ValueError("search_duration_points must be positive.")
     if search_duration_alpha <= 0:
         raise ValueError("search_duration_alpha must be positive.")
+    scale_min, scale_max = target_amplitude_scale_bounds
+    if scale_min <= 0 or scale_max <= 0:
+        raise ValueError("target_amplitude_scale_bounds must be positive.")
+    if scale_min > scale_max:
+        raise ValueError(
+            "target_amplitude_scale_bounds lower bound must be less than or "
+            "equal to upper bound."
+        )
 
     search_detuning_range, search_time_range = _make_adaptive_search_ranges(
         detuning_width=search_detuning_width,
@@ -587,7 +610,7 @@ def estimate_qubit_frequency_from_chevron_adaptive(
         freq = omega_q_est
 
         scale = target_omega_rabi / max(omega_rabi_est, 1e-12)
-        scale = np.clip(scale, 0.1, 10.0)
+        scale = np.clip(scale, scale_min, scale_max)
         amp *= scale
 
         print(
@@ -643,7 +666,11 @@ def estimate_qubit_frequency_from_chevron_adaptive(
         )
 
         target_amplitude_scale = target_omega_rabi / max(omega_rabi_final, 1e-12)
-        target_amplitude_scale = np.clip(target_amplitude_scale, 0.1, 10.0)
+        target_amplitude_scale = np.clip(
+            target_amplitude_scale,
+            scale_min,
+            scale_max,
+        )
         target_amplitude = amp * target_amplitude_scale
         print(
             f"[target amplitude] amp={target_amplitude:.6g}"
@@ -759,7 +786,6 @@ def _make_adaptive_search_ranges(
     time_range = duration_max * (k / duration_points) ** duration_alpha
     sampling_period = get_sampling_period()
     time_range = np.round(time_range / sampling_period) * sampling_period
-    time_range = np.unique(np.clip(time_range, 0.0, duration_max))
     if time_range.size < 2:
         raise ValueError("adaptive search time_range must contain at least two points.")
     return detuning_range, time_range

--- a/src/qubex/contrib/experiment/chevron_matched_transform.py
+++ b/src/qubex/contrib/experiment/chevron_matched_transform.py
@@ -7,14 +7,12 @@ from collections.abc import Collection
 import numpy as np
 import plotly.graph_objects as go
 from numpy.typing import ArrayLike
-from qxpulse import Rect
-from tqdm import tqdm
+from qxpulse import Rect, get_sampling_period
 
 import qubex.visualization as viz
 from qubex.experiment import Experiment
 from qubex.experiment.experiment_constants import (
     DEFAULT_INTERVAL,
-    DEFAULT_RABI_TIME_RANGE,
     DEFAULT_SHOTS,
 )
 from qubex.experiment.models.result import Result
@@ -32,6 +30,7 @@ def estimate_qubit_frequency_from_chevron(
     n_shots: int | None = None,
     shot_interval: float | None = None,
     quadratic_window: int | None = None,
+    background_radius: int | None = None,
     plot: bool | None = None,
     save_image: bool | None = None,
 ) -> Result:
@@ -44,7 +43,7 @@ def estimate_qubit_frequency_from_chevron(
     analysis.
 
     Unlike estimate_qubit_frequency_from_chevron_adaptive(),
-    this function does not perform rough-search measurements or adaptive
+    this function does not perform coarse-search measurements or adaptive
     updates of the drive frequency/amplitude.
 
     Parameters
@@ -56,10 +55,10 @@ def estimate_qubit_frequency_from_chevron(
         If None, all available qubits are used.
     detuning_range : array-like, optional
         Frequency detuning range (GHz) for chevron measurements.
-        Default: np.linspace(-0.1, 0.1, 51)
+        Default: np.linspace(-0.05, 0.05, 41)
     time_range : array-like, optional
         Pulse duration range (ns).
-        Default: DEFAULT_RABI_TIME_RANGE
+        Default: np.linspace(0, 250, 26)
     frequencies : dict[str, float], optional
         Drive frequencies (GHz) for each target qubit.
         If None, calibrated qubit frequencies are used.
@@ -70,13 +69,18 @@ def estimate_qubit_frequency_from_chevron(
         Trial resonant Rabi frequencies (GHz) used in the matched transform.
     n_shots : int, optional
         Number of shots.
-        Default: DEFAULT_SHOTS // 4
+        Default: max(1, DEFAULT_SHOTS // 4)
     shot_interval : float, optional
         Interval between shots.
     quadratic_window : int, optional
         Half-width of the local quadratic fitting window used for
         sub-grid peak refinement.
-        quadratic_window=2 uses a 5x5 patch.
+        Default: 3.
+        quadratic_window=3 uses a 7x7 patch.
+    background_radius : int, optional
+        Radius, in transform-grid points, around the detected peak to exclude
+        when estimating background RMS.
+        Default: 32.
     plot : bool, optional
         If True, display generated figures.
     save_image : bool, optional
@@ -93,10 +97,10 @@ def estimate_qubit_frequency_from_chevron(
                             estimated qubit frequency (GHz),
                         "omega_rabi":
                             estimated resonant Rabi frequency (GHz),
-                        "peak_prominence_ratio":
+                        "peak_background_rms_ratio":
                             confidence metric defined as the ratio between
-                            the main transform peak and the largest competing
-                            peak outside a neighborhood of the main peak,
+                            the main transform peak and background RMS outside
+                            a neighborhood of the main peak,
                         "frequency_used":
                             drive frequency used for measurement (GHz),
                         "amplitude_used":
@@ -117,8 +121,8 @@ def estimate_qubit_frequency_from_chevron(
                     estimated resonant Rabi frequencies,
                 "amplitudes_used":
                     amplitudes used for each target,
-                "peak_prominence_ratios":
-                    peak prominence ratios for each target,
+                "peak_background_rms_ratios":
+                    peak-to-background-RMS ratios for each target,
             }
         figures:
             {
@@ -134,10 +138,8 @@ def estimate_qubit_frequency_from_chevron(
         before analysis.
     - The matched transform integrates over both drive frequency and
         pulse duration and supports nonuniform sampling grids.
-    - The overall sign ambiguity of the transform is fixed such that
-        the dominant peak becomes positive.
     - Quadratic refinement improves sub-grid peak estimation accuracy.
-    - The peak prominence ratio serves as a confidence metric for
+    - The peak-to-background-RMS ratio serves as a confidence metric for
         peak detection.
     """
     if targets is None:
@@ -148,9 +150,9 @@ def estimate_qubit_frequency_from_chevron(
         targets = list(targets)
 
     if detuning_range is None:
-        detuning_range = np.linspace(-0.1, 0.1, 51)
+        detuning_range = np.linspace(-0.05, 0.05, 41)
     if time_range is None:
-        time_range = DEFAULT_RABI_TIME_RANGE
+        time_range = np.linspace(0, 250, 26)
     if omega_rabi_range is None:
         omega_rabi_range = 0.1 * (10 ** np.linspace(0, 1, 256) - 1) / 9
     if n_shots is None:
@@ -158,7 +160,9 @@ def estimate_qubit_frequency_from_chevron(
     if shot_interval is None:
         shot_interval = DEFAULT_INTERVAL
     if quadratic_window is None:
-        quadratic_window = 2
+        quadratic_window = 3
+    if background_radius is None:
+        background_radius = 32
     if plot is None:
         plot = True
     if save_image is None:
@@ -179,7 +183,7 @@ def estimate_qubit_frequency_from_chevron(
     results_data = {}
     resonant_frequencies: dict[str, float] = {}
     omega_rabis: dict[str, float] = {}
-    peak_prominence_ratios: dict[str, float] = {}
+    peak_background_rms_ratios: dict[str, float] = {}
     figures = {}
 
     for target in targets:
@@ -197,6 +201,7 @@ def estimate_qubit_frequency_from_chevron(
             shot_interval=shot_interval,
             refine_peak_quadratic=True,
             quadratic_window=quadratic_window,
+            background_radius=background_radius,
             plot=plot,
             save_image=save_image,
         )
@@ -205,18 +210,18 @@ def estimate_qubit_frequency_from_chevron(
 
         omega_q = analysis["omega_q"]
         omega_rabi = analysis["omega_rabi"]
-        peak_prominence_ratio = analysis["peak_prominence_ratio"]
+        peak_background_rms_ratio = analysis["peak_background_rms_ratio"]
 
         print(
             f"[RESULT] ω_q={omega_q:.6f} GHz,"
             f" ω_Rabi={omega_rabi:.6f} GHz"
-            f" peak_prominence_ratio={peak_prominence_ratio:.3f}"
+            f" peak_background_rms_ratio={peak_background_rms_ratio:.3f}"
         )
 
         results_data[target] = {
             "omega_q": omega_q,
             "omega_rabi": omega_rabi,
-            "peak_prominence_ratio": peak_prominence_ratio,
+            "peak_background_rms_ratio": peak_background_rms_ratio,
             "frequency_used": frequencies[target],
             "amplitude_used": amplitudes[target],
             "chevron_data": measurement_result.data["chevron_data"],
@@ -225,7 +230,7 @@ def estimate_qubit_frequency_from_chevron(
 
         resonant_frequencies[target] = omega_q
         omega_rabis[target] = omega_rabi
-        peak_prominence_ratios[target] = peak_prominence_ratio
+        peak_background_rms_ratios[target] = peak_background_rms_ratio
         figures[f"{target}_measurement"] = measurement_result.figure
         figures[f"{target}_transform"] = analysis_result.figure
 
@@ -237,7 +242,7 @@ def estimate_qubit_frequency_from_chevron(
             "resonant_frequencies": resonant_frequencies,
             "omega_rabis": omega_rabis,
             "amplitudes_used": amplitudes,
-            "peak_prominence_ratios": peak_prominence_ratios,
+            "peak_background_rms_ratios": peak_background_rms_ratios,
         },
         figures=figures,
     )
@@ -247,42 +252,35 @@ def estimate_qubit_frequency_from_chevron_adaptive(
     exp: Experiment,
     targets: Collection[str] | str | None = None,
     *,
-    detuning_range: ArrayLike | None = None,
-    detuning_range_rough_search: ArrayLike | None = None,
-    time_range: ArrayLike | None = None,
+    search_detuning_width: float | None = None,
+    search_duration_max: float | None = None,
+    search_detuning_points_per_half: int | None = None,
+    search_duration_points: int | None = None,
+    search_duration_alpha: float | None = None,
+    peak_background_rms_threshold: float | None = None,
+    final_detuning_range: ArrayLike | None = None,
+    final_time_range: ArrayLike | None = None,
     frequencies: dict[str, float] | None = None,
     amplitudes: dict[str, float] | None = None,
     omega_rabi_range: ArrayLike | None = None,
     target_omega_rabi: float | None = None,
     n_shots: int | None = None,
-    n_shots_rough_search: int | None = None,
+    search_n_shots: int | None = None,
     shot_interval: float | None = None,
-    quadratic_window: int | None = None,
+    final_quadratic_window: int | None = None,
+    background_radius: int | None = None,
     plot: bool | None = None,
     save_image: bool | None = None,
-    enable_rough_search: bool | None = None,
 ) -> Result:
     """
-    Adaptively estimate qubit resonance frequencies from chevron measurements.
+    Adaptively estimate qubit frequencies with a coarse chevron first pass.
 
-    This function performs adaptive chevron-based estimation of the qubit
-    resonance frequency (ω_q) and resonant Rabi frequency (ω_Rabi)
-    using matched-transform analysis.
-
-    The procedure consists of:
-
-    1. Rough-search stage (optional)
-        - Measure a coarse chevron pattern over a wide detuning range.
-        - Estimate ω_q and ω_Rabi using matched-transform analysis
-            with quadratic peak refinement.
-        - Update:
-            * drive frequency ← estimated ω_q
-            * drive amplitude ← rescaled toward target_omega_rabi
-
-    2. Final measurement stage
-        - Measure a chevron pattern over a narrower detuning range.
-        - Perform matched-transform analysis with quadratic peak refinement
-            to obtain final estimates of ω_q and ω_Rabi.
+    The first pass measures a coarse chevron over a wide detuning-duration
+    domain with nonlinear duration spacing. If the peak/background-RMS ratio
+    is small, additional chevron data are measured on both detuning-side
+    bands, then the combined raw IQ data are projected once before
+    re-analysis. The final measurement uses the regular chevron grid with
+    amplitude rescaled from the coarse-search Rabi estimate.
 
     Parameters
     ----------
@@ -291,15 +289,40 @@ def estimate_qubit_frequency_from_chevron_adaptive(
     targets : Collection[str] or str, optional
         Target qubit label(s).
         If None, all available qubits are used.
-    detuning_range : array-like, optional
-        Detuning range (GHz) for the final measurement.
-        Default: np.linspace(-0.05, 0.05, 51)
-    detuning_range_rough_search : array-like, optional
-        Detuning range (GHz) for the rough-search stage.
-        Default: np.linspace(-0.1, 0.1, 51)
-    time_range : array-like, optional
-        Pulse duration range (ns).
-        Default: DEFAULT_RABI_TIME_RANGE
+    search_detuning_width : float, optional
+        Width of the initial central search detuning interval in GHz.
+        The first pass samples
+        [-search_detuning_width / 2, search_detuning_width / 2].
+        Default: 0.2.
+    search_duration_max : float, optional
+        Maximum pulse duration in ns for search measurements.
+        The minimum duration is 0.
+        Default: 400.0.
+    search_detuning_points_per_half : int, optional
+        Number of detuning intervals per half-width in the initial search.
+        The initial detuning axis has 2 * search_detuning_points_per_half + 1
+        points. If side-band extension is triggered, the doubled range uses
+        twice this value per half-width.
+        Default: 20.
+    search_duration_points : int, optional
+        Number of duration intervals in the initial search.
+        The generated duration axis has search_duration_points + 1 samples
+        before sampling-period rounding and de-duplication.
+        Default: 15.
+    search_duration_alpha : float, optional
+        Exponent for nonlinear search duration spacing:
+        tau_k = search_duration_max * (k / N) ** search_duration_alpha.
+        Default: 1.5.
+    peak_background_rms_threshold : float, optional
+        Minimum search peak/background-RMS ratio required to skip
+        side-band extension.
+        Default: 8.0.
+    final_detuning_range : array-like, optional
+        Detuning range (GHz) for the final regular chevron measurement.
+        Default: np.linspace(-0.05, 0.05, 41).
+    final_time_range : array-like, optional
+        Pulse duration range (ns) for the final regular chevron measurement.
+        Default: np.linspace(0, 250, 26).
     frequencies : dict[str, float], optional
         Initial drive frequencies (GHz) for each target qubit.
         If None, calibrated qubit frequencies are used.
@@ -307,29 +330,31 @@ def estimate_qubit_frequency_from_chevron_adaptive(
         Initial drive amplitudes for each target qubit.
         If None, default control amplitudes are used.
     omega_rabi_range : array-like, optional
-        Trial resonant Rabi frequencies (GHz) used in the matched transform.
+        Trial resonant Rabi frequencies (GHz) used in matched transforms.
     target_omega_rabi : float, optional
-        Target resonant Rabi frequency (GHz) used to adaptively rescale
-        the drive amplitude.
-        Default: 0.0125
+        Target resonant Rabi frequency (GHz) used to rescale the final
+        measurement amplitude from the coarse-search estimate.
+        Default: 0.0125.
     n_shots : int, optional
-        Number of shots for the final measurement.
-        Default: DEFAULT_SHOTS // 4
-    n_shots_rough_search : int, optional
-        Number of shots for rough-search measurements.
-        Default: n_shots
+        Number of shots for the final regular chevron measurement.
+        Default: max(1, DEFAULT_SHOTS // 4).
+    search_n_shots : int, optional
+        Number of shots for search measurements.
+        Default: n_shots.
     shot_interval : float, optional
         Interval between shots.
-    quadratic_window : int, optional
+    final_quadratic_window : int, optional
         Half-width of the local quadratic fitting window used for
-        sub-grid peak refinement.
-        quadratic_window=2 uses a 5x5 patch.
+        final sub-grid peak refinement. The search stage uses 2.
+        Default: 3.
+    background_radius : int, optional
+        Radius, in transform-grid points, around the detected peak to exclude
+        when estimating background RMS.
+        Default: 32.
     plot : bool, optional
         If True, display generated figures.
     save_image : bool, optional
         If True, save generated figures.
-    enable_rough_search : bool, optional
-        If True, perform a rough-search measurement before the final stage.
 
     Returns
     -------
@@ -338,69 +363,43 @@ def estimate_qubit_frequency_from_chevron_adaptive(
             {
                 "results": {
                     target: {
-                        "omega_q":
-                            estimated qubit frequency (GHz),
-                        "omega_rabi":
-                            estimated resonant Rabi frequency (GHz),
-                        "peak_prominence_ratio":
-                            confidence metric defined as the ratio between
-                            the main transform peak and the largest competing
-                            peak outside a neighborhood of the main peak,
-                        "frequency_used":
-                            final drive frequency used (GHz),
-                        "amplitude_used":
-                            final drive amplitude used,
-                        "chevron_data":
-                            projected chevron data,
-                        "transform":
-                            matched-transform map,
+                        "omega_q": final estimated qubit frequency (GHz),
+                        "omega_rabi": final estimated Rabi frequency (GHz),
+                        "peak_background_rms_ratio":
+                            final peak-to-background-RMS ratio,
+                        "frequency_used": final drive frequency used (GHz),
+                        "amplitude_used": final drive amplitude used,
+                        "chevron_data": final projected chevron data,
+                        "transform": final matched-transform map,
                     }
                 },
-                "time_range":
-                    pulse duration axis (ns),
-                "detuning_range":
-                    final detuning axis (GHz),
-                "resonant_frequencies":
-                    estimated qubit frequencies,
-                "omega_rabis":
-                    estimated resonant Rabi frequencies,
-                "amplitudes_used":
-                    final amplitudes used for each target,
-                "peak_prominence_ratios":
-                    peak prominence ratios for each target,
-                "rough_search_results":
-                    rough-search measurement and analysis results,
+                "time_range": final pulse duration axis (ns),
+                "detuning_range": final detuning axis (GHz),
+                "resonant_frequencies": final estimated qubit frequencies,
+                "target_amplitudes":
+                    amplitudes estimated to realize target_omega_rabi from
+                    the final measurement,
+                "peak_background_rms_ratios":
+                    final peak-to-background-RMS ratios for each target,
+                "search_results":
+                    search estimates, measured data, amplitude scale,
+                    and whether side-band extension was used,
             }
-
         figures:
             {
-                f"{target}_measurement":
-                    final chevron measurement figure,
-
-                f"{target}_transform":
-                    final matched-transform analysis figure,
-
-                f"{target}_rough_measurement":
-                    rough-search chevron measurement figure,
-
-                f"{target}_rough_transform":
-                    rough-search matched-transform analysis figure,
+                f"{target}_search_measurement": search chevron figure,
+                f"{target}_search_transform": search transform figure,
+                f"{target}_measurement": final chevron measurement figure,
+                f"{target}_transform": final transform figure,
             }
 
     Notes
     -----
-    - Chevron data are projected onto a global PCA axis in the IQ plane
-        before analysis.
-    - The matched transform integrates over both drive frequency and
-        pulse duration and supports nonuniform sampling grids.
-    - The overall sign ambiguity of the transform is fixed such that
-        the dominant peak becomes positive.
-    - Drive amplitudes are adaptively updated to approach the target
-        resonant Rabi frequency.
-    - Quadratic refinement is applied during both the rough-search
-        and final measurement stages.
-    - The peak prominence ratio serves as a confidence metric for
-        peak detection.
+    - If the initial search ratio is below threshold, additional samples are
+        measured on the outer detuning bands of the doubled detuning range.
+    - The final drive frequency is set to the search omega_q estimate.
+    - The final drive amplitude is multiplied by
+        target_omega_rabi / omega_rabi_est, clipped to [0.1, 10.0].
     """
     if targets is None:
         targets = exp.ctx.qubit_labels
@@ -409,37 +408,70 @@ def estimate_qubit_frequency_from_chevron_adaptive(
     else:
         targets = list(targets)
 
-    if detuning_range is None:
-        detuning_range = np.linspace(-0.05, 0.05, 51)
-    if detuning_range_rough_search is None:
-        detuning_range_rough_search = np.linspace(-0.1, 0.1, 51)
-    if time_range is None:
-        time_range = DEFAULT_RABI_TIME_RANGE
+    if search_detuning_width is None:
+        search_detuning_width = 0.2
+    if search_duration_max is None:
+        search_duration_max = 400.0
+    if search_detuning_points_per_half is None:
+        search_detuning_points_per_half = 20
+    if search_duration_points is None:
+        search_duration_points = 15
+    if search_duration_alpha is None:
+        search_duration_alpha = 1.5
+    if peak_background_rms_threshold is None:
+        peak_background_rms_threshold = 8.0
+    if final_detuning_range is None:
+        final_detuning_range = np.linspace(-0.05, 0.05, 41)
+    if final_time_range is None:
+        final_time_range = np.linspace(0, 250, 26)
     if omega_rabi_range is None:
         omega_rabi_range = 0.1 * (10 ** np.linspace(0, 1, 256) - 1) / 9
     if target_omega_rabi is None:
         target_omega_rabi = 0.0125
     if n_shots is None:
         n_shots = max(1, DEFAULT_SHOTS // 4)
-    if n_shots_rough_search is None:
-        n_shots_rough_search = n_shots
+    if search_n_shots is None:
+        search_n_shots = n_shots
     if shot_interval is None:
         shot_interval = DEFAULT_INTERVAL
-    if quadratic_window is None:
-        quadratic_window = 2
+    if final_quadratic_window is None:
+        final_quadratic_window = 3
+    if background_radius is None:
+        background_radius = 32
     if plot is None:
         plot = True
     if save_image is None:
         save_image = True
-    if enable_rough_search is None:
-        enable_rough_search = True
 
-    time_range = np.asarray(time_range, dtype=float)
-    if time_range.size < 2:
-        raise ValueError("time_range must contain at least two points.")
-    detuning_range = np.asarray(detuning_range, dtype=float)
-    detuning_range_rough_search = np.asarray(detuning_range_rough_search, dtype=float)
+    search_detuning_width = float(search_detuning_width)
+    search_duration_max = float(search_duration_max)
+    search_detuning_points_per_half = int(search_detuning_points_per_half)
+    search_duration_points = int(search_duration_points)
+    search_duration_alpha = float(search_duration_alpha)
+    peak_background_rms_threshold = float(peak_background_rms_threshold)
+    final_detuning_range = np.asarray(final_detuning_range, dtype=float)
+    final_time_range = np.asarray(final_time_range, dtype=float)
+    if final_time_range.size < 2:
+        raise ValueError("final_time_range must contain at least two points.")
     omega_rabi_range = np.asarray(omega_rabi_range, dtype=float)
+    if search_detuning_width <= 0:
+        raise ValueError("search_detuning_width must be positive.")
+    if search_duration_max <= 0:
+        raise ValueError("search_duration_max must be positive.")
+    if search_detuning_points_per_half <= 0:
+        raise ValueError("search_detuning_points_per_half must be positive.")
+    if search_duration_points <= 0:
+        raise ValueError("search_duration_points must be positive.")
+    if search_duration_alpha <= 0:
+        raise ValueError("search_duration_alpha must be positive.")
+
+    search_detuning_range, search_time_range = _make_adaptive_search_ranges(
+        detuning_width=search_detuning_width,
+        detuning_points_per_half=search_detuning_points_per_half,
+        duration_max=search_duration_max,
+        duration_points=search_duration_points,
+        duration_alpha=search_duration_alpha,
+    )
 
     if frequencies is None:
         frequencies = {target: exp.ctx.targets[target].frequency for target in targets}
@@ -450,11 +482,10 @@ def estimate_qubit_frequency_from_chevron_adaptive(
         }
 
     results_data = {}
-    results_data_rough_search = {}
+    search_results = {}
     resonant_frequencies: dict[str, float] = {}
-    omega_rabis: dict[str, float] = {}
-    amplitudes_used: dict[str, float] = {}
-    peak_prominence_ratios: dict[str, float] = {}
+    target_amplitudes: dict[str, float] = {}
+    peak_background_rms_ratios: dict[str, float] = {}
     figures = {}
 
     for target in targets:
@@ -462,79 +493,140 @@ def estimate_qubit_frequency_from_chevron_adaptive(
         amp = amplitudes[target]
 
         print(f"=== Target: {target} ===")
+        print("[search measurement]")
 
-        if enable_rough_search:
-            print("[rough search]")
+        search_measurement, search_analysis = _measure_and_analyze_chevron(
+            exp,
+            target,
+            detuning_range=search_detuning_range,
+            time_range=search_time_range,
+            frequency=freq,
+            amplitude=amp,
+            omega_rabi_range=omega_rabi_range,
+            n_shots=search_n_shots,
+            shot_interval=shot_interval,
+            refine_peak_quadratic=True,
+            quadratic_window=2,
+            background_radius=background_radius,
+            plot=plot,
+            save_image=False,
+        )
+        search_analysis_data = search_analysis.data
+        extended_search = False
 
-            measurement_result, analysis_result = _measure_and_analyze_chevron(
-                exp,
-                target,
-                detuning_range=detuning_range_rough_search,
-                time_range=time_range,
+        if (
+            search_analysis_data["peak_background_rms_ratio"]
+            < peak_background_rms_threshold
+        ):
+            print("[search extension]")
+            extended_detuning_range = np.linspace(
+                -search_detuning_width,
+                search_detuning_width,
+                4 * search_detuning_points_per_half + 1,
+            )
+            lower_side, upper_side = _split_unmeasured_detuning_side_bands(
+                measured_detuning_range=search_detuning_range,
+                extended_detuning_range=extended_detuning_range,
+            )
+            side_results = [
+                measure_chevron_pattern(
+                    exp,
+                    target,
+                    detuning_range=detuning_side_range,
+                    time_range=search_time_range,
+                    frequency=freq,
+                    amplitude=amp,
+                    n_shots=search_n_shots,
+                    shot_interval=shot_interval,
+                    plot=False,
+                    save_image=False,
+                )
+                for detuning_side_range in (lower_side, upper_side)
+            ]
+            search_measurement = _combine_chevron_measurements(
+                [search_measurement, *side_results],
+                target=target,
                 frequency=freq,
                 amplitude=amp,
-                omega_rabi_range=omega_rabi_range,
-                n_shots=n_shots_rough_search,
-                shot_interval=shot_interval,
-                refine_peak_quadratic=True,
-                quadratic_window=quadratic_window,
                 plot=plot,
-                save_image=save_image,
+                save_image=False,
             )
-            analysis = analysis_result.data
-
-            omega_q_est = analysis["omega_q"]
-            omega_rabi_est = analysis["omega_rabi"]
-            peak_prominence_ratio_rough = analysis["peak_prominence_ratio"]
-
-            print(
-                f"[rough result] ω_q={omega_q_est:.6f},"
-                f" ω_Rabi={omega_rabi_est:.6f},"
-                f" peak_prominence_ratio={peak_prominence_ratio_rough:.3f}"
+            omega_q_range = np.linspace(
+                freq + 2 * np.min(extended_detuning_range),
+                freq + 2 * np.max(extended_detuning_range),
+                1024,
             )
-
-            freq_old = freq
-            amp_old = amp
-
-            freq = omega_q_est
-
-            scale = target_omega_rabi / max(omega_rabi_est, 1e-12)
-            scale = np.clip(scale, 0.1, 10.0)
-            amp *= scale
-
-            print(
-                f"[update] freq: {freq_old:.6f} → {freq:.6f}, "
-                f"amp: {amp_old:.6g} → {amp:.6g} (scale: {scale:.3f})"
+            search_analysis = analyze_chevron_matched_transform(
+                search_measurement,
+                target,
+                omega_q_range=omega_q_range,
+                omega_rabi_range=omega_rabi_range,
+                refine_peak_quadratic=True,
+                quadratic_window=2,
+                background_radius=background_radius,
+                plot=plot,
+                save_image=False,
             )
+            search_analysis_data = search_analysis.data
+            extended_search = True
 
-            results_data_rough_search[target] = {
-                "omega_q": omega_q_est,
-                "omega_rabi": omega_rabi_est,
-                "peak_prominence_ratio": peak_prominence_ratio_rough,
-                "frequency_used": freq_old,
-                "amplitude_used": amp_old,
-                "scale": scale,
-                "chevron_data": measurement_result.data["chevron_data"],
-                "transform": analysis["transform"],
-            }
+        omega_q_est = search_analysis_data["omega_q"]
+        omega_rabi_est = search_analysis_data["omega_rabi"]
+        peak_background_rms_ratio_search = search_analysis_data[
+            "peak_background_rms_ratio"
+        ]
 
-            figures[f"{target}_rough_measurement"] = measurement_result.figure
-            figures[f"{target}_rough_transform"] = analysis_result.figure
+        print(
+            f"[search result] ω_q={omega_q_est:.6f},"
+            f" ω_Rabi={omega_rabi_est:.6f},"
+            f" peak_background_rms_ratio={peak_background_rms_ratio_search:.3f}"
+        )
+
+        freq_old = freq
+        amp_old = amp
+        freq = omega_q_est
+
+        scale = target_omega_rabi / max(omega_rabi_est, 1e-12)
+        scale = np.clip(scale, 0.1, 10.0)
+        amp *= scale
+
+        print(
+            f"[update] freq: {freq_old:.6f} -> {freq:.6f}, "
+            f"amp: {amp_old:.6g} -> {amp:.6g} (scale: {scale:.3f})"
+        )
+
+        search_results[target] = {
+            "omega_q": omega_q_est,
+            "omega_rabi": omega_rabi_est,
+            "peak_background_rms_ratio": peak_background_rms_ratio_search,
+            "frequency_used": freq_old,
+            "amplitude_used": amp_old,
+            "scale": scale,
+            "extended": extended_search,
+            "detuning_range": search_measurement.data["detuning_range"],
+            "time_range": search_measurement.data["time_range"],
+            "chevron_data": search_measurement.data["chevron_data"],
+            "transform": search_analysis_data["transform"],
+        }
+
+        figures[f"{target}_search_measurement"] = search_measurement.figure
+        figures[f"{target}_search_transform"] = search_analysis.figure
 
         print("[final measurement]")
 
         measurement_result, analysis_result = _measure_and_analyze_chevron(
             exp,
             target,
-            detuning_range=detuning_range,
-            time_range=time_range,
+            detuning_range=final_detuning_range,
+            time_range=final_time_range,
             frequency=freq,
             amplitude=amp,
             omega_rabi_range=omega_rabi_range,
             n_shots=n_shots,
             shot_interval=shot_interval,
             refine_peak_quadratic=True,
-            quadratic_window=quadratic_window,
+            quadratic_window=final_quadratic_window,
+            background_radius=background_radius,
             plot=plot,
             save_image=save_image,
         )
@@ -542,18 +634,27 @@ def estimate_qubit_frequency_from_chevron_adaptive(
 
         omega_q_final = analysis["omega_q"]
         omega_rabi_final = analysis["omega_rabi"]
-        peak_prominence_ratio_final = analysis["peak_prominence_ratio"]
+        peak_background_rms_ratio_final = analysis["peak_background_rms_ratio"]
 
         print(
             f"[FINAL] ω_q={omega_q_final:.6f} GHz,"
             f" ω_Rabi={omega_rabi_final:.6f} GHz,"
-            f" peak_prominence_ratio={peak_prominence_ratio_final:.3f}"
+            f" peak_background_rms_ratio={peak_background_rms_ratio_final:.3f}"
+        )
+
+        target_amplitude_scale = target_omega_rabi / max(omega_rabi_final, 1e-12)
+        target_amplitude_scale = np.clip(target_amplitude_scale, 0.1, 10.0)
+        target_amplitude = amp * target_amplitude_scale
+        print(
+            f"[target amplitude] amp={target_amplitude:.6g}"
+            f" for target_omega_rabi={target_omega_rabi:.6f} GHz"
+            f" (scale: {target_amplitude_scale:.3f})"
         )
 
         results_data[target] = {
             "omega_q": omega_q_final,
             "omega_rabi": omega_rabi_final,
-            "peak_prominence_ratio": peak_prominence_ratio_final,
+            "peak_background_rms_ratio": peak_background_rms_ratio_final,
             "frequency_used": freq,
             "amplitude_used": amp,
             "chevron_data": measurement_result.data["chevron_data"],
@@ -561,22 +662,20 @@ def estimate_qubit_frequency_from_chevron_adaptive(
         }
 
         resonant_frequencies[target] = omega_q_final
-        omega_rabis[target] = omega_rabi_final
-        peak_prominence_ratios[target] = peak_prominence_ratio_final
-        amplitudes_used[target] = amp
+        target_amplitudes[target] = target_amplitude
+        peak_background_rms_ratios[target] = peak_background_rms_ratio_final
         figures[f"{target}_measurement"] = measurement_result.figure
         figures[f"{target}_transform"] = analysis_result.figure
 
     return Result(
         data={
             "results": results_data,
-            "time_range": time_range,
-            "detuning_range": detuning_range,
+            "time_range": final_time_range,
+            "detuning_range": final_detuning_range,
             "resonant_frequencies": resonant_frequencies,
-            "omega_rabis": omega_rabis,
-            "amplitudes_used": amplitudes_used,
-            "peak_prominence_ratios": peak_prominence_ratios,
-            "rough_search_results": results_data_rough_search,
+            "target_amplitudes": target_amplitudes,
+            "peak_background_rms_ratios": peak_background_rms_ratios,
+            "search_results": search_results,
         },
         figures=figures,
     )
@@ -595,6 +694,7 @@ def _measure_and_analyze_chevron(
     shot_interval: float,
     refine_peak_quadratic: bool,
     quadratic_window: int,
+    background_radius: int,
     plot: bool,
     save_image: bool,
 ) -> tuple[Result, Result]:
@@ -619,6 +719,8 @@ def _measure_and_analyze_chevron(
         save_image=save_image,
     )
 
+    # The matched-transform resonance search intentionally spans about twice
+    # the measured detuning interval so a peak near the edge is still captured.
     omega_q_range = np.linspace(
         frequency + 2 * np.min(detuning_range),
         frequency + 2 * np.max(detuning_range),
@@ -632,11 +734,201 @@ def _measure_and_analyze_chevron(
         omega_rabi_range=omega_rabi_range,
         refine_peak_quadratic=refine_peak_quadratic,
         quadratic_window=quadratic_window,
+        background_radius=background_radius,
         plot=plot,
         save_image=save_image,
     )
 
     return measurement_result, analysis_result
+
+
+def _make_adaptive_search_ranges(
+    *,
+    detuning_width: float,
+    detuning_points_per_half: int,
+    duration_max: float,
+    duration_points: int,
+    duration_alpha: float,
+) -> tuple[np.ndarray, np.ndarray]:
+    detuning_range = np.linspace(
+        -0.5 * detuning_width,
+        0.5 * detuning_width,
+        2 * detuning_points_per_half + 1,
+    )
+    k = np.arange(duration_points + 1, dtype=float)
+    time_range = duration_max * (k / duration_points) ** duration_alpha
+    sampling_period = get_sampling_period()
+    time_range = np.round(time_range / sampling_period) * sampling_period
+    time_range = np.unique(np.clip(time_range, 0.0, duration_max))
+    if time_range.size < 2:
+        raise ValueError("adaptive search time_range must contain at least two points.")
+    return detuning_range, time_range
+
+
+def _split_unmeasured_detuning_side_bands(
+    *,
+    measured_detuning_range: ArrayLike,
+    extended_detuning_range: ArrayLike,
+) -> tuple[np.ndarray, np.ndarray]:
+    measured_detuning_range = np.asarray(measured_detuning_range, dtype=float)
+    extended_detuning_range = np.asarray(extended_detuning_range, dtype=float)
+    measured_min = np.min(measured_detuning_range)
+    measured_max = np.max(measured_detuning_range)
+    lower_side = extended_detuning_range[extended_detuning_range < measured_min]
+    upper_side = extended_detuning_range[extended_detuning_range > measured_max]
+    if lower_side.size == 0 or upper_side.size == 0:
+        raise ValueError("extended_detuning_range must include unmeasured side bands.")
+    return lower_side, upper_side
+
+
+def _combine_chevron_measurements(
+    results: Collection[Result],
+    *,
+    target: str,
+    frequency: float,
+    amplitude: float,
+    plot: bool,
+    save_image: bool,
+) -> Result:
+    """Combine chevron payloads and project all raw IQ data at once."""
+    results = list(results)
+    if not results:
+        raise ValueError("results must contain at least one measurement result.")
+
+    time_range = np.asarray(results[0].data["time_range"], dtype=float)
+    detuning_parts = []
+    raw_parts = []
+    for result in results:
+        result_time_range = np.asarray(result.data["time_range"], dtype=float)
+        if result_time_range.shape != time_range.shape or not np.allclose(
+            result_time_range,
+            time_range,
+        ):
+            raise ValueError("all chevron results must use the same time_range.")
+        detuning_parts.append(np.asarray(result.data["detuning_range"], dtype=float))
+        try:
+            raw_parts.append(np.asarray(result.data["raw_data"], dtype=np.complex128))
+        except KeyError as exc:
+            raise ValueError(
+                "chevron measurement results must contain raw_data for "
+                "consistent combined PCA projection."
+            ) from exc
+
+    detuning_range = np.concatenate(detuning_parts)
+    raw_data = np.concatenate(raw_parts, axis=0)
+    if raw_data.shape != (detuning_range.size, time_range.size):
+        raise ValueError(
+            "combined raw_data must have shape (len(detuning_range), len(time_range))."
+        )
+
+    sort_index = np.argsort(detuning_range)
+    detuning_range = detuning_range[sort_index]
+    raw_data = raw_data[sort_index]
+    if np.any(np.diff(detuning_range) <= 0):
+        raise ValueError("combined detuning_range must not contain duplicates.")
+
+    chevron_data = _project_chevron_raw_data(raw_data)
+    fig = _make_chevron_figure(
+        target=target,
+        detuning_range=detuning_range,
+        time_range=time_range,
+        chevron_data=chevron_data,
+        frequency=frequency,
+        amplitude=amplitude,
+        title="Extended search chevron pattern",
+    )
+
+    if plot:
+        fig.show()
+
+    if save_image:
+        viz.save_figure(
+            fig,
+            name=f"extended_search_chevron_pattern_{target}",
+            width=600,
+            height=400,
+        )
+
+    return Result(
+        data={
+            "time_range": time_range,
+            "detuning_range": detuning_range,
+            "frequency": frequency,
+            "amplitude": amplitude,
+            "raw_data": raw_data,
+            "chevron_data": chevron_data,
+        },
+        figure=fig,
+    )
+
+
+def _project_chevron_raw_data(raw_data: ArrayLike) -> np.ndarray:
+    """Project gridded chevron IQ data onto one PCA axis."""
+    raw_data = np.asarray(raw_data, dtype=np.complex128)
+    if raw_data.ndim != 2:
+        raise ValueError("raw_data must be a two-dimensional array.")
+
+    z_all = raw_data.ravel()
+    z_centered = z_all - np.mean(z_all)
+    iq_all = np.column_stack(
+        [
+            z_centered.real,
+            z_centered.imag,
+        ]
+    )
+    try:
+        _, _, vh = np.linalg.svd(iq_all, full_matrices=False)
+        axis = vh[0]
+    except np.linalg.LinAlgError:
+        axis = np.array([1.0, 0.0])
+
+    mean_real = np.mean(z_all.real)
+    mean_imag = np.mean(z_all.imag)
+    projected_data = axis[0] * (raw_data.real - mean_real) + axis[1] * (
+        raw_data.imag - mean_imag
+    )
+    if np.mean(projected_data[:, 0]) < np.mean(projected_data):
+        projected_data *= -1
+
+    return projected_data.T
+
+
+def _make_chevron_figure(
+    *,
+    target: str,
+    detuning_range: ArrayLike,
+    time_range: ArrayLike,
+    chevron_data: ArrayLike,
+    frequency: float,
+    amplitude: float,
+    title: str,
+) -> go.Figure:
+    detuning_range = np.asarray(detuning_range, dtype=float)
+    time_range = np.asarray(time_range, dtype=float)
+    chevron_data = np.asarray(chevron_data, dtype=float)
+
+    fig = viz.make_figure()
+    fig.add_trace(
+        go.Heatmap(
+            x=frequency + detuning_range,
+            y=time_range,
+            z=chevron_data,
+            colorscale="Viridis",
+        )
+    )
+
+    fig.update_layout(
+        title=dict(
+            text=f"{title} : {target}<br><sup>amplitude={amplitude:.6g}</sup>",
+            x=0.5,
+            xanchor="center",
+        ),
+        xaxis_title="Drive frequency (GHz)",
+        yaxis_title="Time (ns)",
+        width=600,
+        height=400,
+    )
+    return fig
 
 
 def measure_chevron_pattern(
@@ -659,23 +951,28 @@ def measure_chevron_pattern(
     ----------
     exp : Experiment
         Experiment object containing hardware context.
-    target:
+    target : str
         Target qubit label.
-    detuning_range:
+    detuning_range : array-like, optional
         Frequency detuning range (GHz).
-    time_range:
+        Default: np.linspace(-0.05, 0.05, 41).
+    time_range : array-like, optional
         Pulse duration range (ns).
-    frequency:
+        Default: np.linspace(0, 250, 26).
+    frequency : float, optional
         Base frequency (GHz).
-    amplitude:
+        If None, the calibrated qubit frequency is used.
+    amplitude : float, optional
         Drive amplitude.
-    n_shots:
+        If None, the default control amplitude is used.
+    n_shots : int, optional
         Number of shots.
-    shot_interval:
+        Default: max(1, DEFAULT_SHOTS // 4).
+    shot_interval : float, optional
         Interval between shots.
-    plot:
+    plot : bool, optional
         If True, display heatmap.
-    save_image:
+    save_image : bool, optional
         If True, save the generated heatmap figure.
 
     Returns
@@ -686,23 +983,31 @@ def measure_chevron_pattern(
             "detuning_range": detuning_range,
             "frequency": frequency,
             "amplitude": amplitude,
+            "raw_data":
+                raw IQ data with shape (len(detuning_range), len(time_range)),
             "chevron_data":
                 projected chevron data with shape
                 (len(time_range), len(detuning_range)),
         }
         figure:
             Chevron heatmap figure.
+
+    Notes
+    -----
+    - Each pulse is generated as Rect(duration, amplitude).detuned(detuning)
+        while the carrier frequency is kept at frequency.
+    - Data are projected onto a global PCA axis in the IQ plane.
     """
     if detuning_range is None:
-        detuning_range = np.linspace(-0.05, 0.05, 51)
+        detuning_range = np.linspace(-0.05, 0.05, 41)
     if time_range is None:
-        time_range = DEFAULT_RABI_TIME_RANGE
+        time_range = np.linspace(0, 250, 26)
     if frequency is None:
         frequency = exp.ctx.targets[target].frequency
     if amplitude is None:
         amplitude = exp.ctx.params.control_amplitude[target]
     if n_shots is None:
-        n_shots = DEFAULT_SHOTS
+        n_shots = max(1, DEFAULT_SHOTS // 4)
     if shot_interval is None:
         shot_interval = DEFAULT_INTERVAL
     if plot is None:
@@ -713,76 +1018,40 @@ def measure_chevron_pattern(
     detuning_range = np.asarray(detuning_range, dtype=float)
     time_range = np.asarray(time_range, dtype=float)
 
-    raw_data_buffer: list[np.ndarray] = []
+    sweep_points = [
+        (detuning, duration) for detuning in detuning_range for duration in time_range
+    ]
 
-    for detuning in tqdm(detuning_range):
-        with exp.ctx.util.no_output():
-            sweep_result = exp.measurement_service.sweep_parameter(
-                sequence=lambda t: {target: Rect(duration=t, amplitude=amplitude)},
-                sweep_range=time_range,
-                frequencies={target: frequency + detuning},
-                n_shots=n_shots,
-                shot_interval=shot_interval,
-                plot=False,
-            )
+    def sequence(point_index: int) -> dict[str, Rect]:
+        detuning, duration = sweep_points[int(point_index)]
+        pulse = Rect(duration=duration, amplitude=amplitude).detuned(detuning)
+        return {target: pulse}
 
-        data = sweep_result.data[target]
-        z = np.asarray(data.data, dtype=np.complex128)
-        raw_data_buffer.append(z)
+    with exp.ctx.util.no_output():
+        sweep_result = exp.measurement_service.sweep_parameter(
+            sequence=sequence,
+            sweep_range=np.arange(len(sweep_points)),
+            frequencies={target: frequency},
+            n_shots=n_shots,
+            shot_interval=shot_interval,
+            plot=False,
+        )
+
+    data = sweep_result.data[target]
+    z = np.asarray(data.data, dtype=np.complex128)
 
     # shape: (detuning, time)
-    raw_data = np.array(raw_data_buffer)
+    raw_data = z.reshape(detuning_range.size, time_range.size)
+    chevron_data = _project_chevron_raw_data(raw_data)
 
-    # Global PCA axis
-    z_all = raw_data.ravel()
-    z_centered = z_all - np.mean(z_all)
-    iq_all = np.column_stack(
-        [
-            z_centered.real,
-            z_centered.imag,
-        ]
-    )
-    try:
-        _, _, vh = np.linalg.svd(iq_all, full_matrices=False)
-        axis = vh[0]
-    except np.linalg.LinAlgError:
-        axis = np.array([1.0, 0.0])
-
-    # Project all data using SAME axis
-    mean_real = np.mean(z_all.real)
-    mean_imag = np.mean(z_all.imag)
-    projected_data = axis[0] * (raw_data.real - mean_real) + axis[1] * (
-        raw_data.imag - mean_imag
-    )
-    if np.mean(projected_data[:, 0]) < np.mean(projected_data):
-        projected_data *= -1
-
-    # shape: (time, detuning)
-    chevron_data = projected_data.T
-
-    # --- plot ---
-    fig = viz.make_figure()
-    fig.add_trace(
-        go.Heatmap(
-            x=frequency + detuning_range,
-            y=time_range,
-            z=chevron_data,
-            colorscale="Viridis",
-        )
-    )
-
-    fig.update_layout(
-        title=dict(
-            text=(
-                f"Chevron pattern : {target}<br><sup>amplitude={amplitude:.6g}</sup>"
-            ),
-            x=0.5,
-            xanchor="center",
-        ),
-        xaxis_title="Drive frequency (GHz)",
-        yaxis_title="Time (ns)",
-        width=600,
-        height=400,
+    fig = _make_chevron_figure(
+        target=target,
+        detuning_range=detuning_range,
+        time_range=time_range,
+        chevron_data=chevron_data,
+        frequency=frequency,
+        amplitude=amplitude,
+        title="Chevron pattern",
     )
 
     if plot:
@@ -802,6 +1071,7 @@ def measure_chevron_pattern(
             "detuning_range": detuning_range,
             "frequency": frequency,
             "amplitude": amplitude,
+            "raw_data": raw_data,
             "chevron_data": chevron_data,
         },
         figure=fig,
@@ -815,29 +1085,29 @@ def analyze_chevron_matched_transform(
     omega_q_range: ArrayLike,
     omega_rabi_range: ArrayLike,
     subtract_mean: bool = True,
-    refine_peak_quadratic: bool = False,
-    quadratic_window: int = 2,
+    refine_peak_quadratic: bool = True,
+    quadratic_window: int = 3,
+    background_radius: int = 32,
     plot: bool = True,
     save_image: bool = True,
 ) -> Result:
     """
     Apply a chevron matched transform and estimate the peak position.
 
-    This function applies
+    This function applies a weighted-integral matched transform to measured
+    chevron data, estimates the peak position, and optionally displays the
+    transform as a heatmap:
 
         F(omega_q', omega_rabi')
         = integral d omega_d d tau
           f(omega_d, tau)
           cos(2 pi sqrt(omega_rabi'^2 + (omega_d - omega_q')^2) tau)
 
-    to measured chevron data, estimates the peak position, and optionally
-    displays the transform as a heatmap.
-
     Parameters
     ----------
     result:
         Chevron measurement result returned by either
-        measure_chevron_pattern() or chevron_pattern().
+        measure_chevron_pattern() or an API with compatible payload keys.
     target:
         Target qubit label.
     omega_q_range:
@@ -848,12 +1118,18 @@ def analyze_chevron_matched_transform(
     subtract_mean:
         If True, subtract the mean over tau for each drive frequency.
         This usually makes the oscillatory part clearer.
+        Default: True.
     refine_peak_quadratic:
         If True, refine the peak position by fitting a local quadratic
         surface around the grid maximum.
+        Default: True.
     quadratic_window:
         Half-width of the local quadratic fitting window.
-        quadratic_window=2 uses a 5x5 patch.
+        Default: 3.
+        quadratic_window=3 uses a 7x7 patch.
+    background_radius:
+        Radius around the peak excluded from background RMS estimation.
+        Default: 32.
     plot:
         If True, show a heatmap with the estimated peak position.
     save_image :
@@ -868,9 +1144,10 @@ def analyze_chevron_matched_transform(
                 "omega_rabi": estimated resonant Rabi frequency in GHz,
                 "peak": peak estimation result returned by
                     _estimate_chevron_transform_peak(),
-                "peak_prominence_ratio":
+                "peak_background_rms_ratio":
                     confidence metric defined as the ratio between
-                    the main transform peak and the largest competing peak,
+                    the main transform peak and the background RMS,
+                "peak_background_rms": background RMS used in the ratio,
                 "omega_q_range": trial qubit frequency axis in GHz,
                 "omega_rabi_range": trial Rabi frequency axis in GHz,
                 "transform": matched-transform map,
@@ -951,12 +1228,6 @@ def analyze_chevron_matched_transform(
             axis=0,
         )
 
-    if np.any(np.isfinite(transform)):
-        max_abs_idx = np.nanargmax(np.abs(transform))
-        max_abs_value = transform.ravel()[max_abs_idx]
-        if max_abs_value < 0:
-            transform *= -1
-
     peak = _estimate_chevron_transform_peak(
         transform,
         omega_q_range,
@@ -969,26 +1240,10 @@ def analyze_chevron_matched_transform(
     omega_q_hat = peak["omega_q"]
     omega_rabi_hat = peak["omega_rabi"]
 
-    peak_idx = np.unravel_index(
-        np.nanargmax(transform),
-        transform.shape,
+    background_rms, peak_background_rms_ratio = _compute_peak_background_rms_ratio(
+        transform=transform,
+        background_radius=background_radius,
     )
-    ii, jj = peak_idx
-    peak_value = transform[ii, jj]
-    mask = np.ones(transform.shape, dtype=bool)
-    radius = 16
-    mask[
-        max(0, ii - radius) : min(transform.shape[0], ii + radius + 1),
-        max(0, jj - radius) : min(transform.shape[1], jj + radius + 1),
-    ] = False
-    background = transform[mask]
-    finite_background = background[np.isfinite(background)]
-    if finite_background.size > 0:
-        second_peak_value = np.nanmax(np.abs(finite_background))
-        peak_prominence_ratio = peak_value / max(second_peak_value, 1e-12)
-    else:
-        second_peak_value = np.nan
-        peak_prominence_ratio = np.nan
 
     fig = go.Figure()
     fig.add_trace(
@@ -1050,6 +1305,7 @@ def analyze_chevron_matched_transform(
                 f"<br><sup>"
                 f"ω_q={omega_q_hat:.9g} GHz, "
                 f"ω_Rabi={omega_rabi_hat:.9g} GHz, "
+                f"peak/background_rms={peak_background_rms_ratio:.3g}, "
                 f"refined={peak['refined']}"
                 f"</sup>"
             ),
@@ -1078,7 +1334,8 @@ def analyze_chevron_matched_transform(
             "omega_q": omega_q_hat,
             "omega_rabi": omega_rabi_hat,
             "peak": peak,
-            "peak_prominence_ratio": peak_prominence_ratio,
+            "peak_background_rms": background_rms,
+            "peak_background_rms_ratio": peak_background_rms_ratio,
             "omega_q_range": omega_q_range,
             "omega_rabi_range": omega_rabi_range,
             "transform": transform,
@@ -1087,14 +1344,47 @@ def analyze_chevron_matched_transform(
     )
 
 
+def _compute_peak_background_rms_ratio(
+    *,
+    transform: ArrayLike,
+    background_radius: int,
+) -> tuple[float, float]:
+    """Return background RMS and peak/background-RMS ratio for a transform map."""
+    z = np.asarray(transform, dtype=float)
+    if background_radius < 0:
+        raise ValueError("background_radius must be non-negative.")
+    if not np.any(np.isfinite(z)):
+        return np.nan, np.nan
+
+    peak_idx = np.unravel_index(np.nanargmax(z), z.shape)
+    ii, jj = peak_idx
+    peak_value = z[ii, jj]
+    radius = int(background_radius)
+
+    mask = np.ones(z.shape, dtype=bool)
+    mask[
+        max(0, ii - radius) : min(z.shape[0], ii + radius + 1),
+        max(0, jj - radius) : min(z.shape[1], jj + radius + 1),
+    ] = False
+
+    finite_background = z[mask]
+    finite_background = finite_background[np.isfinite(finite_background)]
+    if finite_background.size == 0:
+        return np.nan, np.nan
+
+    background_rms = float(np.sqrt(np.nanmean(finite_background**2)))
+    peak_background_rms_ratio = peak_value / max(background_rms, 1e-12)
+    return background_rms, peak_background_rms_ratio
+
+
 def _estimate_chevron_transform_peak(
     transform: ArrayLike,
     omega_q_range: ArrayLike,
     omega_rabi_range: ArrayLike,
     *,
     refine_quadratic: bool = False,
-    window: int = 2,
-    show_diagnostics: bool = False,
+    window: int = 3,
+    show_diagnostics: bool = True,
 ) -> dict:
     """
     Estimate (omega_q, omega_rabi) from a chevron matched-transform map.
@@ -1110,7 +1400,7 @@ def _estimate_chevron_transform_peak(
     refine_quadratic:
         If True, refine the maximum by fitting a local quadratic surface.
     window:
-        Half-width of the fitting window. window=2 uses a 5x5 patch.
+        Half-width of the fitting window. window=3 uses a 7x7 patch.
     show_diagnostics:
         If True, show diagnostics.
 


### PR DESCRIPTION
## Summary

This PR improves the adaptive chevron matched-transform workflow.

- Introduces nonlinear duration sampling in the search stage so a wider `omega_rabi` range can be searched with fewer measurement points.
- Extends the search detuning range and repeats the search analysis when the initial transform does not show a sufficiently clear peak.
- Changes chevron measurement to batch all `(omega_d, tau)` sweep points into a single `exp.measurement_service.sweep_parameter()` call, instead of calling it separately for each detuning.
- Adds `target_amplitudes` to the result data from `estimate_qubit_frequency_from_chevron_adaptive()`, computed as `used_amplitude * target_omega_rabi / measured_omega_rabi`.