### PR TITLE
Preserve output LO after QuEL-1 monitor sync

### DIFF
--- a/src/qubex/system/quel1/quel1_system_synchronizer.py
+++ b/src/qubex/system/quel1/quel1_system_synchronizer.py
@@ -122,10 +122,11 @@ class Quel1SystemSynchronizer:
     def sync_box_to_hardware(self, box: Box) -> None:
         """Apply one experiment-system box configuration to hardware."""
         for port in box.ports:
+            if self._is_capture_port(port):
+                self._sync_capture_port(box=box, port=port)
+        for port in box.ports:
             if self._is_generator_port(port):
                 self._sync_generator_port(box=box, port=port)
-            elif self._is_capture_port(port):
-                self._sync_capture_port(box=box, port=port)
 
     def sync_experiment_system_to_hardware(
         self,

--- a/tests/system/test_quel1_sideband_push_behavior.py
+++ b/tests/system/test_quel1_sideband_push_behavior.py
@@ -178,6 +178,61 @@ def test_sync_capture_port_passes_sideband_none_to_backend() -> None:
     assert read_in_call["sideband"] is None
 
 
+def test_sync_box_configures_capture_ports_before_generator_ports() -> None:
+    """Given QuEL-1 box sync, capture ports are configured before generator ports."""
+
+    class _BackendController:
+        def __init__(self) -> None:
+            self.config_port_calls: list[dict[str, Any]] = []
+            self.config_channel_calls: list[dict[str, Any]] = []
+            self.config_runit_calls: list[dict[str, Any]] = []
+
+        def config_port(self, **kwargs: Any) -> None:
+            self.config_port_calls.append(dict(kwargs))
+
+        def config_channel(self, **kwargs: Any) -> None:
+            self.config_channel_calls.append(dict(kwargs))
+
+        def config_runit(self, **kwargs: Any) -> None:
+            self.config_runit_calls.append(dict(kwargs))
+
+    backend_controller = _BackendController()
+    synchronizer = Quel1SystemSynchronizer(
+        backend_controller=cast(Any, backend_controller)
+    )
+    box = Box.new(
+        id="B0",
+        name="BOX0",
+        type="qube-riken-b",
+        address="127.0.0.1",
+        adapter="A0",
+        port_numbers=[2],
+    )
+    ctrl_port = box.get_port(2)
+    monitor_port = box.get_port(4)
+    assert isinstance(ctrl_port, GenPort)
+    assert isinstance(monitor_port, CapPort)
+
+    ctrl_port.lo_freq = 11_000_000_000
+    ctrl_port.cnco_freq = 2_179_687_500
+    ctrl_port.sideband = "L"
+    ctrl_port.vatt = None
+    ctrl_port.fullscale_current = None
+    ctrl_port.rfswitch = "pass"
+    ctrl_port.channels[0].fnco_freq = 0
+    monitor_port.lo_freq = 9_000_000_000
+    monitor_port.cnco_freq = 1_500_000_000
+    monitor_port.rfswitch = "open"
+    monitor_port.channels[0].fnco_freq = 0
+
+    synchronizer.sync_box_to_hardware(cast(Any, box))
+
+    config_port_order = [call["port"] for call in backend_controller.config_port_calls]
+    assert config_port_order.index(monitor_port.number) < config_port_order.index(
+        ctrl_port.number
+    )
+
+
 def test_sync_model_skips_clockmaster_for_single_box_without_address() -> None:
     """Given one QuEL-1 box without clock master, when syncing model, then clock master setup is skipped."""
 

--- a/tests/system/test_quel1_sideband_push_behavior.py
+++ b/tests/system/test_quel1_sideband_push_behavior.py
@@ -178,23 +178,22 @@ def test_sync_capture_port_passes_sideband_none_to_backend() -> None:
     assert read_in_call["sideband"] is None
 
 
-def test_sync_box_configures_capture_ports_before_generator_ports() -> None:
-    """Given QuEL-1 box sync, capture ports are configured before generator ports."""
+def test_sync_box_preserves_control_lo_for_shared_monitor_lo() -> None:
+    """Given shared monitor/control LO, when syncing, then control LO remains final."""
 
     class _BackendController:
         def __init__(self) -> None:
-            self.config_port_calls: list[dict[str, Any]] = []
-            self.config_channel_calls: list[dict[str, Any]] = []
-            self.config_runit_calls: list[dict[str, Any]] = []
+            self.shared_lo_freq_hz: int | None = None
 
         def config_port(self, **kwargs: Any) -> None:
-            self.config_port_calls.append(dict(kwargs))
+            if kwargs["port"] in {2, 4}:
+                self.shared_lo_freq_hz = kwargs["lo_freq_hz"]
 
-        def config_channel(self, **kwargs: Any) -> None:
-            self.config_channel_calls.append(dict(kwargs))
+        def config_channel(self, **_: Any) -> None:
+            return None
 
-        def config_runit(self, **kwargs: Any) -> None:
-            self.config_runit_calls.append(dict(kwargs))
+        def config_runit(self, **_: Any) -> None:
+            return None
 
     backend_controller = _BackendController()
     synchronizer = Quel1SystemSynchronizer(
@@ -224,13 +223,11 @@ def test_sync_box_configures_capture_ports_before_generator_ports() -> None:
     monitor_port.cnco_freq = 1_500_000_000
     monitor_port.rfswitch = "open"
     monitor_port.channels[0].fnco_freq = 0
+    assert monitor_port.lo_freq != ctrl_port.lo_freq
 
     synchronizer.sync_box_to_hardware(cast(Any, box))
 
-    config_port_order = [call["port"] for call in backend_controller.config_port_calls]
-    assert config_port_order.index(monitor_port.number) < config_port_order.index(
-        ctrl_port.number
-    )
+    assert backend_controller.shared_lo_freq_hz == ctrl_port.lo_freq
 
 
 def test_sync_model_skips_clockmaster_for_single_box_without_address() -> None:


### PR DESCRIPTION
## Summary
- Configure QuEL-1 capture ports before generator ports during full-box hardware synchronization.
- Prevent capture/monitor defaults from becoming the final hardware state for resources shared with generator ports.
- Add regression coverage for the full-box synchronization order.

## Verification
- `uv run pytest tests/system/test_quel1_sideband_push_behavior.py::test_sync_box_configures_capture_ports_before_generator_ports`
- `uv run pytest tests/system/test_quel1_sideband_push_behavior.py`
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`

## Compatibility
Runtime bugfix only. No public API or configuration format changes.