### PR TITLE
fix: forward scan interval to electrical delay

### DIFF
--- a/src/qubex/experiment/services/characterization_service.py
+++ b/src/qubex/experiment/services/characterization_service.py
@@ -2390,12 +2390,16 @@ class CharacterizationService:
         if readout_amplitude is None:
             readout_amplitude = self.ctx.params.readout_amplitude[qubit_label]
 
+        if interval is None:
+            interval = DEFAULT_RESONATOR_SPECTROSCOPY_INTERVAL
+
         if electrical_delay is None:
             # measure electrical delay if not provided
             tau = self.measure_electrical_delay(
                 target,
                 f_start=frequency_range[0],
                 shots=shots,
+                interval=interval,
                 plot=plot,
                 confirm=False,
             )
@@ -2410,8 +2414,6 @@ class CharacterizationService:
             readout_ramptime = DEFAULT_RESONATOR_SPECTROSCOPY_READOUT_RAMPTIME
         if readout_ramp_type is None:
             readout_ramp_type = DEFAULT_RESONATOR_SPECTROSCOPY_READOUT_RAMP_TYPE
-        if interval is None:
-            interval = DEFAULT_RESONATOR_SPECTROSCOPY_INTERVAL
 
         # split frequency range to avoid the frequency sweep range limit
         frequency_range = np.array(frequency_range)

--- a/tests/experiment/test_characterization_service_electrical_delay.py
+++ b/tests/experiment/test_characterization_service_electrical_delay.py
@@ -3,13 +3,45 @@
 from __future__ import annotations
 
 from contextlib import contextmanager
-from types import SimpleNamespace
+from types import MethodType, SimpleNamespace
 from typing import Any, cast
 
 import numpy as np
 import pytest
 
 from qubex.experiment.services.characterization_service import CharacterizationService
+
+
+class _FakeFigure:
+    """Plotly-like figure stub for resonator scan tests."""
+
+    def set_subplots(self, **_kwargs) -> None:
+        """Accept subplot configuration."""
+        return
+
+    def add_scatter(self, **_kwargs) -> None:
+        """Accept scatter traces."""
+        return
+
+    def add_vline(self, **_kwargs) -> None:
+        """Accept vertical markers."""
+        return
+
+    def add_annotation(self, **_kwargs) -> None:
+        """Accept annotations."""
+        return
+
+    def update_xaxes(self, **_kwargs) -> None:
+        """Accept x-axis updates."""
+        return
+
+    def update_yaxes(self, **_kwargs) -> None:
+        """Accept y-axis updates."""
+        return
+
+    def update_layout(self, **_kwargs) -> None:
+        """Accept layout updates."""
+        return
 
 
 class _FakeSystemManager:
@@ -125,28 +157,6 @@ def test_scan_resonator_frequencies_avoids_duplicate_reset_per_subrange(
     service.__dict__["_calibration_service"] = SimpleNamespace()
     service.__dict__["_pulse_service"] = SimpleNamespace()
 
-    class _FakeFigure:
-        def set_subplots(self, **_kwargs) -> None:
-            return
-
-        def add_scatter(self, **_kwargs) -> None:
-            return
-
-        def add_vline(self, **_kwargs) -> None:
-            return
-
-        def add_annotation(self, **_kwargs) -> None:
-            return
-
-        def update_xaxes(self, **_kwargs) -> None:
-            return
-
-        def update_yaxes(self, **_kwargs) -> None:
-            return
-
-        def update_layout(self, **_kwargs) -> None:
-            return
-
     monkeypatch.setattr(
         "qubex.experiment.services.characterization_service.ExperimentUtil.split_frequency_range",
         lambda **_kwargs: [
@@ -182,3 +192,77 @@ def test_scan_resonator_frequencies_avoids_duplicate_reset_per_subrange(
     assert "peaks" in result.data
     assert ctx.system_manager.modified_backend_settings_calls == 2
     assert ctx.reset_calls == []
+
+
+def test_scan_resonator_frequencies_forwards_interval_to_electrical_delay(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given scan interval, internal electrical-delay measurement receives it."""
+    service = cast(Any, object.__new__(CharacterizationService))
+    ctx = _FakeContext()
+    service.__dict__["_experiment_context"] = ctx
+
+    electrical_delay_calls: list[dict[str, Any]] = []
+
+    def _fake_measure_electrical_delay(
+        self: CharacterizationService,
+        target: str,
+        **kwargs: Any,
+    ) -> float:
+        _ = self
+        electrical_delay_calls.append({"target": target, **kwargs})
+        return 0.0
+
+    def _fake_measure(*_args, **_kwargs):
+        signal = np.exp(-1j * 2 * np.pi * ctx.current_frequency)
+        return SimpleNamespace(data={"Q00": SimpleNamespace(kerneled=signal)})
+
+    service.measure_electrical_delay = MethodType(
+        _fake_measure_electrical_delay,
+        service,
+    )
+    service.__dict__["_measurement_service"] = SimpleNamespace(measure=_fake_measure)
+    service.__dict__["_calibration_service"] = SimpleNamespace()
+    service.__dict__["_pulse_service"] = SimpleNamespace()
+
+    monkeypatch.setattr(
+        "qubex.experiment.services.characterization_service.ExperimentUtil.split_frequency_range",
+        lambda **_kwargs: [
+            np.array([9.8, 9.9]),
+        ],
+    )
+    monkeypatch.setattr(
+        "qubex.experiment.services.characterization_service.MixingUtil.calc_lo_cnco",
+        lambda *_args, **_kwargs: (10_000_000_000, 1_500_000_000, 0),
+    )
+    monkeypatch.setattr(
+        "qubex.experiment.services.characterization_service.viz.make_figure",
+        lambda **_kwargs: _FakeFigure(),
+    )
+    monkeypatch.setattr(
+        "scipy.signal.find_peaks",
+        lambda values, **_kwargs: (np.array([], dtype=int), {}),
+    )
+
+    result = service.scan_resonator_frequencies(
+        target="Q00",
+        frequency_range=np.array([9.8, 9.9]),
+        readout_amplitude=0.1,
+        plot=False,
+        save_image=False,
+        subrange_width=0.2,
+        shots=7,
+        interval=123.0,
+    )
+
+    assert "peaks" in result.data
+    assert electrical_delay_calls == [
+        {
+            "target": "Q00",
+            "f_start": 9.8,
+            "shots": 7,
+            "interval": 123.0,
+            "plot": False,
+            "confirm": False,
+        }
+    ]


### PR DESCRIPTION
## Background

`scan_resonator_frequencies()` accepts a shot interval through the public API, but its automatic internal `measure_electrical_delay()` call did not receive that interval. With non-zero skew timing, the internal electrical-delay measurement could therefore run with its shorter local default and fail before the resonator scan itself used the requested interval.

## Summary

- Resolve the resonator-scan interval before the optional electrical-delay measurement.
- Pass the resolved interval into the internal `measure_electrical_delay()` call.
- Add a regression test that verifies `scan_resonator_frequencies(..., interval=...)` forwards the same interval to the internal electrical-delay measurement.

## User / API Impact

Backward-compatible bug fix. No public signature changes.

Users who pass `shot_interval` / `interval` to `scan_resonator_frequencies()` now get the same interval applied to the automatically triggered electrical-delay measurement as well as the resonator scan.

## Compatibility Notes

This preserves the existing `interval` compatibility path and the newer `shot_interval` facade argument. It only fixes internal propagation.

## Validation

- `uv run pytest tests/experiment/test_characterization_service_electrical_delay.py::test_scan_resonator_frequencies_forwards_interval_to_electrical_delay` initially failed before the fix and passed after the fix.
- `uv run pytest tests/experiment/test_characterization_service_electrical_delay.py`
- `uv run pytest tests/experiment/test_experiment_facade_delegation.py`
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`
- `git diff --check`

## Open Risks / Follow-ups

- `measurement_defaults.yaml` defaults can still be bypassed by older characterization paths that set local defaults before reaching the lower-level measurement configuration. This PR fixes the explicit scan interval propagation issue only.
