### PR TITLE
docs: add data persistence guide

### DIFF
--- a/docs/user-guide/experiment/data-persistence.ja.md
+++ b/docs/user-guide/experiment/data-persistence.ja.md
@@ -9,7 +9,7 @@ Qubex には、結果を保存する経路が 2 つあります。解析済み�
 | --- | --- | --- | --- | --- |
 | 解析済みの実験結果を保存する | `ExperimentResult.save()` | `ExperimentRecord[ExperimentResult]` | `data/` | jsonpickle JSON |
 | 特定の実験処理において raw data と metadata を保存する | `exp.system_manager.save_rawdata(...)` | `MeasurementResult` | `.rawdata/` | NetCDF4 `.nc` |
-| セッション中の raw-data 保存を有効にし続ける | `exp.system_manager.set_rawdata_dir(...)` | `MeasurementResult` | ユーザーが指定したディレクトリ | NetCDF4 `.nc` |
+| `execute()` / `measure()` の raw-data 保存を有効にし続ける | `exp.system_manager.set_rawdata_dir(...)` | `MeasurementResult` | ユーザーが指定したディレクトリ | NetCDF4 `.nc` |
 
 ## `ExperimentResult` を保存する
 
@@ -98,10 +98,11 @@ raw_result = MeasurementResult.load(".rawdata/q00-rabi/20260604_101530_123456.nc
 context manager を抜けると、例外が発生した場合も含めて、以前の raw-data 設定へ
 戻ります。
 
-## セッション中の測定を常に保存する
+## `execute()` / `measure()` の raw-data 保存を有効にし続ける
 
-notebook や実験セッション中の測定をすべて保存したい場合は、最初に raw-data
-directory を設定し、セッション終了時に明示的に無効化します。
+notebook や実験セッション中に `execute()` または `measure()` を繰り返し実行し、
+それらの raw data を保存したい場合は、最初に raw-data directory を設定し、
+セッション終了時に明示的に無効化します。
 
 ```python
 exp.system_manager.set_rawdata_dir(".rawdata/20260604-q00-session")
@@ -114,13 +115,18 @@ finally:
 ```
 
 !!! note
-    セッション全体で raw-data 保存を有効にすると、測定条件によっては保存容量が
-    大きくなることがあります。長時間の実験や共有サーバーで使う場合は、保存先の
-    空き容量とセッションごとの整理に注意してください。
+    多くの `execute()` / `measure()` 呼び出しで raw-data 保存を有効にしたままに
+    すると、測定条件によっては保存容量が大きくなることがあります。長時間の実験や
+    共有サーバーで使う場合は、保存先の空き容量とセッションごとの整理に注意して
+    ください。
 
 `SystemManager` の状態は active な実験 stack から共有されることがあるため、
-session-wide raw-data capture を有効にするときは `try` / `finally` を使うことを
-推奨します。
+raw-data 保存を複数の呼び出しにまたがって有効にするときは `try` / `finally` を
+使うことを推奨します。
+
+この設定が効くのは、`execute()` や `measure()` のように自動 raw-data 保存の経路を
+通る API です。API から `MeasurementResult` を直接受け取る場合は、次のように返り値
+を明示的に保存してください。
 
 ## 返された `MeasurementResult` を明示的に保存する
 

--- a/docs/user-guide/experiment/data-persistence.ja.md
+++ b/docs/user-guide/experiment/data-persistence.ja.md
@@ -1,0 +1,197 @@
+# データ保存
+
+Qubex には、結果を保存する経路が 2 つあります。解析済みの実験レベルの結果を
+残す場合は `ExperimentResult.save()` を使います。測定実行中に生成される
+`MeasurementResult` 形式の raw data と metadata を残す場合は
+`SystemManager.save_rawdata()` または `set_rawdata_dir()` を使います。
+
+| 用途 | API | 保存されるオブジェクト | 既定の保存先 | 形式 |
+| --- | --- | --- | --- | --- |
+| 解析済みの実験結果を保存する | `ExperimentResult.save()` | `ExperimentRecord[ExperimentResult]` | `data/` | jsonpickle JSON |
+| 特定の実験処理において raw data と metadata を保存する | `exp.system_manager.save_rawdata(...)` | `MeasurementResult` | `.rawdata/` | NetCDF4 `.nc` |
+| セッション中の raw-data 保存を有効にし続ける | `exp.system_manager.set_rawdata_dir(...)` | `MeasurementResult` | ユーザーが指定したディレクトリ | NetCDF4 `.nc` |
+
+## `ExperimentResult` を保存する
+
+多くの高レベル `Experiment` メソッドは `ExperimentResult` を返します。この
+オブジェクトは、実験向けに整理された target data と `plot()`、`fit()` などの
+helper を持ちます。この解析済み結果オブジェクトを残したいときは、結果に対して
+`save()` を呼びます。
+
+```python
+result = exp.obtain_rabi_params(targets=["Q00"], n_shots=1024)
+
+record = result.save(
+    name="q00_rabi",
+    description="Rabi calibration for Q00 after frequency update.",
+)
+
+print(record.file_name)
+```
+
+この convenience method は `ExperimentRecord` を作成し、ただちに保存し、その
+record を返します。ファイルは `data/` 以下に
+`YYYYMMDD_<name>_<counter>.json` という名前で書かれます。同じ日付・同じ名前の
+ファイルを上書きしないよう、counter は自動で増えます。
+
+読み戻しには `ExperimentRecord.load()` または `Experiment` の convenience
+method を使います。
+
+```python
+loaded = exp.load_record(record.file_name)
+restored_result = loaded.data
+```
+
+既定以外のディレクトリに保存したい場合は、`ExperimentRecord` を直接使います。
+
+```python
+from qubex.experiment.models import ExperimentRecord
+
+record = ExperimentRecord(
+    data=result,
+    name="q00_rabi",
+    description="Rabi calibration for Q00 after frequency update.",
+)
+record.save(data_path="results/experiment-records")
+```
+
+### `ExperimentRecord` の注意点
+
+- `ExperimentResult.save()` が保存するのは高レベルな結果オブジェクトです。
+  実験の途中で生成されたすべての `MeasurementResult` を自動で保存するわけでは
+  ありません。
+- ファイル名には `name` がそのまま入ります。空白や path separator を避け、
+  短く filesystem-safe な名前を使ってください。
+- `ExperimentRecord` ファイルは jsonpickle で encode された Python object
+  graph です。他ツール向けの安定した interchange schema ではなく、Qubex /
+  Python の永続化ファイルとして扱ってください。
+- 信頼できる `ExperimentRecord` ファイルだけを読み込んでください。jsonpickle
+  の decode は Python object を復元できます。
+- 古い record を復元できるかどうかは、保存時と互換性のある Python package と
+  import path があるかに依存します。
+
+## 特定の実験処理だけ raw `MeasurementResult` を保存する
+
+`MeasurementResult` は、1 回の測定実行を表す Qubex 標準の測定結果 model です。
+target ごとの raw data、`MeasurementConfig`、任意の device configuration、
+classifier reference を持ちます。
+
+特定の実験処理だけ raw data と metadata を残したい場合は `save_rawdata()` を
+使います。
+
+```python
+with exp.system_manager.save_rawdata(rawdata_dir=".rawdata", tag="q00-rabi"):
+    analyzed = exp.obtain_rabi_params(targets=["Q00"], n_shots=1024)
+```
+
+この context の中で実行された測定ごとに、`MeasurementResult` が自動保存されます。
+ファイルは `.rawdata/q00-rabi/YYYYMMDD_HHMMSS_microseconds.nc` として書かれます。
+
+保存された raw file は model loader で読み戻します。
+
+```python
+from qubex.measurement.models import MeasurementResult
+
+raw_result = MeasurementResult.load(".rawdata/q00-rabi/20260604_101530_123456.nc")
+```
+
+context manager を抜けると、例外が発生した場合も含めて、以前の raw-data 設定へ
+戻ります。
+
+## セッション中の測定を常に保存する
+
+notebook や実験セッション中の測定をすべて保存したい場合は、最初に raw-data
+directory を設定し、セッション終了時に明示的に無効化します。
+
+```python
+exp.system_manager.set_rawdata_dir(".rawdata/20260604-q00-session")
+
+try:
+    result_a = exp.execute(schedule_a, n_shots=1024)
+    result_b = exp.measure(sequence_b, n_shots=1024)
+finally:
+    exp.system_manager.set_rawdata_dir(None)
+```
+
+!!! note
+    セッション全体で raw-data 保存を有効にすると、測定条件によっては保存容量が
+    大きくなることがあります。長時間の実験や共有サーバーで使う場合は、保存先の
+    空き容量とセッションごとの整理に注意してください。
+
+`SystemManager` の状態は active な実験 stack から共有されることがあるため、
+session-wide raw-data capture を有効にするときは `try` / `finally` を使うことを
+推奨します。
+
+## 返された `MeasurementResult` を明示的に保存する
+
+API から `MeasurementResult` を直接受け取った場合は、返り値を明示的に保存します。
+
+```python
+from qubex.measurement.models import MeasurementResult
+
+raw_result = await exp.run_measurement(
+    schedule=measurement_schedule,
+    n_shots=1024,
+)
+
+path = raw_result.save("results/q00-run-measurement.nc")
+restored = MeasurementResult.load(path)
+```
+
+timestamp 付きの自動 raw-data file ではなく、自分で filename を決めたい場合にも
+この方法が使えます。
+
+## `MeasurementResult` の構造
+
+論理構造は次の通りです。
+
+- `MeasurementResult.data`: target label を key にした
+  `dict[str, list[CaptureData]]`
+- `MeasurementResult.measurement_config`: shot 数、shot interval、averaging
+  mode、integration mode、classification mode、要求した return item
+- `MeasurementResult.device_config`: 任意の device / backend snapshot
+- `MeasurementResult.classifier_refs`: target ごとの任意の classifier metadata
+
+各 `CaptureData` entry は次の情報を持ちます。
+
+- `target`
+- `config`
+- `payload`
+- `sampling_period`
+- `classifier_ref`
+
+primary capture array は `config.primary_return_item` で選ばれ、`capture.data` と
+して参照できます。payload field は次の標準 shape を使います。
+
+| Payload field | Shape |
+| --- | --- |
+| `waveform_series` | `(n_shots, capture_length)` |
+| `iq_series` | `(n_shots,)` |
+| `state_series` | `(n_shots,)` |
+| `averaged_waveform` | `(capture_length,)` |
+| `averaged_iq` | scalar |
+
+## NetCDF4 file contract
+
+`MeasurementResult.save()` は `save_netcdf()` の alias です。ファイルは NetCDF4
+として書かれ、Qubex/qxcore の metadata を持ちます。
+
+- global attribute `format`
+- global attribute `format_version`
+- global attribute `model_class`
+- global attribute `payload_json`
+
+NetCDF4 を使うためファイルは HDF5 ベースですが、公開 contract は手書きの HDF5
+group layout ではなく、Qubex `DataModel` loader です。top-level の配列は
+NetCDF variable として保存されることがあります。一方、nested model payload は
+`payload_json` に encode されることがあります。安定して復元するには、内部の
+variable name に依存せず `MeasurementResult.load()` を使ってください。
+
+手動で `netCDF4` から確認する場合は、complex support を有効にして開きます。
+
+```python
+from netCDF4 import Dataset
+
+with Dataset("result.nc", mode="r", auto_complex=True) as ds:
+    print(ds.ncattrs())
+```

--- a/docs/user-guide/experiment/data-persistence.md
+++ b/docs/user-guide/experiment/data-persistence.md
@@ -9,7 +9,7 @@ during measurement execution.
 | --- | --- | --- | --- | --- |
 | Save an analyzed experiment result | `ExperimentResult.save()` | `ExperimentRecord[ExperimentResult]` | `data/` | jsonpickle JSON |
 | Save raw data and metadata for a specific experiment operation | `exp.system_manager.save_rawdata(...)` | `MeasurementResult` | `.rawdata/` | NetCDF4 `.nc` |
-| Keep raw-data capture enabled for a session | `exp.system_manager.set_rawdata_dir(...)` | `MeasurementResult` | User-selected directory | NetCDF4 `.nc` |
+| Keep raw-data capture enabled for `execute()` / `measure()` calls | `exp.system_manager.set_rawdata_dir(...)` | `MeasurementResult` | User-selected directory | NetCDF4 `.nc` |
 
 ## Save `ExperimentResult`
 
@@ -99,10 +99,11 @@ raw_result = MeasurementResult.load(".rawdata/q00-rabi/20260604_101530_123456.nc
 The context manager restores the previous raw-data setting when the context
 exits, including when an exception is raised.
 
-## Save every measurement in a session
+## Keep raw-data capture enabled for `execute()` / `measure()`
 
-For notebook or lab sessions where every measurement should be captured, set
-the raw-data directory once and disable it explicitly when the session is over.
+For notebook or lab sessions where repeated `execute()` or `measure()` calls
+should be captured, set the raw-data directory once and disable it explicitly
+when the session is over.
 
 ```python
 exp.system_manager.set_rawdata_dir(".rawdata/20260604-q00-session")
@@ -115,13 +116,19 @@ finally:
 ```
 
 !!! note
-    Enabling raw-data capture for a whole session can use a large amount of
-    storage depending on the measurement settings. For long-running sessions or
-    shared servers, pay attention to available storage and session-level
-    organization.
+    Keeping raw-data capture enabled for many `execute()` / `measure()` calls
+    can use a large amount of storage depending on the measurement settings.
+    For long-running sessions or shared servers, pay attention to available
+    storage and session-level organization.
 
 Because `SystemManager` state can be shared by the active experiment stack,
-prefer `try` / `finally` when enabling session-wide raw-data capture.
+prefer `try` / `finally` when keeping raw-data capture enabled across repeated
+calls.
+
+This setting only affects calls that go through the automatic raw-data capture
+path, such as `execute()` and `measure()`. If an API returns a
+`MeasurementResult` directly, save the returned object explicitly as shown
+below.
 
 ## Save returned `MeasurementResult` objects explicitly
 

--- a/docs/user-guide/experiment/data-persistence.md
+++ b/docs/user-guide/experiment/data-persistence.md
@@ -1,0 +1,201 @@
+# Data persistence
+
+Qubex has two result-persistence paths. Use `ExperimentResult.save()` for
+analyzed experiment-level results. Use `SystemManager.save_rawdata()` or
+`set_rawdata_dir()` when you need to keep the raw data and metadata produced
+during measurement execution.
+
+| Use case | API | Saved object | Default location | Format |
+| --- | --- | --- | --- | --- |
+| Save an analyzed experiment result | `ExperimentResult.save()` | `ExperimentRecord[ExperimentResult]` | `data/` | jsonpickle JSON |
+| Save raw data and metadata for a specific experiment operation | `exp.system_manager.save_rawdata(...)` | `MeasurementResult` | `.rawdata/` | NetCDF4 `.nc` |
+| Keep raw-data capture enabled for a session | `exp.system_manager.set_rawdata_dir(...)` | `MeasurementResult` | User-selected directory | NetCDF4 `.nc` |
+
+## Save `ExperimentResult`
+
+Many high-level `Experiment` methods return `ExperimentResult`. This object
+contains experiment-oriented target data and helpers such as `plot()` and
+`fit()`. Call `save()` on the result when you want to keep that analyzed result
+object.
+
+```python
+result = exp.obtain_rabi_params(targets=["Q00"], n_shots=1024)
+
+record = result.save(
+    name="q00_rabi",
+    description="Rabi calibration for Q00 after frequency update.",
+)
+
+print(record.file_name)
+```
+
+The convenience method creates an `ExperimentRecord`, saves it immediately, and
+returns the record. Files are written under `data/` with names like
+`YYYYMMDD_<name>_<counter>.json`. The counter is incremented to avoid
+overwriting an existing file for the same date and name.
+
+Load the record with `ExperimentRecord.load()` or the `Experiment` convenience
+method:
+
+```python
+loaded = exp.load_record(record.file_name)
+restored_result = loaded.data
+```
+
+Use `ExperimentRecord` directly if you need a non-default directory:
+
+```python
+from qubex.experiment.models import ExperimentRecord
+
+record = ExperimentRecord(
+    data=result,
+    name="q00_rabi",
+    description="Rabi calibration for Q00 after frequency update.",
+)
+record.save(data_path="results/experiment-records")
+```
+
+### Notes for `ExperimentRecord`
+
+- `ExperimentResult.save()` stores the high-level result object. It does not
+  automatically store every intermediate `MeasurementResult` produced while the
+  experiment was running.
+- The filename uses `name` as provided. Use short, filesystem-safe names without
+  spaces or path separators.
+- `ExperimentRecord` files are jsonpickle-encoded Python object graphs. Treat
+  them as Qubex/Python persistence files, not as a stable interchange schema for
+  other tools.
+- Only load `ExperimentRecord` files that you trust. jsonpickle decoding can
+  recreate Python objects.
+- Restoring old records depends on compatible Python packages and import paths
+  for the stored classes.
+
+## Save raw `MeasurementResult` files for a specific experiment operation
+
+`MeasurementResult` is the Qubex standard result model for one measurement run.
+It stores target-keyed raw data, the `MeasurementConfig`, optional device
+configuration, and classifier references.
+
+Use `save_rawdata()` when you want raw data and metadata only for a specific
+experiment operation:
+
+```python
+with exp.system_manager.save_rawdata(rawdata_dir=".rawdata", tag="q00-rabi"):
+    analyzed = exp.obtain_rabi_params(targets=["Q00"], n_shots=1024)
+```
+
+Each measurement run inside this context is saved automatically as a
+`MeasurementResult`. Files are written as
+`.rawdata/q00-rabi/YYYYMMDD_HHMMSS_microseconds.nc`.
+
+Read a saved raw file with the model loader:
+
+```python
+from qubex.measurement.models import MeasurementResult
+
+raw_result = MeasurementResult.load(".rawdata/q00-rabi/20260604_101530_123456.nc")
+```
+
+The context manager restores the previous raw-data setting when the context
+exits, including when an exception is raised.
+
+## Save every measurement in a session
+
+For notebook or lab sessions where every measurement should be captured, set
+the raw-data directory once and disable it explicitly when the session is over.
+
+```python
+exp.system_manager.set_rawdata_dir(".rawdata/20260604-q00-session")
+
+try:
+    result_a = exp.execute(schedule_a, n_shots=1024)
+    result_b = exp.measure(sequence_b, n_shots=1024)
+finally:
+    exp.system_manager.set_rawdata_dir(None)
+```
+
+!!! note
+    Enabling raw-data capture for a whole session can use a large amount of
+    storage depending on the measurement settings. For long-running sessions or
+    shared servers, pay attention to available storage and session-level
+    organization.
+
+Because `SystemManager` state can be shared by the active experiment stack,
+prefer `try` / `finally` when enabling session-wide raw-data capture.
+
+## Save returned `MeasurementResult` objects explicitly
+
+When an API returns a `MeasurementResult` directly, save the return value
+explicitly:
+
+```python
+from qubex.measurement.models import MeasurementResult
+
+raw_result = await exp.run_measurement(
+    schedule=measurement_schedule,
+    n_shots=1024,
+)
+
+path = raw_result.save("results/q00-run-measurement.nc")
+restored = MeasurementResult.load(path)
+```
+
+This explicit form is also useful when you want to choose a filename yourself
+instead of using timestamped automatic raw-data files.
+
+## `MeasurementResult` structure
+
+The logical structure is:
+
+- `MeasurementResult.data`: `dict[str, list[CaptureData]]`, keyed by target
+  label.
+- `MeasurementResult.measurement_config`: number of shots, shot interval,
+  averaging mode, integration mode, classification mode, and requested return
+  items.
+- `MeasurementResult.device_config`: optional device or backend snapshot.
+- `MeasurementResult.classifier_refs`: optional classifier metadata keyed by
+  target.
+
+Each `CaptureData` entry stores:
+
+- `target`
+- `config`
+- `payload`
+- `sampling_period`
+- `classifier_ref`
+
+The primary capture array is selected by `config.primary_return_item` and is
+available as `capture.data`. Payload fields use these standard shapes:
+
+| Payload field | Shape |
+| --- | --- |
+| `waveform_series` | `(n_shots, capture_length)` |
+| `iq_series` | `(n_shots,)` |
+| `state_series` | `(n_shots,)` |
+| `averaged_waveform` | `(capture_length,)` |
+| `averaged_iq` | scalar |
+
+## NetCDF4 file contract
+
+`MeasurementResult.save()` is an alias of `save_netcdf()`. Files are written as
+NetCDF4 with Qubex/qxcore metadata:
+
+- global attribute `format`
+- global attribute `format_version`
+- global attribute `model_class`
+- global attribute `payload_json`
+
+The file is HDF5-based because it uses NetCDF4, but the public contract is the
+Qubex `DataModel` loader, not a hand-authored HDF5 group layout. Top-level
+arrays may be stored as NetCDF variables. Nested model payloads may be encoded
+inside `payload_json`. Use `MeasurementResult.load()` for reliable restoration
+instead of depending on internal variable names.
+
+If you inspect files manually with `netCDF4`, open them with complex support:
+
+```python
+from netCDF4 import Dataset
+
+with Dataset("result.nc", mode="r", auto_complex=True) as ds:
+    print(ds.ncattrs())
+```

--- a/docs/user-guide/experiment/examples.ja.md
+++ b/docs/user-guide/experiment/examples.ja.md
@@ -23,5 +23,6 @@
 
 - [パルスシーケンスの組み方](../pulse-sequences/index.md)
 - [`Experiment` クラス](index.md)
+- [データ保存](data-persistence.md)
 - [コミュニティ提供ワークフロー](../getting-started/contrib-workflows.md)
 - [サンプル集全体](../../examples/index.md)

--- a/docs/user-guide/experiment/examples.md
+++ b/docs/user-guide/experiment/examples.md
@@ -23,5 +23,6 @@ Use these notebooks after completing the [Quickstart](../getting-started/quickst
 
 - [Build pulse sequences with PulseSchedule](../pulse-sequences/index.md)
 - [`Experiment`](index.md)
+- [Data persistence](data-persistence.md)
 - [Community-contributed workflows](../getting-started/contrib-workflows.md)
 - [Full examples index](../../examples/index.md)

--- a/docs/user-guide/experiment/index.ja.md
+++ b/docs/user-guide/experiment/index.ja.md
@@ -2,6 +2,8 @@
 
 `Experiment` は、実機を使う Qubex ユーザーの多くにとって推奨される入口です。
 system の設定、装置接続、パルスシーケンスの構築、測定実行、結果解析までを高レベルなワークフローとして提供します。
+解析済みの `ExperimentResult` や、測定実行から得られる raw `MeasurementResult`
+を保存したい場合は [データ保存](data-persistence.md) を参照してください。
 
 ## Experiment を使うべき人
 
@@ -14,8 +16,9 @@ system の設定、装置接続、パルスシーケンスの構築、測定実�
 1. [インストール](../getting-started/installation.md) で Qubex を入れる
 2. [システム設定](../getting-started/system-configuration.md) で設定ファイルを用意する
 3. [クイックスタート](../getting-started/quickstart.md) で基本ワークフローを確認する
-4. [Experiment サンプルワークフロー](examples.md) で notebook をたどる
-5. 必要に応じて [コミュニティ提供ワークフロー](../getting-started/contrib-workflows.md) を使う
+4. [データ保存](data-persistence.md) で結果の残し方を決める
+5. [Experiment サンプルワークフロー](examples.md) で notebook をたどる
+6. 必要に応じて [コミュニティ提供ワークフロー](../getting-started/contrib-workflows.md) を使う
 
 ## Experimental な非同期 API
 

--- a/docs/user-guide/experiment/index.md
+++ b/docs/user-guide/experiment/index.md
@@ -2,6 +2,9 @@
 
 `Experiment` is the recommended starting point for most hardware-backed Qubex users.
 It provides a high-level workflow for configuring systems, connecting to instruments, building pulse sequences, running measurements, and analyzing results.
+Use [Data persistence](data-persistence.md) when you need to save analyzed
+`ExperimentResult` objects or raw `MeasurementResult` files from measurement
+execution.
 
 ## Who should use Experiment
 
@@ -14,8 +17,9 @@ It provides a high-level workflow for configuring systems, connecting to instrum
 1. Install Qubex: [Installation](../getting-started/installation.md)
 2. Prepare your configuration files: [System configuration](../getting-started/system-configuration.md)
 3. Work through the basic workflow: [Quickstart](../getting-started/quickstart.md)
-4. Continue with curated notebooks: [Experiment example workflows](examples.md)
-5. Explore extra routines when needed: [Community-contributed workflows](../getting-started/contrib-workflows.md)
+4. Decide how to save results: [Data persistence](data-persistence.md)
+5. Continue with curated notebooks: [Experiment example workflows](examples.md)
+6. Explore extra routines when needed: [Community-contributed workflows](../getting-started/contrib-workflows.md)
 
 ## Experimental async APIs
 

--- a/docs/user-guide/measurement/examples.ja.md
+++ b/docs/user-guide/measurement/examples.ja.md
@@ -18,6 +18,7 @@
 
 - [低レベル API 概要](../low-level-apis/index.md)
 - [`measurement` モジュール](index.md)
+- [データ保存](../experiment/data-persistence.md)
 - [`system` モジュール](../system/index.md)
 - [`backend` モジュール](../backend/index.md)
 - [サンプル集全体](../../examples/index.md)

--- a/docs/user-guide/measurement/examples.md
+++ b/docs/user-guide/measurement/examples.md
@@ -19,6 +19,7 @@ Use these notebooks when you want a measurement-centric workflow built around
 
 - [Low-level APIs](../low-level-apis/index.md)
 - [`measurement` module](index.md)
+- [Data persistence](../experiment/data-persistence.md)
 - [`system` module](../system/index.md)
 - [`backend` module](../backend/index.md)
 - [Full examples index](../../examples/index.md)

--- a/docs/user-guide/measurement/index.ja.md
+++ b/docs/user-guide/measurement/index.ja.md
@@ -5,6 +5,8 @@
 [`backend`](../backend/index.md) のあいだに位置し、読み込まれた
 システム状態を使って schedule からキャプチャ/読み出しや sweep の実行フローを
 組み立てます。
+結果保存については、raw `MeasurementResult` の NetCDF4 保存を含む
+[データ保存](../experiment/data-persistence.md) を参照してください。
 
 このページは [低レベル API](../low-level-apis/index.md) セクションの一部です。
 
@@ -33,8 +35,9 @@
 1. [低レベル API 概要](../low-level-apis/index.md) で全体像を確認する
 2. パルスシーケンスから始まる場合は [パルスシーケンスの組み方](../pulse-sequences/index.md) を読む
 3. [`measurement` サンプルワークフロー](examples.md) から notebook を始める
-4. 設定読み込みや同期が主題なら [`system`](../system/index.md) に進む
-5. controller や payload が主題なら [`backend`](../backend/index.md) に進む
+4. raw result の保存が必要なら [データ保存](../experiment/data-persistence.md) を確認する
+5. 設定読み込みや同期が主題なら [`system`](../system/index.md) に進む
+6. controller や payload が主題なら [`backend`](../backend/index.md) に進む
 
 ## 次のような場合は `Experiment` を選ぶ
 

--- a/docs/user-guide/measurement/index.md
+++ b/docs/user-guide/measurement/index.md
@@ -5,6 +5,8 @@ flows from the models exposed by the measurement layer. It sits between
 [`system`](../system/index.md) and
 [`backend`](../backend/index.md): it consumes loaded system state and turns
 schedules into capture/readout and sweep execution flows.
+For result storage, see [Data persistence](../experiment/data-persistence.md),
+especially the sections on raw `MeasurementResult` NetCDF4 files.
 
 This page sits under [Low-level APIs](../low-level-apis/index.md).
 
@@ -33,8 +35,9 @@ This page sits under [Low-level APIs](../low-level-apis/index.md).
 1. Read the section overview: [Low-level APIs](../low-level-apis/index.md)
 2. Learn the shared pulse-sequence model if needed: [Build pulse sequences with PulseSchedule](../pulse-sequences/index.md)
 3. Start with curated notebooks: [`measurement` example workflows](examples.md)
-4. Move to [`system`](../system/index.md) when configuration or synchronization is the main issue
-5. Move to [`backend`](../backend/index.md) when controller-level payloads or execution paths are the main issue
+4. Review raw result storage: [Data persistence](../experiment/data-persistence.md)
+5. Move to [`system`](../system/index.md) when configuration or synchronization is the main issue
+6. Move to [`backend`](../backend/index.md) when controller-level payloads or execution paths are the main issue
 
 ## Choose `Experiment` instead when
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -66,6 +66,7 @@ plugins:
                 - パルスシーケンスの組み方: user-guide/pulse-sequences/index.md
             - 実験インタフェース:
                 - Experiment クラス: user-guide/experiment/index.md
+                - データ保存: user-guide/experiment/data-persistence.md
                 - クイックスタート: user-guide/getting-started/quickstart.md
                 - サンプルワークフロー: user-guide/experiment/examples.md
                 - コミュニティ提供ワークフロー: user-guide/getting-started/contrib-workflows.md
@@ -133,6 +134,7 @@ nav:
       - Build pulse sequences with PulseSchedule: user-guide/pulse-sequences/index.md
   - Experiment interface:
       - Experiment class: user-guide/experiment/index.md
+      - Data persistence: user-guide/experiment/data-persistence.md
       - Quickstart: user-guide/getting-started/quickstart.md
       - Example workflows: user-guide/experiment/examples.md
       - Community-contributed workflows: user-guide/getting-started/contrib-workflows.md

--- a/tests/backend/test_system_manager.py
+++ b/tests/backend/test_system_manager.py
@@ -125,6 +125,37 @@ class FakeExperimentSystemForBackendSettings:
         return self.control_system.hash
 
 
+def test_save_rawdata_context_sets_tagged_directory_and_restores(
+    tmp_path: Path,
+) -> None:
+    """Given save_rawdata context, when exiting, then raw-data directory is restored."""
+    manager = SystemManager.shared()
+    original_rawdata_dir = manager.rawdata_dir
+    previous_dir = tmp_path / "previous"
+    tagged_dir = tmp_path / "raw" / "q00-rabi"
+
+    def raise_inside_rawdata_context() -> None:
+        with manager.save_rawdata(rawdata_dir=tmp_path / "raw-error"):
+            assert manager.rawdata_dir == tmp_path / "raw-error"
+            raise RuntimeError("stop")
+
+    try:
+        manager.set_rawdata_dir(previous_dir)
+
+        with manager.save_rawdata(rawdata_dir=tmp_path / "raw", tag="q00-rabi"):
+            assert manager.rawdata_dir == tagged_dir
+            assert tagged_dir.exists()
+
+        assert manager.rawdata_dir == previous_dir
+
+        with pytest.raises(RuntimeError, match="stop"):
+            raise_inside_rawdata_context()
+
+        assert manager.rawdata_dir == previous_dir
+    finally:
+        manager.set_rawdata_dir(original_rawdata_dir)
+
+
 def test_backend_settings_hash_is_order_independent() -> None:
     """Given the same nested content, when hashing backend settings, then hash is independent of key insertion order."""
     settings_a = BackendSettings(

--- a/tests/experiment/test_result_model.py
+++ b/tests/experiment/test_result_model.py
@@ -4,9 +4,12 @@ from __future__ import annotations
 
 from datetime import datetime, timezone
 
+import numpy as np
 import plotly.graph_objects as go
 import pytest
 
+from qubex.experiment.models.experiment_record import ExperimentRecord
+from qubex.experiment.models.experiment_result import ExperimentResult, TargetData
 from qubex.experiment.models.result import Result
 
 
@@ -21,6 +24,31 @@ def test_result_should_preserve_mapping_payload_access() -> None:
     assert datetime.fromisoformat(result.created_at).tzinfo == timezone.utc
     assert result.figure is None
     assert result.figures is None
+
+
+def test_experiment_result_save_round_trips_experiment_record(
+    tmp_path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given ExperimentResult.save, when loading the record, then data is restored."""
+    monkeypatch.chdir(tmp_path)
+    result = ExperimentResult(
+        data={"Q00": TargetData(target="Q00", data=np.array([1.0, 2.0]))}
+    )
+
+    record = result.save(
+        name="q00_rabi",
+        description="Rabi calibration for Q00.",
+    )
+    second_record = result.save(name="q00_rabi")
+    loaded = ExperimentRecord.load(record.file_name, data_dir="data")
+
+    assert record.file_name.endswith("_q00_rabi_1.json")
+    assert second_record.file_name.endswith("_q00_rabi_2.json")
+    assert loaded.name == "q00_rabi"
+    assert loaded.description == "Rabi calibration for Q00."
+    assert isinstance(loaded.data, ExperimentResult)
+    assert np.array_equal(loaded.data.data["Q00"].data, np.array([1.0, 2.0]))
 
 
 def test_result_should_not_derive_figure_fields_from_legacy_payload_keys() -> None:

--- a/tests/measurement/test_measurement_api_delegation.py
+++ b/tests/measurement/test_measurement_api_delegation.py
@@ -211,6 +211,85 @@ def test_execute_delegates_to_schedule_executor_with_built_schedule(
     assert called["run_config"].shot_averaging is True
 
 
+def test_execute_saves_raw_measurement_result_when_rawdata_dir_is_set(
+    monkeypatch: pytest.MonkeyPatch,
+    tmp_path,
+) -> None:
+    """Given rawdata_dir, when execute runs, then raw MeasurementResult is saved."""
+    measurement = Measurement(
+        chip_id="TEST",
+        qubits=["Q00"],
+        load_configs=False,
+        connect_devices=False,
+    )
+    pulse_schedule = PulseSchedule(["Q00"])
+    built_schedule = MeasurementSchedule(
+        pulse_schedule=PulseSchedule(["RQ00"]),
+        capture_schedule=CaptureSchedule(captures=[]),
+    )
+    measurement_config = _make_config(mode="avg", shots=2)
+    raw_result = _make_measurement_result(
+        data={"Q00": [np.array([1.0 + 0.0j])]},
+        measurement_config=measurement_config,
+        sampling_period=2.0,
+        device_config={"backend": "stub"},
+    )
+
+    def fake_build(
+        self: MeasurementExecutionService,
+        *,
+        pulse_schedule: PulseSchedule,
+        **kwargs: object,
+    ) -> MeasurementSchedule:
+        _ = (self, pulse_schedule, kwargs)
+        return built_schedule
+
+    class _Executor:
+        def execute_sync(
+            self,
+            *,
+            schedule: MeasurementSchedule,
+            config: MeasurementConfig,
+            quel1_options: Quel1MeasurementOptions | None = None,
+        ) -> MeasurementResult:
+            _ = (self, schedule, config, quel1_options)
+            return raw_result
+
+    execution_service = measurement.execution_service
+    execution_service.build_measurement_schedule = MethodType(
+        fake_build, execution_service
+    )
+    monkeypatch.setattr(
+        MeasurementExecutionService,
+        "measurement_schedule_runner",
+        property(lambda self: _Executor()),
+    )
+    experiment_system = type(
+        "_ES",
+        (),
+        {
+            "control_params": type("_CP", (), {"readout_amplitude": {}})(),
+            "measurement_defaults": {},
+        },
+    )()
+    backend_controller = type("_BC", (), {"box_config": {"shots": 2}})()
+    _bind_runtime(
+        measurement,
+        backend_controller=backend_controller,
+        experiment_system=experiment_system,
+        rawdata_dir=tmp_path,
+    )
+
+    converted = measurement.execute(schedule=pulse_schedule)
+
+    saved_files = list(tmp_path.glob("*.nc"))
+    assert len(saved_files) == 1
+    restored = MeasurementResult.load(saved_files[0])
+    assert np.array_equal(restored.data["Q00"][0].data, np.array([1.0 + 0.0j]))
+    assert restored.device_config == {"backend": "stub"}
+    assert np.array_equal(converted.data["Q00"][0].raw, np.array([1.0 + 0.0j]))
+
+
 def test_execute_forwards_frequency_overrides_to_schedule_builder(
     monkeypatch,
 ) -> None:


### PR DESCRIPTION
## Summary
- add English and Japanese data-persistence pages for ExperimentResult and MeasurementResult storage
- document jsonpickle ExperimentRecord persistence and NetCDF4 raw MeasurementResult persistence
- add navigation and cross-links from Experiment and measurement guide pages
- add regression tests for ExperimentResult/ExperimentRecord persistence, save_rawdata context restoration, and raw MeasurementResult auto-save through the execute path without hardware access

## Compatibility
- docs and tests only; no runtime behavior changes

## Code review notes
- The raw-data auto-save hook is in MeasurementExecutionService.execute after the schedule runner returns a MeasurementResult and before conversion to legacy measure-result types. Measurement.measure delegates through execute, so the documented context-manager flow is covered without touching hardware in tests.
- Async-first run_measurement returns MeasurementResult directly and does not auto-save from rawdata_dir; the docs describe explicit save for that path.

## Verification
- git diff --check
- uv run ruff check --fix
- uv run ruff format
- uv run pyright
- uv run pytest tests/experiment/test_result_model.py::test_experiment_result_save_round_trips_experiment_record tests/backend/test_system_manager.py::test_save_rawdata_context_sets_tagged_directory_and_restores tests/measurement/test_measurement_api_delegation.py::test_execute_saves_raw_measurement_result_when_rawdata_dir_is_set
- uv run pytest
- uv run mkdocs build

Note: mkdocs build passes with existing repository warning noise from nav-unregistered pages, griffe, and autorefs.