### PR TITLE
Fix i18n notebook output paths

### DIFF
--- a/scripts/mkdocs_hooks.py
+++ b/scripts/mkdocs_hooks.py
@@ -55,7 +55,13 @@ def _on_files_restore_notebooks(files: Files, config: MkDocsConfig) -> Files:
     ]
     for file in files_to_wrap:
         files.remove(file)
-        files.append(NotebookFile(file, **config))
+        notebook_file = NotebookFile(file, **config)
+        current_language = getattr(config.plugins.get("i18n"), "current_language", None)
+        output_file = getattr(file, "alternates", {}).get(current_language, file)
+        notebook_file.dest_path = output_file.dest_path
+        notebook_file.abs_dest_path = output_file.abs_dest_path
+        notebook_file.url = output_file.url
+        files.append(notebook_file)
     return files
 
 


### PR DESCRIPTION
## Summary

Fixes #253.

Preserve `mkdocs-static-i18n` output paths when notebook files are re-wrapped as `NotebookFile` in the MkDocs hook.

## Cause

The docs build generates English pages first, then Japanese pages. Notebook pages often do not have separate Japanese notebook sources, so `mkdocs-static-i18n` falls back to the English notebook source and builds it as part of the Japanese docs.

The bug was in `scripts/mkdocs_hooks.py`: when those fallback notebook pages were re-wrapped for `mkdocs-jupyter`, the i18n-selected `ja/` output path was lost. As a result, the Japanese build wrote fallback notebook pages to the English output path and overwrote the already-generated English pages.

## Fix

After creating the `NotebookFile`, copy the current i18n alternate's output fields back onto it:

- `dest_path`
- `abs_dest_path`
- `url`

## Verification

- `uv run mkdocs build`
- Confirmed both English and Japanese generated notebook pages exist
- Confirmed English page has `<html lang="en">`
- Confirmed Japanese page has `<html lang="ja">`
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`