### PR TITLE
Fix/quel1se riken8 vatt configuration

### DIFF
--- a/src/qubex/backend/quel1/managers/configuration_manager.py
+++ b/src/qubex/backend/quel1/managers/configuration_manager.py
@@ -78,10 +78,13 @@ class Quel1ConfigurationManager:
             reconnect=True,
         )
         if box.boxtype == "quel1se-riken8":
-            vatt = None
-            sideband = None
-        if box.boxtype == "quel1se-riken8" and port not in box.get_input_ports():
-            lo_freq_hz = None
+            port_info = box.dump_port(port)
+            if port_info == {}:
+                raise ValueError('No ports information provided.')
+            if not (port_info.get("direction") == "out" and "lo_freq" in port_info and "sideband" in port_info):
+                lo_freq_hz = None
+                vatt = None
+                sideband = None
         box.config_port(
             port=port,
             lo_freq=lo_freq_hz,

--- a/src/qubex/backend/quel1/managers/configuration_manager.py
+++ b/src/qubex/backend/quel1/managers/configuration_manager.py
@@ -80,8 +80,12 @@ class Quel1ConfigurationManager:
         if box.boxtype == "quel1se-riken8":
             port_info = box.dump_port(port)
             if port_info == {}:
-                raise ValueError('No ports information provided.')
-            if not (port_info.get("direction") == "out" and "lo_freq" in port_info and "sideband" in port_info):
+                raise ValueError("No ports information provided.")
+            if not (
+                port_info.get("direction") == "out"
+                and "lo_freq" in port_info
+                and "sideband" in port_info
+            ):
                 lo_freq_hz = None
                 vatt = None
                 sideband = None

--- a/src/qubex/backend/quel1/managers/configuration_manager.py
+++ b/src/qubex/backend/quel1/managers/configuration_manager.py
@@ -78,15 +78,11 @@ class Quel1ConfigurationManager:
             reconnect=True,
         )
         if box.boxtype == "quel1se-riken8":
-            port_info = box.dump_port(port)
-            if port_info == {}:
-                raise ValueError("No ports information provided.")
-            if not (
-                port_info.get("direction") == "out"
-                and "lo_freq" in port_info
-                and "sideband" in port_info
-            ):
+            QUEL1SE_R8_MIXER_PORTS = frozenset({1, 2})
+            input_ports = box.get_input_ports()
+            if port not in (set(input_ports) | QUEL1SE_R8_MIXER_PORTS):
                 lo_freq_hz = None
+            if port not in QUEL1SE_R8_MIXER_PORTS:
                 vatt = None
                 sideband = None
         box.config_port(

--- a/tests/backend/test_quel1_configuration_manager.py
+++ b/tests/backend/test_quel1_configuration_manager.py
@@ -1,0 +1,119 @@
+"""Tests for QuEL-1 configuration manager behavior."""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+import pytest
+
+from qubex.backend.quel1.managers.configuration_manager import Quel1ConfigurationManager
+from qubex.backend.quel1.quel1_runtime_context import Quel1RuntimeContext
+
+Port = int | tuple[int, int]
+
+
+class _FakeBox:
+    def __init__(
+        self,
+        *,
+        boxtype: str = "quel1se-riken8",
+        input_ports: tuple[Port, ...] = (),
+    ) -> None:
+        self.boxtype = boxtype
+        self._input_ports = input_ports
+        self.config_port_calls: list[dict[str, Any]] = []
+        self.dump_port_calls: list[Port] = []
+
+    def get_input_ports(self) -> tuple[Port, ...]:
+        """Return fixed input ports."""
+        return self._input_ports
+
+    def config_port(self, **kwargs: Any) -> None:
+        """Record config_port kwargs."""
+        self.config_port_calls.append(kwargs)
+
+    def dump_port(self, port: Port) -> dict[str, Any]:
+        """Record dump_port calls."""
+        self.dump_port_calls.append(port)
+        return {}
+
+
+class _BoxPoolStub:
+    def __init__(self, box: _FakeBox) -> None:
+        self._boxes = {"B0": (box,)}
+
+
+class _RuntimeContextStub:
+    is_connected = True
+
+    def __init__(self, box: _FakeBox) -> None:
+        self.boxpool = _BoxPoolStub(box)
+        self.validated_box_names: list[str] = []
+
+    def validate_box_availability(self, box_name: str) -> None:
+        """Record box availability checks."""
+        self.validated_box_names.append(box_name)
+
+
+def _configure_r8_port(
+    *,
+    port: Port,
+    input_ports: tuple[Port, ...] = (),
+) -> tuple[_RuntimeContextStub, _FakeBox]:
+    box = _FakeBox(input_ports=input_ports)
+    runtime_context = _RuntimeContextStub(box)
+    manager = Quel1ConfigurationManager(
+        runtime_context=cast(Quel1RuntimeContext, runtime_context)
+    )
+
+    manager.config_port(
+        box_name="B0",
+        port=port,
+        lo_freq_hz=5_000_000_000,
+        cnco_freq_hz=100_000_000,
+        vatt=2048,
+        sideband="U",
+        fullscale_current=16383,
+        rfswitch="pass",
+    )
+
+    return runtime_context, box
+
+
+@pytest.mark.parametrize(
+    (
+        "port",
+        "input_ports",
+        "expected_lo_freq",
+        "expected_vatt",
+        "expected_sideband",
+    ),
+    [
+        (1, (), 5_000_000_000, 2048, "U"),
+        (0, (0,), 5_000_000_000, None, None),
+        (3, (), None, None, None),
+    ],
+)
+def test_r8_config_port_filters_only_unsupported_mixer_fields(
+    port: Port,
+    input_ports: tuple[Port, ...],
+    expected_lo_freq: int | None,
+    expected_vatt: int | None,
+    expected_sideband: str | None,
+) -> None:
+    """Given R8 port traits, when configuring a port, then unsupported mixer fields are dropped."""
+    runtime_context, box = _configure_r8_port(port=port, input_ports=input_ports)
+
+    assert runtime_context.validated_box_names == ["B0"]
+    assert box.dump_port_calls == []
+    assert box.config_port_calls == [
+        {
+            "port": port,
+            "lo_freq": expected_lo_freq,
+            "cnco_freq": 100_000_000,
+            "vatt": expected_vatt,
+            "sideband": expected_sideband,
+            "fullscale_current": 16383,
+            "rfswitch": "pass",
+        }
+    ]

--- a/tests/experiment/test_experiment_facade_delegation.py
+++ b/tests/experiment/test_experiment_facade_delegation.py
@@ -793,6 +793,7 @@ def test_configure_delegates_to_session_service() -> None:
                 "box_ids": "Q2A",
                 "exclude": "Q00",
                 "mode": "ge-cr-cr",
+                "confirm": True,
             },
         )
     ]

--- a/tests/experiment/test_session_service.py
+++ b/tests/experiment/test_session_service.py
@@ -205,6 +205,7 @@ def test_configure_uses_system_manager_and_sync_hook(monkeypatch) -> None:
             {
                 "box_ids": ["Q2A"],
                 "target_labels": ["Q00", "RQ00"],
+                "confirm": True,
             },
         ),
     ]


### PR DESCRIPTION
Fixed a bug where vatt was not set correctly when configuring with `quel1se-riken8`.

`dump_port()` retrieves port information; lo, vatt, and sideband are set only for output ports where `lo_freq` and `sideband` exist. Otherwise, lo, vatt, and sideband are set to None.

Note: Since vatt cannot be retrieved when a new box object is created, vatt will appear to be unset in `print_box_info()`. This issue has not yet been addressed.