### PR TITLE
fix(quel3): support quelware-client 0.2 result containers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,7 @@ dependencies = [
 [project.optional-dependencies]
 backend = ["qxdriver-quel1 == 1.5.0b4"]
 quel1 = ["qxdriver-quel1 == 1.5.0b4"]
-quel3 = ["quelware-client >= 0.1.4.post1"]
+quel3 = ["quelware-client >= 0.2.0"]
 
 [project.scripts]
 qubex = "qubex.cli:main"
@@ -117,11 +117,7 @@ exclude = [
 typeCheckingMode = "basic"
 
 [tool.ruff]
-extend-exclude = [
-    "lib",
-    "packages/qube-calib",
-    "packages/qxdriver-quel1",
-]
+extend-exclude = ["lib", "packages/qube-calib", "packages/qxdriver-quel1"]
 
 [tool.ruff.lint]
 select = [

--- a/src/qubex/backend/quel3/interfaces/driver.py
+++ b/src/qubex/backend/quel3/interfaces/driver.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Mapping, Sequence
-from typing import Protocol, TypeAlias
+from typing import Protocol
 
 import numpy.typing as npt
 
@@ -23,15 +23,17 @@ class IqWaveformResultProtocol(Protocol):
         ...
 
 
-CaptureResultValues: TypeAlias = Sequence[complex] | Sequence[IqWaveformResultProtocol]
-
-
 class ResultContainerProtocol(Protocol):
     """Minimal fixed-timeline result container protocol."""
 
     @property
-    def iq_result(self) -> Mapping[str, CaptureResultValues]:
-        """Return capture-window IQ results keyed by window name."""
+    def iq_waveform_result(self) -> Mapping[str, Sequence[IqWaveformResultProtocol]]:
+        """Return waveform capture-window IQ results keyed by window name."""
+        ...
+
+    @property
+    def iq_point_result(self) -> Mapping[str, Sequence[complex]]:
+        """Return point capture-window IQ results keyed by window name."""
         ...
 
 

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -982,11 +982,13 @@ class Quel3ExecutionManager:
         capture_mode: Quel3CaptureMode,
     ) -> np.ndarray | None:
         """Extract one capture sample-array from a result container entry."""
-        values = result.iq_result.get(window_key)
-        if values is None or len(values) == 0:
-            return None
-        first = values[0]
-        if _has_iq_array(first):
+        if capture_mode in (
+            Quel3CaptureMode.AVERAGED_WAVEFORM,
+            Quel3CaptureMode.RAW_WAVEFORMS,
+        ):
+            values = result.iq_waveform_result.get(window_key)
+            if values is None or len(values) == 0:
+                return None
             if capture_mode is Quel3CaptureMode.RAW_WAVEFORMS:
                 waveforms = []
                 for value in values:
@@ -998,7 +1000,17 @@ class Quel3ExecutionManager:
             if not _has_iq_array(latest):
                 return None
             return np.asarray(latest.iq_array, dtype=np.complex128)
-        return np.asarray(values, dtype=np.complex128)
+
+        if capture_mode in (
+            Quel3CaptureMode.AVERAGED_VALUE,
+            Quel3CaptureMode.VALUES_PER_ITER,
+        ):
+            values = result.iq_point_result.get(window_key)
+            if values is None or len(values) == 0:
+                return None
+            return np.asarray(values, dtype=np.complex128)
+
+        raise ValueError(f"Unsupported capture mode: {capture_mode}.")
 
     @staticmethod
     def _build_measurement_result(

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -235,7 +235,7 @@ def test_build_measurement_result_keeps_backend_alias_labels() -> None:
 
 
 def test_extract_capture_samples_from_waveform_result_container() -> None:
-    """Given waveform-style iq_result, extraction returns latest waveform samples."""
+    """Given waveform result container, extraction returns latest waveform samples."""
 
     class _Waveform:
         def __init__(self, values: np.ndarray) -> None:
@@ -243,12 +243,13 @@ def test_extract_capture_samples_from_waveform_result_container() -> None:
 
     class _Result:
         def __init__(self) -> None:
-            self.iq_result = {
+            self.iq_waveform_result = {
                 "RQ00:0": [
                     _Waveform(np.array([1.0 + 0.0j], dtype=np.complex128)),
                     _Waveform(np.array([2.0 + 0.0j], dtype=np.complex128)),
                 ]
             }
+            self.iq_point_result = {}
 
     values = Quel3ExecutionManager._extract_capture_samples(
         _Result(),
@@ -261,7 +262,7 @@ def test_extract_capture_samples_from_waveform_result_container() -> None:
 
 
 def test_extract_capture_samples_from_raw_waveform_result_container() -> None:
-    """Given raw waveform iq_result, extraction returns one waveform per shot."""
+    """Given raw waveform result container, extraction returns one waveform per shot."""
 
     class _Waveform:
         def __init__(self, values: np.ndarray) -> None:
@@ -269,12 +270,13 @@ def test_extract_capture_samples_from_raw_waveform_result_container() -> None:
 
     class _Result:
         def __init__(self) -> None:
-            self.iq_result = {
+            self.iq_waveform_result = {
                 "RQ00:0": [
                     _Waveform(np.array([1.0 + 0.0j, 2.0 + 0.0j])),
                     _Waveform(np.array([3.0 + 0.0j, 4.0 + 0.0j])),
                 ]
             }
+            self.iq_point_result = {}
 
     values = Quel3ExecutionManager._extract_capture_samples(
         _Result(),
@@ -296,11 +298,12 @@ def test_extract_capture_samples_from_raw_waveform_result_container() -> None:
 
 
 def test_extract_capture_samples_from_point_result_container() -> None:
-    """Given point-style iq_result, extraction returns complex-point array."""
+    """Given point result container, extraction returns complex-point array."""
 
     class _Result:
         def __init__(self) -> None:
-            self.iq_result = {
+            self.iq_waveform_result = {}
+            self.iq_point_result = {
                 "RQ00:0": [1.0 + 2.0j, 3.0 + 4.0j],
             }
 
@@ -841,11 +844,8 @@ class _FakeWaveformResult:
 
 class _FakeResultContainer:
     def __init__(self) -> None:
-        self.iq_result = {
-            "alias-rq00:0": [
-                _FakeWaveformResult(np.array([1.0 + 0.0j], dtype=np.complex128))
-            ]
-        }
+        self.iq_waveform_result = {}
+        self.iq_point_result = {"alias-rq00:0": [1.0 + 0.0j]}
 
 
 class _FakeInstrumentDriver:
@@ -931,9 +931,8 @@ class _PhaseBarrier:
 
 class _ParallelResultContainer:
     def __init__(self, alias: str, value: complex) -> None:
-        self.iq_result = {
-            f"{alias}:0": [_FakeWaveformResult(np.array([value], dtype=np.complex128))]
-        }
+        self.iq_waveform_result = {}
+        self.iq_point_result = {f"{alias}:0": [value]}
 
 
 class _ParallelInstrumentDriver:

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -24,7 +24,7 @@ def test_project_optional_dependencies_split_backend_quel1_quel3() -> None:
         re.MULTILINE,
     )
     assert re.search(
-        r'^quel3\s*=\s*\["quelware-client >= 0\.1\.4\.post1"\]',
+        r'^quel3\s*=\s*\["quelware-client >= 0\.2\.0"\]',
         text,
         re.MULTILINE,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -3483,7 +3483,7 @@ requires-dist = [
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qctrl-visualizer", specifier = ">=8.0" },
-    { name = "quelware-client", marker = "extra == 'quel3'", specifier = ">=0.1.4.post1" },
+    { name = "quelware-client", marker = "extra == 'quel3'", specifier = ">=0.2.0" },
     { name = "qxcore", editable = "packages/qxcore" },
     { name = "qxdriver-quel1", marker = "extra == 'backend'", editable = "packages/qxdriver-quel1" },
     { name = "qxdriver-quel1", marker = "extra == 'quel1'", editable = "packages/qxdriver-quel1" },
@@ -3550,7 +3550,7 @@ wheels = [
 
 [[package]]
 name = "quelware-client"
-version = "0.1.4.post1"
+version = "0.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "betterproto2" },
@@ -3559,14 +3559,14 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/6a/58/7b2fd171588b8778f679e83c4a2ca9f1a33f0a512684eb54b6144698ddd3/quelware_client-0.1.4.post1.tar.gz", hash = "sha256:30704906d8b71975695cdb32c7b6b21cedbecff5a57153d29af14ef9a7ff647d", size = 59189, upload-time = "2026-05-18T01:55:19.911Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/9b/bb/0232743965856f544f14421b2984cf32f87c5216e5941637622529032a64/quelware_client-0.2.0.tar.gz", hash = "sha256:bea752ed2d188bb6fc4373c034f35b3f582cddcd0829a1d5ce10e2e477bdc4de", size = 105908, upload-time = "2026-05-28T04:50:11.598Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/32/d6bbd2fc59e41861a5c64b8147bae383762fc59b11a9b58394f43cecf1d1/quelware_client-0.1.4.post1-py3-none-any.whl", hash = "sha256:75009748fd06bbef5512dba582d8127008197f0ff86bc9f63b82cdc27d45292b", size = 34079, upload-time = "2026-05-18T01:55:17.759Z" },
+    { url = "https://files.pythonhosted.org/packages/0a/32/0356be3bf95db56ce72a3cad1cb55f8c588b48dc20741327d77dd85523e7/quelware_client-0.2.0-py3-none-any.whl", hash = "sha256:c94fbd2b3b5fe5d09770e68427ba94d2770bfa2afa3bb5ba9bdbeaae9b15a592", size = 38521, upload-time = "2026-05-28T04:50:10.171Z" },
 ]
 
 [[package]]
 name = "quelware-core"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "betterproto2" },
@@ -3576,9 +3576,9 @@ dependencies = [
     { name = "numpy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/f4/3c/ac047fe0fd1216cdb4c9f6cdbfb24835d1e568e94593d45bf691be732b46/quelware_core-0.1.3.tar.gz", hash = "sha256:d322548a30fb426fb791cb239fd4ebc63e880186ffc8d9a2aad15b7890dca952", size = 51015, upload-time = "2026-05-15T06:53:44.66Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/7da83b41ccab7c109ba34b5ef309816bf5a9e387f1251503ecc6ae2f839b/quelware_core-0.1.4.tar.gz", hash = "sha256:4ecdbc5839b940610ba02a1937327107615a300a929c6a695cd0ae5fc82c2d74", size = 54579, upload-time = "2026-05-28T04:49:47.266Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5d/79/4780cdedc1cc98b434d536072ebfc57034ab04b372e34b35720119fa05ec/quelware_core-0.1.3-py3-none-any.whl", hash = "sha256:e05b2bcd10844d993cc19908bf8fcfe525448c5204becc1d91733c3f1914f6f8", size = 35377, upload-time = "2026-05-15T06:53:42.947Z" },
+    { url = "https://files.pythonhosted.org/packages/45/0e/0abac65a3fff8afe81c4f635d17985ef5d13f3d8155c0a42ffb177ecbead/quelware_core-0.1.4-py3-none-any.whl", hash = "sha256:f9189b33d6f6941b9d4ff0407e416628e35df44c974320d37075523b9485d2d5", size = 41188, upload-time = "2026-05-28T04:49:45.771Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Background

quelware-client 0.2 separates capture results into waveform and point result mappings. Qubex's QuEL-3 execution path still read both result types from the old combined `iq_result` mapping, so capture extraction needed to follow the new runtime API.

## Summary

- Require `quelware-client >= 0.2.0` for the `quel3` optional dependency and refresh the lockfile.
- Update QuEL-3 result protocols for separate `iq_waveform_result` and `iq_point_result` mappings.
- Route waveform capture modes through `iq_waveform_result` and point capture modes through `iq_point_result`.
- Update QuEL-3 backend and optional dependency tests for the 0.2 API.

## Impact

This keeps QuEL-3 execution compatible with quelware-client 0.2 result containers. Existing Qubex capture mode semantics are preserved: raw waveform captures still stack per-shot waveforms, averaged waveform captures use the latest waveform result, and point captures return complex point arrays.

## Compatibility

The `quel3` extra now requires `quelware-client >= 0.2.0`; older quelware-client 0.1 result containers are no longer supported by this branch.

## Verification

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`