### PR TITLE
docs: add params configuration guide

### DIFF
--- a/docs/user-guide/getting-started/params-configuration.ja.md
+++ b/docs/user-guide/getting-started/params-configuration.ja.md
@@ -1,0 +1,296 @@
+# パラメータファイル
+
+`params/<system_id>/` ディレクトリには、1 つの実行可能な system に固有の
+パラメータを置きます。`chip.yaml`、`system.yaml`、`wiring.yaml`、
+`skew.yaml` などの共有設定ファイルとは分けて管理します。
+
+Qubex は `Experiment` または `ConfigLoader` が system を load するときに
+parameter file を読み込みます。その後で YAML を編集した場合は、新しい
+`Experiment` を作るか、`ConfigLoader.load()` を再実行してください。
+
+## ディレクトリ構成
+
+```text
+qubex-config/
+  config/
+    chip.yaml
+    box.yaml
+    system.yaml
+    wiring.yaml
+    skew.yaml
+  params/
+    SYSTEM_A/
+      qubit_frequency.yaml
+      control_frequency.yaml
+      readout_frequency.yaml
+      control_amplitude.yaml
+      readout_amplitude.yaml
+      measurement_defaults.yaml
+      capture_delay.yaml
+      ...
+```
+
+選択した system のディレクトリを `params_dir` として渡してください。
+
+```python
+import qubex as qx
+
+exp = qx.Experiment(
+    system_id="SYSTEM_A",
+    qubits=[0, 1],
+    config_dir="/path/to/qubex-config/config",
+    params_dir="/path/to/qubex-config/params/SYSTEM_A",
+)
+```
+
+`params/<system_id>/` の下に Qubex が認識しないファイルを置いても、ユーザー
+コードが明示的に開かない限り Qubex はそれを読みません。
+
+## 構造化パラメータ形式
+
+ほとんどの parameter file は `meta` / `data` 形式を使います。
+
+```yaml
+meta:
+  description: Example GE control frequencies
+  unit: GHz
+  default: null
+data:
+  0: 4.912
+  1: 4.846
+  2: null
+```
+
+- `meta` は注釈と loader option のための領域です。
+- `data` には Qubex が読み込む実データを書きます。
+- `meta.unit` を指定すると、top-level の数値が Qubex の内部単位へ変換されます。
+- `meta.default` を指定すると、`data` 中の `null` と YAML NaN が unit 変換前に
+  その値へ置き換えられます。
+
+認識される unit 変換は次の通りです。
+
+| 種類 | 受け付ける unit | 内部単位 |
+| --- | --- | --- |
+| 周波数 | `Hz`, `kHz`, `MHz`, `GHz` | `GHz` |
+| 時間 | `s`, `ms`, `us`, `ns` | `ns` |
+
+未認識の unit は scale `1.0` として扱われます。ただし `capture_delay` 系の
+ファイルは backend ごとの unit validation を受けます。`meta.unit` による変換は
+top-level の数値だけに適用されるため、`jpa_params.yaml` のような nested map は
+下で説明する内部単位で直接書いてください。
+
+### キー
+
+qubit 単位のファイルでは、整数 index、数字文字列、または具体的な qubit label を
+キーにできます。
+
+```yaml
+data:
+  0: 4.912      # chip の qubit label に正規化される
+  "1": 4.846    # これも正規化される
+  Q002: 4.901   # 文字列 label はそのまま使われる
+```
+
+数字キーの場合、Qubex は `chip.yaml:n_qubits` から label 幅を決めます。
+例えば 64 qubit chip は `Q00` のような label、144 qubit chip は `Q000` のような
+label を使います。文字列 label はそのまま受け付けられるため、選択した chip の
+label と一致している必要があります。
+
+mux 単位のファイルでは mux index を使います。pair 単位のファイルでは、
+`Q000-Q001` のように、その値を読む workflow が期待する pair label を使います。
+
+## 読み込み優先度
+
+現在の推奨形式は、parameter family ごとに 1 つの YAML ファイルを置く形式です。
+旧形式の `params.yaml` と `props.yaml` も互換入力として引き続きサポートされます。
+
+認識される各 parameter について、読み込み順は次の通りです。
+
+1. `<parameter>.yaml` が存在し、`data` が空でなければ、それを読み込みます。
+2. per-file YAML に無いキーだけ、`params.yaml` または `props.yaml` の legacy entry
+   で補います。
+3. per-file YAML が存在しても `data` が空の場合、その parameter については legacy
+   map へフォールバックします。
+4. per-file YAML が存在しない場合、legacy map だけを使います。
+
+この merge は浅い key 単位の merge です。同じキーがある場合、per-file YAML が
+legacy entry より優先されます。
+
+## 周波数の優先度
+
+物理的に関連していても、同じ意味ではない file があります。Qubex は target を作る
+とき、次の優先度を使います。
+
+| 実行時に使われる値 | 優先 source | fallback source | 主な用途 |
+| --- | --- | --- | --- |
+| Qubit GE 周波数 | `control_frequency.yaml` | `qubit_frequency.yaml` | GE target と、target qubit がある CR target |
+| Qubit bare 周波数 | `qubit_frequency.yaml` | なし | `Qubit.bare_frequency` と GE fallback |
+| Qubit EF 周波数 | `control_frequency_ef.yaml` | 有効な GE 周波数 + anharmonicity | EF target |
+| Resonator readout 周波数 | `readout_frequency.yaml` | `resonator_frequency.yaml` | readout generator target と capture target |
+| Resonator ground-state 周波数 | `resonator_frequency.yaml` | なし | `Resonator.frequency_g` と readout fallback |
+
+したがって、同じ qubit に対して `control_frequency.yaml` に有限値がある間は、
+`qubit_frequency.yaml` を編集しても GE target 周波数は変わりません。同様に、
+同じ resonator に対して `readout_frequency.yaml` に有限値がある間は、
+`resonator_frequency.yaml` を編集しても readout target 周波数は変わりません。
+
+## 認識されるファイル
+
+以下は `ConfigLoader` が認識する parameter file です。
+
+### 量子系と周波数パラメータ
+
+| ファイル | scope | unit | 効果 | legacy source |
+| --- | --- | --- | --- | --- |
+| `qubit_frequency.yaml` | qubit | 周波数、通常 `GHz` | bare qubit 周波数と GE fallback。 | `props.yaml:<chip_id>.qubit_frequency` |
+| `qubit_anharmonicity.yaml` | qubit | 周波数、通常 `GHz` | qubit anharmonicity。無い場合、model は有効な GE 周波数から fallback 値を導出します。 | `props.yaml:<chip_id>.anharmonicity` |
+| `control_frequency.yaml` | qubit | 周波数、通常 `GHz` | 優先される GE control 周波数。GE target と target qubit がある CR target に使われます。 | `props.yaml:<chip_id>.control_frequency` |
+| `control_frequency_ef.yaml` | qubit | 周波数、通常 `GHz` | 優先される EF control 周波数。無い場合、GE 周波数 + anharmonicity を使います。 | `props.yaml:<chip_id>.control_frequency_ef` |
+| `resonator_frequency.yaml` | qubit または qubit-keyed resonator | 周波数、通常 `GHz` | resonator ground-state 周波数と readout fallback。キーは qubit label または index です。 | `props.yaml:<chip_id>.resonator_frequency` |
+| `readout_frequency.yaml` | qubit または qubit-keyed resonator | 周波数、通常 `GHz` | 優先される readout drive / capture 周波数。キーは qubit label または index です。 | `props.yaml:<chip_id>.readout_frequency` |
+
+例:
+
+```yaml
+meta:
+  description: Tuned GE control frequencies
+  unit: GHz
+data:
+  0: 4.9123
+  1: 4.8461
+```
+
+### 制御・ハードウェアパラメータ
+
+| ファイル | scope | unit | 効果 | legacy source |
+| --- | --- | --- | --- | --- |
+| `frequency_margin.yaml` | target type | 周波数、通常 `GHz` | target deployment 時の周波数 margin を target type ごとに上書きします。key は `READ`, `CTRL_GE`, `CTRL_EF`, `CTRL_CR`, `PUMP` です。 | `params.yaml:<chip_id>.frequency_margin` |
+| `control_amplitude.yaml` | qubit | 無次元 | 既定の control pulse amplitude。 | `params.yaml:<chip_id>.control_amplitude` |
+| `readout_amplitude.yaml` | qubit | 無次元 | 既定の readout pulse amplitude。 | `params.yaml:<chip_id>.readout_amplitude` |
+| `control_vatt.yaml` | qubit | 整数または `null` | 対応 backend の control-line VATT 設定。 | `params.yaml:<chip_id>.control_vatt` |
+| `readout_vatt.yaml` | mux | 整数または `null` | 対応 backend の readout-line VATT 設定。 | `params.yaml:<chip_id>.readout_vatt` |
+| `pump_vatt.yaml` | mux | 整数または `null` | 対応 backend の pump-line VATT 設定。 | `params.yaml:<chip_id>.pump_vatt` |
+| `control_fsc.yaml` | qubit | 整数または `null` | 対応 backend の control-line full-scale current 設定。 | `params.yaml:<chip_id>.control_fsc` |
+| `readout_fsc.yaml` | mux | 整数または `null` | 対応 backend の readout-line full-scale current 設定。 | `params.yaml:<chip_id>.readout_fsc` |
+| `pump_fsc.yaml` | mux | 整数または `null` | 対応 backend の pump-line full-scale current 設定。 | `params.yaml:<chip_id>.pump_fsc` |
+| `capture_delay.yaml` | mux | backend 依存 | capture timing offset。QuEL-1 では `meta.unit: ndelay`、QuEL-3 では `meta.unit: ns` が必須です。 | `params.yaml:<chip_id>.capture_delay` |
+| `capture_delay_word.yaml` | mux | `word` または `words` | QuEL-1 の capture-delay word offset。QuEL-3 ではサポートされません。 | `params.yaml:<chip_id>.capture_delay_word` |
+| `jpa_params.yaml` | mux | 内部単位 | JPA parameter。各 mux entry は `pump_frequency` (`GHz`), `pump_amplitude`, `dc_voltage` を持てます。無い field は backend default で補われます。 | `params.yaml:<chip_id>.jpa_params` |
+
+QuEL-1 では VATT、FSC、capture delay、JPA fields に対して QuEL-1 default が
+materialize されます。QuEL-3 では未対応の VATT/FSC/capture-delay-word は `null`
+として materialize され、frequency margin と JPA fields には QuEL-3 default が
+使われます。
+
+例:
+
+```yaml
+# QuEL-3 用 capture_delay.yaml
+meta:
+  description: Capture timing offsets
+  unit: ns
+data:
+  0: 8.0
+  1: 8.0
+```
+
+```yaml
+# QuEL-1 用 capture_delay.yaml
+meta:
+  description: Capture timing offsets
+  unit: ndelay
+data:
+  0: 7
+  1: 8
+```
+
+```yaml
+# jpa_params.yaml
+meta:
+  description: JPA pump and bias settings
+data:
+  0:
+    pump_frequency: 6.000
+    pump_amplitude: 0.10
+    dc_voltage: 0.00
+```
+
+### Measurement defaults
+
+`measurement_defaults.yaml` は `meta` / `data` 形式ではありません。system ごとの
+measurement 実行条件と readout timing に対する partial default file です。
+
+```yaml
+schema_version: 1
+
+execution:
+  n_shots: 2048
+  shot_interval_ns: 200000.0
+
+readout:
+  duration_ns: 512.0
+  ramp_time_ns: 24.0
+  pre_margin_ns: 16.0
+  post_margin_ns: 96.0
+```
+
+| field | 意味 |
+| --- | --- |
+| `schema_version` | 指定する場合は `1` である必要があります。 |
+| `execution.n_shots` | configured default を使う measurement API で明示引数が無い場合の shot 数。正の値が必要です。 |
+| `execution.shot_interval_ns` | configured default を使う measurement API で明示引数が無い場合の shot interval (`ns`)。正の値が必要です。 |
+| `readout.duration_ns` | 既定の readout duration (`ns`)。非負値が必要です。 |
+| `readout.ramp_time_ns` | 既定の readout ramp time (`ns`)。非負値が必要です。 |
+| `readout.pre_margin_ns` | 既定の pre-readout margin (`ns`)。非負値が必要です。 |
+| `readout.post_margin_ns` | 既定の post-readout margin (`ns`)。非負値が必要です。 |
+
+API に明示的に渡した引数は `measurement_defaults.yaml` より優先されます。一部の
+legacy または特殊な measurement path では、lower-level の measurement config に
+届く前に関数内の local default が設定される場合があります。default が反映されない
+場合は、その関数の signature と呼び出し経路を確認してください。
+
+### Characterization / diagnostic properties
+
+次のファイルは `ConfigLoader.load_param_data(...)` で認識されます。base system
+loader はこれらを target frequency や hardware setting には変換しませんが、
+characterization や workflow code が system property として使えます。
+
+| ファイル | scope | unit | 意味 | legacy source |
+| --- | --- | --- | --- | --- |
+| `t1.yaml` | qubit | 時間、通常 `ns` または `us` | T1 推定値。 | `props.yaml:<chip_id>.t1` |
+| `t2_echo.yaml` | qubit | 時間、通常 `ns` または `us` | Echo T2 推定値。 | `props.yaml:<chip_id>.t2_echo` |
+| `t2_star.yaml` | qubit | 時間、通常 `ns` または `us` | Ramsey T2* 推定値。 | `props.yaml:<chip_id>.t2_star` |
+| `t2_star_ef.yaml` | qubit | 時間、通常 `ns` または `us` | EF Ramsey T2* 推定値。 | `props.yaml:<chip_id>.t2_star_ef` |
+| `average_readout_fidelity.yaml` | qubit | 無次元 | average readout fidelity 推定値。 | `props.yaml:<chip_id>.average_readout_fidelity` |
+| `quantum_efficiency.yaml` | qubit | 無次元 | quantum efficiency 推定値。 | `props.yaml:<chip_id>.quantum_efficiency` |
+| `x90_gate_fidelity.yaml` | qubit | 無次元 | X90 gate fidelity 推定値。 | `props.yaml:<chip_id>.x90_gate_fidelity` |
+| `x180_gate_fidelity.yaml` | qubit | 無次元 | X180 gate fidelity 推定値。 | `props.yaml:<chip_id>.x180_gate_fidelity` |
+| `zx90_gate_fidelity.yaml` | pair | 無次元 | ZX90 gate fidelity 推定値。 | `props.yaml:<chip_id>.zx90_gate_fidelity` |
+| `static_zz_interaction.yaml` | pair | 周波数、通常 `GHz` または `MHz` | static ZZ interaction 推定値。 | `props.yaml:<chip_id>.static_zz_interaction` |
+| `qubit_qubit_coupling_strength.yaml` | pair | 周波数、通常 `GHz` または `MHz` | qubit-qubit coupling 推定値。 | `props.yaml:<chip_id>.qubit_qubit_coupling_strength` |
+| `resonator_external_linewidth.yaml` | qubit または qubit-keyed resonator | 周波数、通常 `GHz` または `MHz` | resonator external linewidth 推定値。 | `props.yaml:<chip_id>.external_loss_rate` |
+| `resonator_internal_linewidth.yaml` | qubit または qubit-keyed resonator | 周波数、通常 `GHz` または `MHz` | resonator internal linewidth 推定値。 | `props.yaml:<chip_id>.internal_loss_rate` |
+
+## `params/` ではないファイル
+
+共有 system file は `params/<system_id>/` には置かないでください。
+
+- `skew.yaml` は共有 `config/` ディレクトリのファイルです。QuEL-1 / QuBE の
+  box 間 timing を制御し、waveform timing に影響し得ますが、parameter family
+  file ではありません。
+- `calibration/<system_id>/calib_note.json` は既定の calibration note 保存先です。
+  このページで説明している parameter file とは別です。
+
+## よくある落とし穴
+
+- `params.yaml` や `props.yaml` が per-file YAML を上書きすると期待すること。
+  同じキーでは per-file YAML が優先されます。
+- `control_frequency.yaml` が同じ qubit を定義している状態で
+  `qubit_frequency.yaml` だけを編集すること。GE と CR target は
+  `control_frequency.yaml` を先に使います。
+- `readout_frequency.yaml` が同じ resonator を定義している状態で
+  `resonator_frequency.yaml` だけを編集すること。readout target は
+  `readout_frequency.yaml` を先に使います。
+- `capture_delay.yaml` の `meta.unit` を省略したり、QuEL-3 system に QuEL-1 用の
+  unit を使ったりすること。
+- `Experiment` を作った後に YAML を編集し、既存 object が自動更新されると期待すること。

--- a/docs/user-guide/getting-started/params-configuration.md
+++ b/docs/user-guide/getting-started/params-configuration.md
@@ -1,0 +1,299 @@
+# Parameter files
+
+Use the `params/<system_id>/` directory for parameters that belong to one
+concrete runnable system. These files are separate from the shared config files
+under `config/`, such as `chip.yaml`, `system.yaml`, `wiring.yaml`, and
+`skew.yaml`.
+
+Qubex loads parameter files when `Experiment` or `ConfigLoader` loads the
+system. If you edit a YAML file after that, create a new `Experiment` or call
+`ConfigLoader.load()` again before expecting the change to affect runtime
+objects.
+
+## Directory layout
+
+```text
+qubex-config/
+  config/
+    chip.yaml
+    box.yaml
+    system.yaml
+    wiring.yaml
+    skew.yaml
+  params/
+    SYSTEM_A/
+      qubit_frequency.yaml
+      control_frequency.yaml
+      readout_frequency.yaml
+      control_amplitude.yaml
+      readout_amplitude.yaml
+      measurement_defaults.yaml
+      capture_delay.yaml
+      ...
+```
+
+Pass the selected system directory as `params_dir`.
+
+```python
+import qubex as qx
+
+exp = qx.Experiment(
+    system_id="SYSTEM_A",
+    qubits=[0, 1],
+    config_dir="/path/to/qubex-config/config",
+    params_dir="/path/to/qubex-config/params/SYSTEM_A",
+)
+```
+
+Unknown files under `params/<system_id>/` are ignored unless user code opens
+them directly.
+
+## Structured parameter format
+
+Most parameter files use the structured `meta` / `data` format.
+
+```yaml
+meta:
+  description: Example GE control frequencies
+  unit: GHz
+  default: null
+data:
+  0: 4.912
+  1: 4.846
+  2: null
+```
+
+- `meta` is for annotations and loader options.
+- `data` contains the values that Qubex loads.
+- `meta.unit` converts top-level numeric values into Qubex internal units.
+- `meta.default` replaces `null` and YAML NaN values in `data` before unit
+  conversion.
+
+The recognized unit conversion families are:
+
+| Unit family | Accepted units | Internal unit |
+| --- | --- | --- |
+| Frequency | `Hz`, `kHz`, `MHz`, `GHz` | `GHz` |
+| Time | `s`, `ms`, `us`, `ns` | `ns` |
+
+Unrecognized units are kept with scale `1.0`, except for backend-specific
+`capture_delay` validation. `meta.unit` conversion applies only to top-level
+numeric values, so nested maps such as `jpa_params.yaml` should already use the
+internal units documented below.
+
+### Keys
+
+Qubit-scoped files accept integer indices, numeric strings, or concrete qubit
+labels.
+
+```yaml
+data:
+  0: 4.912      # normalized to the chip's qubit label
+  "1": 4.846    # also normalized
+  Q002: 4.901   # accepted as-is
+```
+
+For numeric keys, Qubex derives the label width from `chip.yaml:n_qubits`. For
+example, a 64-qubit chip uses labels like `Q00`, while a 144-qubit chip uses
+labels like `Q000`. String labels are accepted as-is, so they must already match
+the labels for the selected chip.
+
+Mux-scoped files use mux indices. Pair-scoped files use the pair labels expected
+by the consuming workflow, such as `Q000-Q001`.
+
+## Source priority
+
+The current preferred format is one YAML file per parameter family. Legacy
+`params.yaml` and `props.yaml` are still supported as compatibility inputs.
+
+For each recognized parameter:
+
+1. If `<parameter>.yaml` exists and its `data` section is non-empty, Qubex
+   loads it.
+2. Legacy entries from `params.yaml` or `props.yaml` are used only for keys that
+   are missing from the per-file YAML.
+3. If the per-file YAML exists but has empty `data`, Qubex falls back to the
+   legacy map for that parameter.
+4. If the per-file YAML is absent, Qubex uses only the legacy map.
+
+This merge is shallow and key-based. Per-file entries win over legacy entries
+for the same key.
+
+## Frequency priority
+
+Some files describe related physical quantities but are not equivalent. Qubex
+uses the following runtime priority when building targets.
+
+| Runtime value | Primary source | Fallback source | Used by |
+| --- | --- | --- | --- |
+| Qubit GE frequency | `control_frequency.yaml` | `qubit_frequency.yaml` | GE targets and CR targets with a target qubit |
+| Qubit bare frequency | `qubit_frequency.yaml` | none | `Qubit.bare_frequency` and GE fallback |
+| Qubit EF frequency | `control_frequency_ef.yaml` | effective GE frequency + anharmonicity | EF targets |
+| Resonator readout frequency | `readout_frequency.yaml` | `resonator_frequency.yaml` | readout generator and capture targets |
+| Resonator ground-state frequency | `resonator_frequency.yaml` | none | `Resonator.frequency_g` and readout fallback |
+
+This means that editing `qubit_frequency.yaml` does not change the GE target
+frequency while `control_frequency.yaml` contains a finite value for the same
+qubit. Likewise, editing `resonator_frequency.yaml` does not change readout
+targets while `readout_frequency.yaml` contains a finite value for the same
+resonator.
+
+## Recognized files
+
+These are the parameter files recognized by `ConfigLoader`.
+
+### Quantum and frequency parameters
+
+| File | Scope | Unit | Effect | Legacy source |
+| --- | --- | --- | --- | --- |
+| `qubit_frequency.yaml` | qubit | frequency, usually `GHz` | Bare qubit frequency and fallback GE frequency. | `props.yaml:<chip_id>.qubit_frequency` |
+| `qubit_anharmonicity.yaml` | qubit | frequency, usually `GHz` | Qubit anharmonicity. If absent, the model derives a fallback from the effective GE frequency. | `props.yaml:<chip_id>.anharmonicity` |
+| `control_frequency.yaml` | qubit | frequency, usually `GHz` | Preferred GE control frequency. This is the frequency used by GE targets and CR targets with a target qubit. | `props.yaml:<chip_id>.control_frequency` |
+| `control_frequency_ef.yaml` | qubit | frequency, usually `GHz` | Preferred EF control frequency. If absent, the model uses GE frequency plus anharmonicity. | `props.yaml:<chip_id>.control_frequency_ef` |
+| `resonator_frequency.yaml` | qubit or resonator-by-qubit | frequency, usually `GHz` | Resonator ground-state frequency and readout fallback. Keys are qubit labels or indices. | `props.yaml:<chip_id>.resonator_frequency` |
+| `readout_frequency.yaml` | qubit or resonator-by-qubit | frequency, usually `GHz` | Preferred readout drive and capture frequency. Keys are qubit labels or indices. | `props.yaml:<chip_id>.readout_frequency` |
+
+Example:
+
+```yaml
+meta:
+  description: Tuned GE control frequencies
+  unit: GHz
+data:
+  0: 4.9123
+  1: 4.8461
+```
+
+### Control and hardware parameters
+
+| File | Scope | Unit | Effect | Legacy source |
+| --- | --- | --- | --- | --- |
+| `frequency_margin.yaml` | target type | frequency, usually `GHz` | Overrides target-deployment frequency margins by target type. Supported keys are `READ`, `CTRL_GE`, `CTRL_EF`, `CTRL_CR`, and `PUMP`. | `params.yaml:<chip_id>.frequency_margin` |
+| `control_amplitude.yaml` | qubit | dimensionless | Default control pulse amplitude. | `params.yaml:<chip_id>.control_amplitude` |
+| `readout_amplitude.yaml` | qubit | dimensionless | Default readout pulse amplitude. | `params.yaml:<chip_id>.readout_amplitude` |
+| `control_vatt.yaml` | qubit | integer or `null` | Control-line VATT setting for backends that support it. | `params.yaml:<chip_id>.control_vatt` |
+| `readout_vatt.yaml` | mux | integer or `null` | Readout-line VATT setting for backends that support it. | `params.yaml:<chip_id>.readout_vatt` |
+| `pump_vatt.yaml` | mux | integer or `null` | Pump-line VATT setting for backends that support it. | `params.yaml:<chip_id>.pump_vatt` |
+| `control_fsc.yaml` | qubit | integer or `null` | Control-line full-scale current setting for backends that support it. | `params.yaml:<chip_id>.control_fsc` |
+| `readout_fsc.yaml` | mux | integer or `null` | Readout-line full-scale current setting for backends that support it. | `params.yaml:<chip_id>.readout_fsc` |
+| `pump_fsc.yaml` | mux | integer or `null` | Pump-line full-scale current setting for backends that support it. | `params.yaml:<chip_id>.pump_fsc` |
+| `capture_delay.yaml` | mux | backend-specific | Capture timing offset. QuEL-1 requires `meta.unit: ndelay`; QuEL-3 requires `meta.unit: ns`. | `params.yaml:<chip_id>.capture_delay` |
+| `capture_delay_word.yaml` | mux | `word` or `words` | QuEL-1 capture-delay word offset. This file is not supported for QuEL-3. | `params.yaml:<chip_id>.capture_delay_word` |
+| `jpa_params.yaml` | mux | internal units | JPA parameters. Each mux entry may contain `pump_frequency` in `GHz`, `pump_amplitude`, and `dc_voltage`. Missing fields are filled from backend defaults. | `params.yaml:<chip_id>.jpa_params` |
+
+QuEL-1 materializes defaults for VATT, FSC, capture delay, and JPA fields.
+QuEL-3 materializes `null` for unsupported VATT/FSC/capture-delay-word settings
+and uses QuEL-3 defaults for frequency margins and JPA fields.
+
+Examples:
+
+```yaml
+# capture_delay.yaml for QuEL-3
+meta:
+  description: Capture timing offsets
+  unit: ns
+data:
+  0: 8.0
+  1: 8.0
+```
+
+```yaml
+# capture_delay.yaml for QuEL-1
+meta:
+  description: Capture timing offsets
+  unit: ndelay
+data:
+  0: 7
+  1: 8
+```
+
+```yaml
+# jpa_params.yaml
+meta:
+  description: JPA pump and bias settings
+data:
+  0:
+    pump_frequency: 6.000
+    pump_amplitude: 0.10
+    dc_voltage: 0.00
+```
+
+### Measurement defaults
+
+`measurement_defaults.yaml` does not use the `meta` / `data` format. It is a
+system-scoped partial default file for measurement execution and readout timing.
+
+```yaml
+schema_version: 1
+
+execution:
+  n_shots: 2048
+  shot_interval_ns: 200000.0
+
+readout:
+  duration_ns: 512.0
+  ramp_time_ns: 24.0
+  pre_margin_ns: 16.0
+  post_margin_ns: 96.0
+```
+
+| Field | Meaning |
+| --- | --- |
+| `schema_version` | Must be `1` when present. |
+| `execution.n_shots` | Default number of shots when a measurement API uses configured defaults and no explicit argument is provided. Must be positive. |
+| `execution.shot_interval_ns` | Default shot interval in `ns` when a measurement API uses configured defaults and no explicit argument is provided. Must be positive. |
+| `readout.duration_ns` | Default readout duration in `ns`. Must be non-negative. |
+| `readout.ramp_time_ns` | Default readout ramp time in `ns`. Must be non-negative. |
+| `readout.pre_margin_ns` | Default pre-readout margin in `ns`. Must be non-negative. |
+| `readout.post_margin_ns` | Default post-readout margin in `ns`. Must be non-negative. |
+
+Explicit API arguments take precedence over `measurement_defaults.yaml`. Some
+legacy or specialized measurement paths may also define local defaults before
+they reach the lower-level measurement configuration, so check the function
+signature when a default does not appear to apply.
+
+### Characterization and diagnostic properties
+
+These files are recognized by `ConfigLoader.load_param_data(...)`. The base
+system loader does not turn them into target frequencies or hardware settings,
+but characterization and workflow code can use them as persisted system
+properties.
+
+| File | Scope | Unit | Meaning | Legacy source |
+| --- | --- | --- | --- | --- |
+| `t1.yaml` | qubit | time, usually `ns` or `us` | T1 estimate. | `props.yaml:<chip_id>.t1` |
+| `t2_echo.yaml` | qubit | time, usually `ns` or `us` | Echo T2 estimate. | `props.yaml:<chip_id>.t2_echo` |
+| `t2_star.yaml` | qubit | time, usually `ns` or `us` | Ramsey T2* estimate. | `props.yaml:<chip_id>.t2_star` |
+| `t2_star_ef.yaml` | qubit | time, usually `ns` or `us` | EF Ramsey T2* estimate. | `props.yaml:<chip_id>.t2_star_ef` |
+| `average_readout_fidelity.yaml` | qubit | dimensionless | Average readout fidelity estimate. | `props.yaml:<chip_id>.average_readout_fidelity` |
+| `quantum_efficiency.yaml` | qubit | dimensionless | Quantum-efficiency estimate. | `props.yaml:<chip_id>.quantum_efficiency` |
+| `x90_gate_fidelity.yaml` | qubit | dimensionless | X90 gate fidelity estimate. | `props.yaml:<chip_id>.x90_gate_fidelity` |
+| `x180_gate_fidelity.yaml` | qubit | dimensionless | X180 gate fidelity estimate. | `props.yaml:<chip_id>.x180_gate_fidelity` |
+| `zx90_gate_fidelity.yaml` | pair | dimensionless | ZX90 gate fidelity estimate. | `props.yaml:<chip_id>.zx90_gate_fidelity` |
+| `static_zz_interaction.yaml` | pair | frequency, usually `GHz` or `MHz` | Static ZZ interaction estimate. | `props.yaml:<chip_id>.static_zz_interaction` |
+| `qubit_qubit_coupling_strength.yaml` | pair | frequency, usually `GHz` or `MHz` | Qubit-qubit coupling estimate. | `props.yaml:<chip_id>.qubit_qubit_coupling_strength` |
+| `resonator_external_linewidth.yaml` | qubit or resonator-by-qubit | frequency, usually `GHz` or `MHz` | Resonator external linewidth estimate. | `props.yaml:<chip_id>.external_loss_rate` |
+| `resonator_internal_linewidth.yaml` | qubit or resonator-by-qubit | frequency, usually `GHz` or `MHz` | Resonator internal linewidth estimate. | `props.yaml:<chip_id>.internal_loss_rate` |
+
+## Files outside `params/`
+
+Do not put shared system files under `params/<system_id>/`.
+
+- `skew.yaml` belongs in the shared `config/` directory. It controls QuEL-1 or
+  QuBE inter-box timing and can affect waveform timing, but it is not a
+  parameter-family file.
+- `calibration/<system_id>/calib_note.json` is the default calibration-note
+  location. It is separate from the parameter files described here.
+
+## Common pitfalls
+
+- Expecting `params.yaml` or `props.yaml` to override a per-file YAML. The
+  per-file YAML wins for the same key.
+- Editing `qubit_frequency.yaml` while `control_frequency.yaml` still defines
+  the qubit. GE and CR targets use `control_frequency.yaml` first.
+- Editing `resonator_frequency.yaml` while `readout_frequency.yaml` still
+  defines the resonator. Readout targets use `readout_frequency.yaml` first.
+- Omitting `meta.unit` for `capture_delay.yaml` or using a QuEL-1 unit on a
+  QuEL-3 system.
+- Editing YAML after an `Experiment` has already loaded and expecting the
+  existing object to update automatically.

--- a/docs/user-guide/getting-started/system-configuration.ja.md
+++ b/docs/user-guide/getting-started/system-configuration.ja.md
@@ -205,50 +205,13 @@ timestamp 付き backup が作られます。
 
 ## パラメータファイルを定義する
 
-現在の形式では、パラメータファミリごとに 1 つの構造化 YAML ファイルを使います。各ファイルは、注釈用の `meta` と実データ用の `data` を持ちます。
+system 固有の parameter file は、Qubex に渡す `params_dir` の下に置いてください。
+推奨形式は parameter family ごとに 1 つの構造化 YAML を置く形式で、旧来の
+`params.yaml` と `props.yaml` は互換 fallback として使われます。
 
-```yaml
-meta:
-  description: Example low-frequency control frequencies
-  unit: GHz
-data:
-  0: 3.000
-  1: 3.031
-  2: 3.062
-```
-
-- ファイルは、Qubex に渡す `params_dir` の下に置いてください。
-- qubit 単位のパラメータでは、キーに `0` や `1` のような整数インデックス、あるいは `Q000` や `Q001` のようなラベルを使えます。
-- 文字列ラベルを使う場合は、チップの量子ビット数に応じて桁数が変わることに注意してください。
-- `meta.unit` を設定すると、Qubex は値を内部の基底単位 (`GHz`, `ns`) へ変換します。
-- `meta.default` を設定すると、`data` 中の `None` はその既定値にフォールバックします。
-
-旧来の `params.yaml` と `props.yaml` も互換入力としてサポートされています。旧形式の map と分割 YAML が両方ある場合、Qubex はまず分割 YAML を読み込み、足りないキーだけ旧形式ファイルから補います。
-
-### `measurement_defaults.yaml`
-
-system ごとに既定の measurement 実行条件や readout timing を変えたい場合は、`measurement_defaults.yaml` を使います。
-
-```yaml
-schema_version: 1
-
-execution:
-  n_shots: 2048
-  shot_interval_ns: 200000.0
-
-readout:
-  duration_ns: 512.0
-  ramp_time_ns: 24.0
-  pre_margin_ns: 16.0
-  post_margin_ns: 96.0
-```
-
-- ファイルは `params/<system_id>/` の直下に置いてください。
-- このファイルは任意です。無い場合は、Qubex の組み込み既定値を使います。
-- `execution.n_shots` と `execution.shot_interval_ns` は、measurement API で対応引数を省略したときの既定値になります。
-- `readout.*` は、明示 override が無い場合の readout pulse 生成と `ExperimentContext` の readout timing の既定値になります。
-- API に明示的に渡した引数は、常に `measurement_defaults.yaml` より優先されます。
-- 時間値はすべて `ns` です。
+認識される file の一覧、読み込み優先度、`control_frequency.yaml` が
+`qubit_frequency.yaml` より優先されるような周波数 fallback ルールについては
+[パラメータファイル](params-configuration.md) を参照してください。
 
 ## コードから設定を読み込む
 

--- a/docs/user-guide/getting-started/system-configuration.md
+++ b/docs/user-guide/getting-started/system-configuration.md
@@ -222,59 +222,13 @@ For a full walkthrough, see [QuEL-1 skew adjustment workflow](../../examples/sys
 
 ## Define parameter files
 
-The current format is one structured YAML file per parameter family. Each file
-uses `meta` for annotations and `data` for the actual values.
+Put system-specific parameter files in the `params_dir` that you pass to Qubex.
+The preferred format is one structured YAML file per parameter family, with
+legacy `params.yaml` and `props.yaml` used only as compatibility fallbacks.
 
-```yaml
-meta:
-  description: Example low-frequency control frequencies
-  unit: GHz
-data:
-  0: 3.000
-  1: 3.031
-  2: 3.062
-```
-
-- Put the file in the `params_dir` that you pass to Qubex.
-- For qubit-scoped parameters, keys may be integer indices such as `0` and `1`,
-  or labels such as `Q000` and `Q001`.
-- When string labels are used, keep in mind that the zero-padding width depends
-  on the number of qubits on the chip.
-- When `meta.unit` is set, Qubex converts values into its internal base units
-  (`GHz`, `ns`).
-- When `meta.default` is set, `None` values in `data` fall back to that default.
-
-Legacy `params.yaml` and `props.yaml` are still supported as compatibility
-inputs. When both legacy maps and per-file YAMLs exist, Qubex loads the
-per-file YAML first and uses the legacy files only as fallback for missing keys.
-
-### `measurement_defaults.yaml`
-
-Use `measurement_defaults.yaml` when one system should carry different default
-measurement execution or readout timing values.
-
-```yaml
-schema_version: 1
-
-execution:
-  n_shots: 2048
-  shot_interval_ns: 200000.0
-
-readout:
-  duration_ns: 512.0
-  ramp_time_ns: 24.0
-  pre_margin_ns: 16.0
-  post_margin_ns: 96.0
-```
-
-- Put the file directly under `params/<system_id>/`.
-- The file is optional. If it is missing, Qubex keeps the built-in defaults.
-- `execution.n_shots` and `execution.shot_interval_ns` become the defaults for
-  measurement APIs when those arguments are omitted.
-- `readout.*` becomes the default timing source for readout pulse generation
-  and `ExperimentContext` readout timing when explicit overrides are omitted.
-- Explicit API arguments still take precedence over `measurement_defaults.yaml`.
-- All time values are in `ns`.
+For the complete file catalog, source-priority rules, and frequency fallback
+rules such as `control_frequency.yaml` taking precedence over
+`qubit_frequency.yaml`, see [Parameter files](params-configuration.md).
 
 ## Load configuration from code
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,6 +61,7 @@ plugins:
                 - インストール: user-guide/getting-started/installation.md
                 - 始め方を選ぶ: user-guide/getting-started/choose-where-to-start.md
                 - システム設定: user-guide/getting-started/system-configuration.md
+                - パラメータファイル: user-guide/getting-started/params-configuration.md
             - パルスシーケンス:
                 - パルスシーケンスの組み方: user-guide/pulse-sequences/index.md
             - 実験インタフェース:
@@ -126,6 +127,7 @@ nav:
       - Installation: user-guide/getting-started/installation.md
       - Choose where to start: user-guide/getting-started/choose-where-to-start.md
       - System configuration: user-guide/getting-started/system-configuration.md
+      - Parameter files: user-guide/getting-started/params-configuration.md
   - Pulse sequences:
       - Build pulse sequences with PulseSchedule: user-guide/pulse-sequences/index.md
   - Experiment interface:


### PR DESCRIPTION
## Background

Users need a single documentation page that explains what can be configured under `params/<system_id>/`, how per-file YAMLs relate to legacy `params.yaml` / `props.yaml`, and which frequency files take precedence at runtime.

## Summary

- Add English and Japanese `Parameter files` pages under Getting started.
- Document the structured `meta` / `data` format, unit conversion, key normalization, source-priority rules, and reload expectations.
- Catalog all parameter files recognized by `ConfigLoader`, including quantum frequencies, control/hardware settings, `measurement_defaults.yaml`, and characterization properties.
- Explain runtime frequency priority, including `control_frequency.yaml` over `qubit_frequency.yaml` and `readout_frequency.yaml` over `resonator_frequency.yaml`.
- Update `system-configuration` pages and MkDocs navigation to point to the new detailed guide.

## User / API Impact

Docs-only change. No runtime behavior or public API changes.

## Compatibility Notes

The guide preserves the current compatibility story: per-file YAMLs are preferred, while legacy `params.yaml` and `props.yaml` remain fallback inputs for missing keys.

## Validation

- `git diff --check`
- `uv run mkdocs build`

`mkdocs build` passed. Existing MkDocs/griffe/autorefs warnings are still emitted, but no new build failure was introduced.

## Open Risks / Follow-ups

- The page documents the current implementation contract. If new parameter families are added later, this catalog should be updated alongside the code.
