### PR TITLE
src: fix to preserve unmeasured port timing when updating skew waits

### DIFF
--- a/src/qubex/backend/quel1/managers/skew_manager.py
+++ b/src/qubex/backend/quel1/managers/skew_manager.py
@@ -126,19 +126,25 @@ class Quel1SkewManager:
             }
             updated_ports[box_name] = sorted(measured_ports)
             unmeasured_ports[box_name] = sorted(existing_ports - measured_ports)
-            adjusted_waits = {}
+            # Work with effective per-port waits so unmeasured ports keep their
+            # original timing even when we normalize common box wait.
+            effective_waits = {}
+            for port in existing_ports:
+                current_port_wait = port_wait[port]
+                self._validate_wait_value(current_port_wait, box_name=box_name)
+                effective_waits[port] = box_wait + current_port_wait
             for port, idx in estimated_ports:
                 current_port_wait = port_wait.get(port, 0)
                 self._validate_wait_value(current_port_wait, box_name=box_name)
-                adjusted_waits[port] = max(
+                effective_waits[port] = max(
                     self._WAIT_MIN,
                     box_wait + current_port_wait + (wait - idx),
                 )
 
-            common_wait = min(adjusted_waits.values())
+            common_wait = min(effective_waits.values())
             setting["wait"] = common_wait
-            for port, adjusted_wait in adjusted_waits.items():
-                port_wait[port] = adjusted_wait - common_wait
+            for port, effective_wait in effective_waits.items():
+                port_wait[port] = effective_wait - common_wait
 
         self._validate_wait_values(payload)
         with path.open("w", encoding="utf-8") as file:

--- a/tests/backend/test_quel1_skew_manager.py
+++ b/tests/backend/test_quel1_skew_manager.py
@@ -400,7 +400,7 @@ time_to_start: 0
     }
     assert payload["box_setting"]["A"]["port_wait"] == {1: 0}
     assert payload["box_setting"]["B"]["wait"] == 9
-    assert payload["box_setting"]["B"]["port_wait"] == {8: 7, 9: 0, 10: 7}
+    assert payload["box_setting"]["B"]["port_wait"] == {8: 7, 9: 0, 10: 3}
     assert backup_payload["box_setting"]["A"]["port_wait"] == {1: 0}
     assert backup_payload["box_setting"]["B"]["wait"] == 5
     assert backup_payload["box_setting"]["B"]["port_wait"] == {8: 1, 9: 4, 10: 7}

--- a/tests/experiment/test_experiment_facade_delegation.py
+++ b/tests/experiment/test_experiment_facade_delegation.py
@@ -793,6 +793,7 @@ def test_configure_delegates_to_session_service() -> None:
                 "box_ids": "Q2A",
                 "exclude": "Q00",
                 "mode": "ge-cr-cr",
+                "confirm": True,
             },
         )
     ]

--- a/tests/experiment/test_session_service.py
+++ b/tests/experiment/test_session_service.py
@@ -205,6 +205,7 @@ def test_configure_uses_system_manager_and_sync_hook(monkeypatch) -> None:
             {
                 "box_ids": ["Q2A"],
                 "target_labels": ["Q00", "RQ00"],
+                "confirm": True,
             },
         ),
     ]


### PR DESCRIPTION
skew の共通部分を wait: に押し込めるときのバグを見つけました。
全筐体で全ポート測定するときは大丈夫なのですが、一部のポートのみ測定しようとすると、
その測定したポートだけを使って新しい wait を作っていました。

そのため、測定していない既存ポートがある場合、そのポートの port_wait は再計算対象に含まれていませんでした。一方で box 全体の wait は更新されるため
box wait + port_wait
が意図せず変化してしまう、というバグです。

修正では、既存の全ポートについて実効 wait
box wait + port_wait
を計算しておき、測定済みポートだけに skew 補正を適用し、未測定ポートについては元の実効 wait をそのまま保持します。
最後に、その全ポート分の実効 wait をもとに box の wait と各 port_wait を再計算します。これで測定済みポートは補正されつつ、未測定ポートの実際の待ち時間は更新前と同じ値に保たれるようになります。

理研144Q で、筐体を分けながら skew 調整を行う必要があるときに、skew.yaml の測定対象ボートリストが完全でないときに出てきたバグでした。