### PR TITLE
Require unit-qualified QuEL-3 runtime aliases

### DIFF
--- a/src/qubex/backend/quel3/managers/configuration_manager.py
+++ b/src/qubex/backend/quel3/managers/configuration_manager.py
@@ -39,6 +39,7 @@ from qubex.backend.quel3.models import InstrumentDeployRequest, RoleName
 from qubex.core.async_bridge import DEFAULT_TIMEOUT_SECONDS, get_shared_async_bridge
 
 T = TypeVar("T")
+TargetAliasKey = tuple[str, str]
 
 logger = logging.getLogger(__name__)
 
@@ -97,7 +98,7 @@ class _PortDeployResult:
     """Deployment result for one port batch."""
 
     deployed: dict[str, tuple[InstrumentInfoProtocol, ...]]
-    target_alias_map: dict[str, str]
+    target_alias_map: dict[TargetAliasKey, str]
 
 
 def _run_async(
@@ -131,7 +132,7 @@ class Quel3ConfigurationManager:
         self._last_deployed_instrument_infos: dict[
             str, tuple[InstrumentInfoProtocol, ...]
         ] = {}
-        self._target_alias_map: dict[str, str] = {}
+        self._target_alias_map: dict[TargetAliasKey, str] = {}
 
     @property
     def quelware_endpoint(self) -> str:
@@ -161,8 +162,8 @@ class Quel3ConfigurationManager:
         return dict(self._last_deployed_instrument_infos)
 
     @property
-    def target_alias_map(self) -> dict[str, str]:
-        """Return last deployed target-to-runtime-alias mapping."""
+    def target_alias_map(self) -> dict[TargetAliasKey, str]:
+        """Return last deployed box-and-target to runtime-alias mapping."""
         return dict(self._target_alias_map)
 
     def deploy_instruments(
@@ -204,9 +205,9 @@ class Quel3ConfigurationManager:
     ) -> None:
         """Restore instrument alias caches from normalized backend settings."""
         deployed: dict[str, tuple[InstrumentInfoProtocol, ...]] = {}
-        target_alias_map: dict[str, str] = {}
+        target_alias_map: dict[TargetAliasKey, str] = {}
 
-        for box_config in backend_settings.values():
+        for box_id, box_config in backend_settings.items():
             instruments = box_config.get("instruments")
             if not isinstance(instruments, dict):
                 continue
@@ -225,6 +226,10 @@ class Quel3ConfigurationManager:
                     role=role,
                     definition_config=instrument_config.get("definition"),
                 )
+                local_alias, runtime_alias = self._split_alias_for_port(
+                    alias=definition.alias,
+                    port_id=port_id,
+                )
                 deployed[alias] = (
                     _CachedInstrumentInfo(
                         id=resource_id,
@@ -232,7 +237,7 @@ class Quel3ConfigurationManager:
                         definition=definition,
                     ),
                 )
-                target_alias_map[alias] = definition.alias
+                target_alias_map[(box_id, local_alias)] = runtime_alias
 
         self._last_deployed_instrument_infos = deployed
         self._target_alias_map = target_alias_map
@@ -253,7 +258,7 @@ class Quel3ConfigurationManager:
         instrument_entities = self._load_instrument_entities()
 
         deployed: dict[str, tuple[InstrumentInfoProtocol, ...]] = {}
-        target_alias_map: dict[str, str] = {}
+        target_alias_map: dict[TargetAliasKey, str] = {}
         requests_by_port: dict[str, list[InstrumentDeployRequest]] = defaultdict(list)
         for request in requests:
             requests_by_port[request.port_id].append(request)
@@ -403,7 +408,7 @@ class Quel3ConfigurationManager:
             instrument_infos_by_alias[local_alias].append(instrument_info)
 
         deployed: dict[str, tuple[InstrumentInfoProtocol, ...]] = {}
-        target_alias_map: dict[str, str] = {}
+        target_alias_map: dict[TargetAliasKey, str] = {}
         for request in port_requests:
             matched_instrument_infos = tuple(
                 instrument_infos_by_alias.get(request.alias, ())
@@ -418,7 +423,7 @@ class Quel3ConfigurationManager:
                 fallback_alias=request.alias,
             )
             for target_label in request.target_labels:
-                target_alias_map[target_label] = runtime_alias
+                target_alias_map[(request.box_id, target_label)] = runtime_alias
         return _PortDeployResult(
             deployed=deployed,
             target_alias_map=target_alias_map,
@@ -440,20 +445,18 @@ class Quel3ConfigurationManager:
             )
 
         deployed: dict[str, tuple[InstrumentInfoProtocol, ...]] = {}
-        target_alias_map: dict[str, str] = {}
         for instrument_info in instrument_infos:
             alias = instrument_info.definition.alias
             if len(alias.strip()) == 0:
                 continue
-            local_alias, runtime_alias = self._split_alias_for_port(
+            local_alias, _runtime_alias = self._split_alias_for_port(
                 alias=alias,
                 port_id=instrument_info.port_id,
             )
             deployed[local_alias] = (instrument_info,)
-            target_alias_map[local_alias] = runtime_alias
 
         self._last_deployed_instrument_infos = deployed
-        self._target_alias_map = target_alias_map
+        self._target_alias_map = {}
         return dict(deployed)
 
     async def _fetch_backend_settings_from_hardware(
@@ -583,13 +586,24 @@ class Quel3ConfigurationManager:
     @classmethod
     def _split_alias_for_port(cls, *, alias: str, port_id: str) -> tuple[str, str]:
         """Return local and runtime aliases for one instrument on a port."""
-        runtime_alias = alias.strip()
+        runtime_alias = cls._runtime_alias_for_port(alias=alias, port_id=port_id)
         unit_label = cls._extract_unit_label(str(port_id))
         local_alias = cls._strip_unit_label_prefix(
             alias=runtime_alias,
             unit_label=unit_label,
         )
         return local_alias, runtime_alias
+
+    @classmethod
+    def _runtime_alias_for_port(cls, *, alias: str, port_id: str) -> str:
+        """Return unit-qualified runtime alias for one port-local alias."""
+        stripped_alias = alias.strip()
+        if len(stripped_alias) == 0 or ":" not in str(port_id):
+            return stripped_alias
+        unit_label = cls._extract_unit_label(str(port_id))
+        if stripped_alias.startswith(f"{unit_label}:") or ":" in stripped_alias:
+            return stripped_alias
+        return f"{unit_label}:{stripped_alias}"
 
     @staticmethod
     def _strip_unit_label_prefix(*, alias: str, unit_label: str) -> str:
@@ -607,9 +621,12 @@ class Quel3ConfigurationManager:
     ) -> str:
         """Return the runtime alias stored on one quelware instrument info."""
         alias = instrument_info.definition.alias.strip()
-        if len(alias) > 0:
-            return alias
-        return fallback_alias
+        if len(alias) == 0:
+            alias = fallback_alias
+        return Quel3ConfigurationManager._runtime_alias_for_port(
+            alias=alias,
+            port_id=str(instrument_info.port_id),
+        )
 
     @staticmethod
     def _normalize_role_name(role: object) -> str:

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -389,10 +389,7 @@ class Quel3ExecutionManager:
             )
         ]
         for payload in payloads[1:]:
-            resolved_payload = self._resolve_payload(
-                payload=payload,
-                resolver=runtime.resolver,
-            )
+            resolved_payload = self._resolve_payload(payload=payload)
             resolved_payload = self._filter_runnable_payload(resolved_payload)
             resolved_aliases = tuple(sorted(resolved_payload.fixed_timelines))
             if resolved_aliases != expected_aliases:
@@ -421,14 +418,16 @@ class Quel3ExecutionManager:
         resolver = quelware_api.instrument_resolver_factory()
         await resolver.refresh(self._session_manager.client)
 
-        resolved_payload = self._resolve_payload(
-            payload=payload,
-            resolver=resolver,
-        )
+        resolved_payload = self._resolve_payload(payload=payload)
         resolved_payload = self._filter_runnable_payload(resolved_payload)
         aliases = sorted(resolved_payload.fixed_timelines.keys())
+        alias_to_instrument_info = self._resolve_alias_to_instrument_info_map(
+            resolver=resolver,
+            aliases=aliases,
+        )
         alias_to_resource_id = self._resolve_alias_to_resource_id_map(
             resolver=resolver,
+            alias_to_instrument_info=alias_to_instrument_info,
             aliases=aliases,
         )
         instrument_resource_ids = [alias_to_resource_id[alias] for alias in aliases]
@@ -441,10 +440,7 @@ class Quel3ExecutionManager:
         alias_to_driver: dict[str, InstrumentDriverProtocol] = {}
         capture_sampling_period_ns: float | None = None
         for alias in aliases:
-            instrument_info = self._find_instrument_info_by_alias(
-                resolver=resolver,
-                alias=alias,
-            )
+            instrument_info = alias_to_instrument_info[alias]
             driver = quelware_api.fixed_timeline_driver_factory(
                 session,
                 instrument_info,
@@ -646,20 +642,33 @@ class Quel3ExecutionManager:
         return alias_results
 
     @classmethod
-    def _resolve_alias_to_resource_id_map(
+    def _resolve_alias_to_instrument_info_map(
         cls,
         *,
         resolver: InstrumentResolverProtocol,
         aliases: list[str],
-    ) -> dict[str, ResourceIdProtocol]:
-        """Resolve alias-to-resource-id mapping using InstrumentResolver."""
-        alias_to_resource_id: dict[str, ResourceIdProtocol] = {}
-        aliases_without_resource_id: list[str] = []
-        for alias in aliases:
-            instrument_info = cls._find_instrument_info_by_alias(
+    ) -> dict[str, InstrumentInfoProtocol]:
+        """Resolve instrument infos by runtime alias using InstrumentResolver."""
+        return {
+            alias: cls._find_instrument_info_by_alias(
                 resolver=resolver,
                 alias=alias,
             )
+            for alias in aliases
+        }
+
+    @staticmethod
+    def _resolve_alias_to_resource_id_map(
+        *,
+        resolver: InstrumentResolverProtocol,
+        alias_to_instrument_info: dict[str, InstrumentInfoProtocol],
+        aliases: list[str],
+    ) -> dict[str, ResourceIdProtocol]:
+        """Resolve alias-to-resource-id mapping from resolved instrument infos."""
+        alias_to_resource_id: dict[str, ResourceIdProtocol] = {}
+        aliases_without_resource_id: list[str] = []
+        for alias in aliases:
+            instrument_info = alias_to_instrument_info[alias]
             resource_id = getattr(instrument_info, "id", None)
             if isinstance(resource_id, str) and len(resource_id) > 0:
                 alias_to_resource_id[alias] = resource_id
@@ -684,14 +693,9 @@ class Quel3ExecutionManager:
         cls,
         *,
         payload: Quel3ExecutionPayload,
-        resolver: InstrumentResolverProtocol,
     ) -> Quel3ExecutionPayload:
         """Resolve timeline bindings to concrete instrument aliases."""
-        bindings = (
-            payload.instrument_bindings
-            if len(payload.instrument_bindings) > 0
-            else {key: f"alias:{key}" for key in payload.fixed_timelines}
-        )
+        bindings = payload.instrument_bindings
 
         alias_to_events: dict[str, list[tuple[int, Quel3WaveformEvent]]] = defaultdict(
             list
@@ -706,18 +710,14 @@ class Quel3ExecutionManager:
 
         for target, timeline in payload.fixed_timelines.items():
             binding = bindings.get(target)
-            if binding is None:
+            if binding is None and len(bindings) > 0:
                 raise ValueError(
                     f"Instrument binding is not configured for target `{target}`."
                 )
-            capture_port_binding = payload.capture_port_bindings.get(target)
-            alias = cls._resolve_alias_from_binding(
-                target=target,
-                resolver=resolver,
-                binding=binding,
-                capture_port_binding=capture_port_binding,
-                has_events=len(timeline.events) > 0,
-                has_captures=len(timeline.capture_windows) > 0,
+            alias = (
+                target
+                if binding is None
+                else cls._resolve_alias_from_binding(binding=binding)
             )
             alias_to_length_ns[alias] = max(
                 alias_to_length_ns.get(alias, 0.0),
@@ -810,32 +810,19 @@ class Quel3ExecutionManager:
     def _resolve_alias_from_binding(
         cls,
         *,
-        target: str,
-        resolver: InstrumentResolverProtocol,
         binding: str,
-        capture_port_binding: str | None,
-        has_events: bool,
-        has_captures: bool,
     ) -> str:
         """Resolve one target binding to one instrument alias with fail-fast rules."""
-        del target, capture_port_binding, has_events, has_captures
         if binding.startswith("alias:"):
             alias = binding.removeprefix("alias:").strip()
             if len(alias) == 0:
                 raise ValueError("Empty alias binding is not allowed.")
-            try:
-                instrument_info = cls._find_instrument_info_by_alias(
-                    resolver=resolver,
-                    alias=alias,
-                )
-            except ValueError as exc:
+            _local_alias, unit_label = cls._split_unit_qualified_alias(alias)
+            if unit_label is None:
                 raise ValueError(
-                    f"Instrument alias `{alias}` could not be resolved."
-                ) from exc
-            return cls._runtime_alias_from_instrument_info(
-                instrument_info=instrument_info,
-                fallback_alias=alias,
-            )
+                    f"QuEL-3 alias binding must include a unit label: `{binding}`."
+                )
+            return alias
         raise ValueError(f"Unsupported instrument binding: `{binding}`.")
 
     @classmethod
@@ -848,13 +835,10 @@ class Quel3ExecutionManager:
         """Find one instrument info, passing unit when the alias is unit-qualified."""
         local_alias, alias_unit_label = cls._split_unit_qualified_alias(alias)
         if alias_unit_label is not None:
-            try:
-                return resolver.find_inst_info_by_alias(
-                    local_alias,
-                    unit=alias_unit_label,
-                )
-            except TypeError:
-                return resolver.find_inst_info_by_alias(alias)
+            return resolver.find_inst_info_by_alias(
+                local_alias,
+                unit=alias_unit_label,
+            )
         return resolver.find_inst_info_by_alias(alias)
 
     @staticmethod
@@ -865,19 +849,6 @@ class Quel3ExecutionManager:
         if separator and len(unit_label) > 0 and len(local_alias) > 0:
             return local_alias, unit_label
         return stripped_alias, None
-
-    @staticmethod
-    def _runtime_alias_from_instrument_info(
-        *,
-        instrument_info: InstrumentInfoProtocol,
-        fallback_alias: str,
-    ) -> str:
-        """Return the runtime alias stored on one runtime instrument info."""
-        definition = getattr(instrument_info, "definition", None)
-        alias = getattr(definition, "alias", None)
-        if isinstance(alias, str) and len(alias.strip()) > 0:
-            return alias.strip()
-        return fallback_alias
 
     @staticmethod
     def _initialize_shot_samples(

--- a/src/qubex/backend/quel3/models/deploy.py
+++ b/src/qubex/backend/quel3/models/deploy.py
@@ -18,3 +18,4 @@ class InstrumentDeployRequest:
     frequency_range_max_hz: float
     alias: str
     target_labels: tuple[str, ...]
+    box_id: str

--- a/src/qubex/backend/quel3/quel3_backend_controller.py
+++ b/src/qubex/backend/quel3/quel3_backend_controller.py
@@ -308,8 +308,8 @@ class Quel3BackendController(BackendController):
         return self._execution_manager
 
     @property
-    def target_alias_map(self) -> dict[str, str]:
-        """Return deployed target-to-runtime-alias mapping from backend runtime state."""
+    def target_alias_map(self) -> dict[tuple[str, str], str]:
+        """Return deployed box-and-target to runtime-alias mapping."""
         return self._configuration_manager.target_alias_map
 
     @property

--- a/src/qubex/measurement/adapters/quel3_backend_adapter.py
+++ b/src/qubex/measurement/adapters/quel3_backend_adapter.py
@@ -36,6 +36,8 @@ from qubex.system.target_type import TargetType
 
 from ._capture_shape import normalize_shot_averaged_capture_array
 
+InstrumentAliasMap = Mapping[tuple[str, str], str]
+
 
 def _as_read_only_array(data: object) -> np.ndarray:
     """Return read-only NumPy array view for capture payloads."""
@@ -53,7 +55,7 @@ class Quel3MeasurementBackendAdapter:
         backend_controller: Quel3BackendController,
         experiment_system: ExperimentSystem,
         constraint_profile: MeasurementConstraintProfile | None = None,
-        instrument_alias_map: Mapping[str, str] | None = None,
+        instrument_alias_map: InstrumentAliasMap | None = None,
     ) -> None:
         self._backend_controller = backend_controller
         self._experiment_system = experiment_system
@@ -67,15 +69,15 @@ class Quel3MeasurementBackendAdapter:
         self._constraint_profile = constraint_profile
 
     @property
-    def instrument_alias_map(self) -> Mapping[str, str]:
+    def instrument_alias_map(self) -> InstrumentAliasMap:
         """Return configured target-to-instrument alias mapping."""
         return self._instrument_alias_map
 
-    def set_instrument_alias_map(self, alias_map: Mapping[str, str]) -> None:
+    def set_instrument_alias_map(self, alias_map: InstrumentAliasMap) -> None:
         """Replace full target-to-alias mapping in adapter layer."""
         self._instrument_alias_map = dict(alias_map)
 
-    def update_instrument_alias_map(self, alias_map: Mapping[str, str]) -> None:
+    def update_instrument_alias_map(self, alias_map: InstrumentAliasMap) -> None:
         """Update target-to-alias mapping entries in adapter layer."""
         self._instrument_alias_map.update(alias_map)
 
@@ -117,7 +119,9 @@ class Quel3MeasurementBackendAdapter:
         alias_map = self._instrument_alias_map
 
         for target in pulse_schedule.labels:
-            configured_alias = str(alias_map.get(target, "")).strip()
+            target_info = self._experiment_system.get_target(target)
+            box_id = str(target_info.channel.port.box_id).strip()
+            configured_alias = str(alias_map.get((box_id, target), "")).strip()
             if len(configured_alias) == 0:
                 raise ValueError(
                     "Missing QuEL-3 instrument alias mapping for "
@@ -126,7 +130,7 @@ class Quel3MeasurementBackendAdapter:
             instrument_bindings[target] = f"alias:{configured_alias}"
 
             sequence = pulse_schedule.get_sequence(target, copy=False)
-            target_type = self._experiment_system.get_target(target).type
+            target_type = target_info.type
             events, waveform_index = self._create_waveform_events(
                 target_is_read=(target_type is TargetType.READ),
                 sequence=sequence,

--- a/src/qubex/system/quel3/quel3_target_deploy_planner.py
+++ b/src/qubex/system/quel3/quel3_target_deploy_planner.py
@@ -78,6 +78,7 @@ class Quel3TargetDeployPlanner:
                     frequency_range_max_hz=freq_max,
                     alias=alias,
                     target_labels=(target.label,),
+                    box_id=port.box_id,
                 )
             )
         return tuple(requests)

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -389,7 +389,7 @@ def test_constructor_accepts_injected_managers() -> None:
         quelware_port=61000,
         client_mode="server",
         quelware_pat_path="/run/secrets/quelware-pat",
-        target_alias_map={"Q00": "Q00"},
+        target_alias_map={("BOX1", "Q00"): "Q00"},
         last_deployed_instrument_infos={"Q00": (object(),)},
         deploy_instruments=lambda *, requests: {"Q00": tuple(requests)},
     )
@@ -582,29 +582,20 @@ def test_resolve_payload_merges_targets_mapped_to_one_alias() -> None:
             "RQ01": payload.fixed_timelines["alias-rq00"],
         },
         instrument_bindings={
-            "RQ00": "alias:alias-shared",
-            "RQ01": "alias:alias-shared",
+            "RQ00": "alias:unit-a:alias-shared",
+            "RQ01": "alias:unit-a:alias-shared",
         },
-    )
-    resolver = _FakeInstrumentResolver(
-        alias_to_info={
-            "alias-shared": _FakeInstrumentInfo(
-                port_id="unit-a:trx_p00",
-                definition=_FakeInstrumentDefinition(role="TRANSCEIVER"),
-            )
-        }
     )
 
     resolved = Quel3ExecutionManager._resolve_payload(
         payload=payload,
-        resolver=cast(Any, resolver),
     )
 
-    assert set(resolved.fixed_timelines.keys()) == {"alias-shared"}
-    timeline = resolved.fixed_timelines["alias-shared"]
+    assert set(resolved.fixed_timelines.keys()) == {"unit-a:alias-shared"}
+    timeline = resolved.fixed_timelines["unit-a:alias-shared"]
     assert [window.name for window in timeline.capture_windows] == [
-        "alias-shared:0",
-        "alias-shared:1",
+        "unit-a:alias-shared:0",
+        "unit-a:alias-shared:1",
     ]
     assert timeline.frequency_hz == pytest.approx(6.2e9)
 
@@ -620,23 +611,14 @@ def test_resolve_payload_rejects_conflicting_frequencies_for_shared_alias() -> N
             "RQ01": replace(base_timeline, frequency_hz=6.1e9),
         },
         instrument_bindings={
-            "RQ00": "alias:alias-shared",
-            "RQ01": "alias:alias-shared",
+            "RQ00": "alias:unit-a:alias-shared",
+            "RQ01": "alias:unit-a:alias-shared",
         },
-    )
-    resolver = _FakeInstrumentResolver(
-        alias_to_info={
-            "alias-shared": _FakeInstrumentInfo(
-                port_id="unit-a:trx_p00",
-                definition=_FakeInstrumentDefinition(role="TRANSCEIVER"),
-            )
-        }
     )
 
     with pytest.raises(ValueError, match="Conflicting frequency"):
         Quel3ExecutionManager._resolve_payload(
             payload=payload,
-            resolver=cast(Any, resolver),
         )
 
 
@@ -687,38 +669,24 @@ def test_resolve_payload_rejects_port_binding() -> None:
         instrument_bindings={"RQ00": "port:unit-a-0"},
         capture_port_bindings={"RQ00": "unit-a-0"},
     )
-    resolver = _FakeInstrumentResolver(alias_to_info={})
 
     with pytest.raises(ValueError, match="Unsupported instrument binding"):
         Quel3ExecutionManager._resolve_payload(
             payload=payload,
-            resolver=cast(Any, resolver),
         )
 
 
-def test_resolve_payload_accepts_alias_binding() -> None:
-    """Given alias binding, resolving payload keeps the resolved alias."""
+def test_resolve_payload_rejects_unqualified_alias_binding() -> None:
+    """Given unqualified alias binding, resolving payload should fail fast."""
     payload = _make_payload()
     payload = replace(
         payload,
         fixed_timelines={"Q00": payload.fixed_timelines["alias-rq00"]},
         instrument_bindings={"Q00": "alias:inst-q00"},
     )
-    resolver = _FakeInstrumentResolver(
-        alias_to_info={
-            "inst-q00": _FakeInstrumentInfo(
-                port_id="quel3-02-a01:tx_p04",
-                definition=_FakeInstrumentDefinition(role="TRANSMITTER"),
-            )
-        }
-    )
 
-    resolved = Quel3ExecutionManager._resolve_payload(
-        payload=payload,
-        resolver=cast(Any, resolver),
-    )
-
-    assert set(resolved.fixed_timelines.keys()) == {"inst-q00"}
+    with pytest.raises(ValueError, match="unit label"):
+        Quel3ExecutionManager._resolve_payload(payload=payload)
 
 
 def test_execute_resolves_unit_prefixed_alias_binding(
@@ -772,7 +740,7 @@ def test_execute_resolves_unit_prefixed_alias_binding(
                 id="inst-q00",
                 port_id="quel3-02-a01:tx_p04",
                 definition=_Definition(
-                    alias="quel3-02-a01:Q00",
+                    alias="Q00",
                     role="TRANSMITTER",
                 ),
             )
@@ -796,11 +764,7 @@ def test_execute_resolves_unit_prefixed_alias_binding(
         manager.execute_async(request=BackendExecutionRequest(payload=payload))
     )
 
-    assert resolver.find_calls == [
-        ("Q00", "quel3-02-a01"),
-        ("Q00", "quel3-02-a01"),
-        ("Q00", "quel3-02-a01"),
-    ]
+    assert resolver.find_calls == [("Q00", "quel3-02-a01")]
     assert driver.apply_calls == [
         [
             ("capture_mode", _FakeCaptureMode.AVERAGED_VALUE),

--- a/tests/backend/test_quel3_configuration_manager.py
+++ b/tests/backend/test_quel3_configuration_manager.py
@@ -162,6 +162,7 @@ def test_deploy_instruments_calls_session_api(
         frequency_range_max_hz=4.3e9,
         alias="Q00",
         target_labels=("Q00",),
+        box_id="BOX1",
     )
 
     deployed = manager.deploy_instruments(requests=(request,))
@@ -176,7 +177,7 @@ def test_deploy_instruments_calls_session_api(
     assert definition.profile.frequency_range_min == pytest.approx(4.1e9)
     assert definition.profile.frequency_range_max == pytest.approx(4.3e9)
     assert definition.alias == "Q00"
-    assert manager.target_alias_map == {"Q00": definition.alias}
+    assert manager.target_alias_map == {("BOX1", "Q00"): "quel3-02-a01:Q00"}
     assert definition.alias in deployed
 
 
@@ -319,6 +320,7 @@ def test_deploy_instruments_recreates_session_after_transient_request_failure(
         frequency_range_max_hz=4.3e9,
         alias="Q00",
         target_labels=("Q00",),
+        box_id="BOX1",
     )
 
     deployed = manager.deploy_instruments(requests=(request,))
@@ -452,6 +454,7 @@ def test_deploy_instruments_ignores_session_close_failure_after_success(
         frequency_range_max_hz=4.3e9,
         alias="Q00",
         target_labels=("Q00",),
+        box_id="BOX1",
     )
 
     deployed = manager.deploy_instruments(requests=(request,))
@@ -567,6 +570,7 @@ def test_deploy_instruments_wraps_final_request_failure(
         frequency_range_max_hz=4.3e9,
         alias="Q00",
         target_labels=("Q00",),
+        box_id="BOX1",
     )
 
     with pytest.raises(
@@ -712,6 +716,7 @@ def test_deploy_instruments_retries_resource_allocation_on_session_create(
         frequency_range_max_hz=4.3e9,
         alias="Q00",
         target_labels=("Q00",),
+        box_id="BOX1",
     )
 
     deployed = manager.deploy_instruments(requests=(request,))
@@ -829,6 +834,7 @@ def test_deploy_instruments_accepts_unit_prefixed_returned_alias(
         frequency_range_max_hz=4.3e9,
         alias="Q00",
         target_labels=("Q00",),
+        box_id="BOX1",
     )
 
     deployed = manager.deploy_instruments(requests=(request,))
@@ -836,7 +842,7 @@ def test_deploy_instruments_accepts_unit_prefixed_returned_alias(
     assert [definition.alias for definition in deploy_definitions] == ["Q00"]
     assert set(deployed) == {"Q00"}
     assert deployed["Q00"][0].definition.alias == "quel3-02-a01:Q00"
-    assert manager.target_alias_map == {"Q00": "quel3-02-a01:Q00"}
+    assert manager.target_alias_map == {("BOX1", "Q00"): "quel3-02-a01:Q00"}
 
 
 def test_deploy_instruments_clears_cache_for_empty_requests() -> None:
@@ -852,6 +858,7 @@ def test_deploy_instruments_clears_cache_for_empty_requests() -> None:
         frequency_range_max_hz=4.3e9,
         alias="Q00",
         target_labels=("Q00",),
+        box_id="BOX1",
     )
     manager._last_deployed_instrument_infos = {  # noqa: SLF001
         request.alias: (
@@ -862,7 +869,7 @@ def test_deploy_instruments_clears_cache_for_empty_requests() -> None:
             ),
         )
     }
-    manager._target_alias_map = {"Q00": request.alias}  # noqa: SLF001
+    manager._target_alias_map = {("BOX1", "Q00"): request.alias}  # noqa: SLF001
 
     deployed = manager.deploy_instruments(requests=())
 
@@ -972,6 +979,7 @@ def test_deploy_instruments_groups_requests_by_port(
             frequency_range_max_hz=4.3e9,
             alias="Q00",
             target_labels=("Q00",),
+            box_id="BOX1",
         ),
         InstrumentDeployRequest(
             port_id="quel3-02-a01:tx_p04",
@@ -980,6 +988,7 @@ def test_deploy_instruments_groups_requests_by_port(
             frequency_range_max_hz=4.4e9,
             alias="Q00-CR",
             target_labels=("Q00-CR",),
+            box_id="BOX1",
         ),
     )
 
@@ -994,8 +1003,8 @@ def test_deploy_instruments_groups_requests_by_port(
         "Q00-CR",
     ]
     assert manager.target_alias_map == {
-        "Q00": "Q00",
-        "Q00-CR": "Q00-CR",
+        ("BOX1", "Q00"): "quel3-02-a01:Q00",
+        ("BOX1", "Q00-CR"): "quel3-02-a01:Q00-CR",
     }
     assert set(deployed) == {"Q00", "Q00-CR"}
     assert deployed["Q00"][0].id == "id:quel3-02-a01:tx_p04:0"
@@ -1103,6 +1112,7 @@ def test_deploy_instruments_uses_one_session_for_all_ports(
             frequency_range_max_hz=4.3e9,
             alias="Q00",
             target_labels=("Q00",),
+            box_id="BOX1",
         ),
         InstrumentDeployRequest(
             port_id="quel3-02-a01:tx_p06",
@@ -1111,6 +1121,7 @@ def test_deploy_instruments_uses_one_session_for_all_ports(
             frequency_range_max_hz=4.4e9,
             alias="Q01",
             target_labels=("Q01",),
+            box_id="BOX1",
         ),
     )
 
@@ -1232,6 +1243,7 @@ def test_deploy_instruments_parallelizes_ports_by_default(
                 frequency_range_max_hz=4.3e9,
                 alias="Q00",
                 target_labels=("Q00",),
+                box_id="BOX1",
             ),
             InstrumentDeployRequest(
                 port_id="quel3-02-a01:tx_p06",
@@ -1240,6 +1252,7 @@ def test_deploy_instruments_parallelizes_ports_by_default(
                 frequency_range_max_hz=4.4e9,
                 alias="Q01",
                 target_labels=("Q01",),
+                box_id="BOX1",
             ),
         )
     )
@@ -1356,6 +1369,7 @@ def test_deploy_instruments_parallel_false_serializes_ports(
                 frequency_range_max_hz=4.3e9,
                 alias="Q00",
                 target_labels=("Q00",),
+                box_id="BOX1",
             ),
             InstrumentDeployRequest(
                 port_id="quel3-02-a01:tx_p06",
@@ -1364,6 +1378,7 @@ def test_deploy_instruments_parallel_false_serializes_ports(
                 frequency_range_max_hz=4.4e9,
                 alias="Q01",
                 target_labels=("Q01",),
+                box_id="BOX1",
             ),
         ),
         parallel=False,
@@ -1500,7 +1515,7 @@ def test_refresh_instrument_cache_loads_existing_instruments(
     cached = manager.refresh_instrument_cache()
 
     assert set(cached.keys()) == {"Q00", "RQ00"}
-    assert manager.target_alias_map == {"Q00": "Q00", "RQ00": "RQ00"}
+    assert manager.target_alias_map == {}
     assert set(manager.last_deployed_instrument_infos.keys()) == {"Q00", "RQ00"}
 
 
@@ -1558,7 +1573,7 @@ def test_refresh_instrument_cache_maps_unit_prefixed_aliases(
     cached = manager.refresh_instrument_cache()
 
     assert set(cached) == {"Q00"}
-    assert manager.target_alias_map == {"Q00": "quel3-02-a01:Q00"}
+    assert manager.target_alias_map == {}
     assert manager.last_deployed_instrument_infos["Q00"][0].definition.alias == (
         "quel3-02-a01:Q00"
     )
@@ -1865,7 +1880,10 @@ def test_sync_backend_settings_to_cache_restores_alias_mapping_from_snapshot() -
         }
     )
 
-    assert manager.target_alias_map == {"Q00": "Q00", "RQ00": "RQ00"}
+    assert manager.target_alias_map == {
+        ("BOX1", "Q00"): "quel3-02-a01:Q00",
+        ("BOX2", "RQ00"): "quel3-02-a02:RQ00",
+    }
     assert manager.last_deployed_instrument_infos["Q00"][0].id == "inst-q00"
     assert (
         manager.last_deployed_instrument_infos["Q00"][0].port_id
@@ -1991,6 +2009,7 @@ def test_deploy_instruments_replaces_cached_alias(
                 frequency_range_max_hz=4.3e9,
                 alias="Q00",
                 target_labels=("Q00",),
+                box_id="BOX1",
             ),
         )
     )
@@ -1998,7 +2017,7 @@ def test_deploy_instruments_replaces_cached_alias(
     assert len(deploy_calls) == 1
     assert deploy_calls[0][2] is False
     assert deployed == {"Q00": (returned_info,)}
-    assert manager.target_alias_map == {"Q00": "Q00"}
+    assert manager.target_alias_map == {("BOX1", "Q00"): "quel3-02-a01:Q00"}
 
 
 def test_deploy_instruments_replaces_cached_port_in_one_batched_deploy(
@@ -2118,6 +2137,7 @@ def test_deploy_instruments_replaces_cached_port_in_one_batched_deploy(
                 frequency_range_max_hz=4.3e9,
                 alias="Q00",
                 target_labels=("Q00",),
+                box_id="BOX1",
             ),
             InstrumentDeployRequest(
                 port_id="quel3-02-a01:tx_p04",
@@ -2126,6 +2146,7 @@ def test_deploy_instruments_replaces_cached_port_in_one_batched_deploy(
                 frequency_range_max_hz=4.4e9,
                 alias="Q00-CR",
                 target_labels=("Q00-CR",),
+                box_id="BOX1",
             ),
         )
     )

--- a/tests/measurement/test_measurement_api_delegation.py
+++ b/tests/measurement/test_measurement_api_delegation.py
@@ -1690,7 +1690,7 @@ def test_run_measurement_selects_quel3_adapter_from_controller_type(
         box_config: ClassVar[dict[str, str]] = {"kind": "quel3"}
         sampling_period_ns: ClassVar[float] = 0.4
         CAPTURE_DECIMATION_FACTOR: ClassVar[int] = 4
-        target_alias_map: ClassVar[dict[str, str]] = {}
+        target_alias_map: ClassVar[dict[tuple[str, str], str]] = {}
 
         async def execute_async(
             self,

--- a/tests/measurement/test_measurement_schedule_runner.py
+++ b/tests/measurement/test_measurement_schedule_runner.py
@@ -716,7 +716,7 @@ def test_init_uses_quel3_adapter_when_backend_controller_is_quel3(
             backend_controller: object,
             experiment_system: object,
             constraint_profile: MeasurementConstraintProfile,
-            instrument_alias_map: dict[str, str],
+            instrument_alias_map: dict[tuple[str, str], str],
         ) -> None:
             called["adapter_backend_controller"] = backend_controller
             called["adapter_experiment_system"] = experiment_system
@@ -737,7 +737,9 @@ def test_init_uses_quel3_adapter_when_backend_controller_is_quel3(
 
     class _Quel3Controller:
         sampling_period_ns: ClassVar[float] = 0.4
-        target_alias_map: ClassVar[dict[str, str]] = {"Q00": "Q00"}
+        target_alias_map: ClassVar[dict[tuple[str, str], str]] = {
+            ("BOX1", "Q00"): "quel3-02-a01:Q00"
+        }
 
     monkeypatch.setattr(
         "qubex.measurement.measurement_schedule_runner.Quel3BackendController",
@@ -755,7 +757,7 @@ def test_init_uses_quel3_adapter_when_backend_controller_is_quel3(
     assert isinstance(runner, MeasurementScheduleRunner)
     assert called["adapter_backend_controller"] is backend_controller
     assert called["adapter_experiment_system"] is experiment_system
-    assert called["instrument_alias_map"] == {"Q00": "Q00"}
+    assert called["instrument_alias_map"] == {("BOX1", "Q00"): "quel3-02-a01:Q00"}
     profile = cast(MeasurementConstraintProfile, called["adapter_constraint_profile"])
     assert profile.sampling_period_ns == 0.4
     assert profile.enforce_block_alignment is False

--- a/tests/measurement/test_quel3_measurement_backend_adapter.py
+++ b/tests/measurement/test_quel3_measurement_backend_adapter.py
@@ -156,6 +156,24 @@ def _make_config(
     )
 
 
+def _runtime_alias(alias: str, *, unit_label: str = "box") -> str:
+    """Build one unit-qualified QuEL-3 runtime alias."""
+    return f"{unit_label}:{alias}"
+
+
+def _alias_map(
+    entries: dict[str, str],
+    *,
+    box_id: str = "BOX",
+    unit_label: str = "box",
+) -> dict[tuple[str, str], str]:
+    """Build a QuEL-3 box-and-target alias map for adapter tests."""
+    return {
+        (box_id, target): _runtime_alias(alias, unit_label=unit_label)
+        for target, alias in entries.items()
+    }
+
+
 def _pulse_array(
     *,
     values: np.ndarray,
@@ -224,9 +242,15 @@ def test_quel3_adapter_allows_capture_beyond_pulse_duration() -> None:
     )
     adapter = Quel3MeasurementBackendAdapter(
         backend_controller=_make_backend_controller(),
-        experiment_system=cast(Any, _FakeExperimentSystem()),
+        experiment_system=cast(
+            Any,
+            _FakeExperimentSystem(
+                target_port_bindings={target: ("BOX1", 4)},
+                box_names={"BOX1": "quel3-02-a01"},
+            ),
+        ),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map={("BOX1", target): f"quel3-02-a01:{alias}"},
     )
 
     result = adapter.validate_schedule(schedule)
@@ -262,9 +286,15 @@ def test_quel3_adapter_builds_fixed_timeline_payload() -> None:
     )
     adapter = Quel3MeasurementBackendAdapter(
         backend_controller=_make_backend_controller(),
-        experiment_system=cast(Any, _FakeExperimentSystem()),
+        experiment_system=cast(
+            Any,
+            _FakeExperimentSystem(
+                target_port_bindings={target: ("BOX1", 4)},
+                box_names={"BOX1": "quel3-02-a01"},
+            ),
+        ),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map={("BOX1", target): f"quel3-02-a01:{alias}"},
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -275,7 +305,7 @@ def test_quel3_adapter_builds_fixed_timeline_payload() -> None:
     assert payload.n_iterations == 16
     assert payload.capture_mode is Quel3CaptureMode.AVERAGED_WAVEFORM
     assert target in payload.fixed_timelines
-    assert payload.instrument_bindings[target] == f"alias:{alias}"
+    assert payload.instrument_bindings[target] == f"alias:quel3-02-a01:{alias}"
     timeline = payload.fixed_timelines[target]
     assert len(timeline.events) == 1
     event = timeline.events[0]
@@ -318,7 +348,7 @@ def test_quel3_adapter_embeds_schedule_frequency_in_payload() -> None:
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -357,7 +387,7 @@ def test_quel3_adapter_raw_waveforms_use_one_iteration_per_shot() -> None:
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=config)
@@ -391,7 +421,7 @@ def test_quel3_adapter_falls_back_to_target_frequency_in_payload() -> None:
             _FakeExperimentSystem(target_frequencies={target: 9.87}),
         ),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -423,7 +453,7 @@ def test_quel3_adapter_treats_schedule_frequency_as_ghz() -> None:
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -458,7 +488,7 @@ def test_quel3_adapter_prefers_schedule_frequency_over_target_frequency() -> Non
             _FakeExperimentSystem(target_frequencies={target: 5.08}),
         ),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -505,7 +535,7 @@ def test_quel3_adapter_applies_mux_capture_delay_to_capture_windows() -> None:
             ),
         ),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -553,7 +583,7 @@ def test_quel3_adapter_rejects_capture_delay_off_sampling_grid() -> None:
             ),
         ),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
 
     with pytest.raises(ValueError, match=r"0\.8 ns"):
@@ -579,7 +609,7 @@ def test_quel3_adapter_keeps_zero_regions_inside_one_waveform_event() -> None:
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -628,7 +658,7 @@ def test_quel3_adapter_uses_adapter_alias_map() -> None:
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -636,7 +666,7 @@ def test_quel3_adapter_uses_adapter_alias_map() -> None:
     payload = request.payload
     assert isinstance(payload, Quel3ExecutionPayload)
     assert set(payload.fixed_timelines.keys()) == {target}
-    assert payload.instrument_bindings[target] == f"alias:{alias}"
+    assert payload.instrument_bindings[target] == f"alias:{_runtime_alias(alias)}"
 
 
 def test_quel3_adapter_allows_multiple_targets_for_same_alias() -> None:
@@ -661,15 +691,17 @@ def test_quel3_adapter_allows_multiple_targets_for_same_alias() -> None:
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={"RQ00": "alias-shared", "RQ01": "alias-shared"},
+        instrument_alias_map=_alias_map(
+            {"RQ00": "alias-shared", "RQ01": "alias-shared"}
+        ),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
     payload = request.payload
     assert isinstance(payload, Quel3ExecutionPayload)
     assert set(payload.fixed_timelines.keys()) == {"RQ00", "RQ01"}
-    assert payload.instrument_bindings["RQ00"] == "alias:alias-shared"
-    assert payload.instrument_bindings["RQ01"] == "alias:alias-shared"
+    assert payload.instrument_bindings["RQ00"] == "alias:box:alias-shared"
+    assert payload.instrument_bindings["RQ01"] == "alias:box:alias-shared"
 
 
 def test_quel3_adapter_uses_registry_for_result_target_labels() -> None:
@@ -709,13 +741,13 @@ def test_quel3_adapter_uses_registry_for_result_target_labels() -> None:
             _FakeExperimentSystem(target_registry=_TargetRegistry()),
         ),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
 
     _ = adapter.build_execution_request(schedule=schedule, config=_make_config())
     backend_result = Quel3BackendExecutionResult(
         status={},
-        data={alias: [np.array([1.0 + 0.0j], dtype=np.complex128)]},
+        data={_runtime_alias(alias): [np.array([1.0 + 0.0j], dtype=np.complex128)]},
         config={},
     )
     result = adapter.build_measurement_result(
@@ -752,7 +784,9 @@ def test_quel3_adapter_reuses_shared_shape_with_scale_and_phase() -> None:
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target_a: "alias-RQ00", target_b: "alias-RQ01"},
+        instrument_alias_map=_alias_map(
+            {target_a: "alias-RQ00", target_b: "alias-RQ01"}
+        ),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -790,7 +824,9 @@ def test_quel3_adapter_keeps_distinct_waveforms_for_different_sampling_periods()
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target_a: "alias-RQ00", target_b: "alias-RQ01"},
+        instrument_alias_map=_alias_map(
+            {target_a: "alias-RQ00", target_b: "alias-RQ01"}
+        ),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -827,7 +863,7 @@ def test_quel3_adapter_downsamples_readout_waveforms_to_0p8ns() -> None:
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: "alias-RQ00"},
+        instrument_alias_map=_alias_map({target: "alias-RQ00"}),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -866,7 +902,7 @@ def test_quel3_adapter_registers_waveform_iq_without_gain_normalization() -> Non
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: "alias-Q00"},
+        instrument_alias_map=_alias_map({target: "alias-Q00"}),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -902,7 +938,7 @@ def test_quel3_adapter_rejects_nonfinite_waveform_iq() -> None:
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: "alias-Q00"},
+        instrument_alias_map=_alias_map({target: "alias-Q00"}),
     )
 
     with pytest.raises(ValueError, match="Waveform IQ values must be finite"):
@@ -944,7 +980,7 @@ def test_quel3_adapter_keeps_readout_timing_unrounded_in_payload() -> None:
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: "alias-RQ00"},
+        instrument_alias_map=_alias_map({target: "alias-RQ00"}),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -977,7 +1013,7 @@ def test_quel3_adapter_omits_empty_waveforms_from_payload() -> None:
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: "alias-Q00"},
+        instrument_alias_map=_alias_map({target: "alias-Q00"}),
     )
 
     request = adapter.build_execution_request(schedule=schedule, config=_make_config())
@@ -1028,8 +1064,8 @@ def test_quel3_adapter_rejects_missing_alias_mapping() -> None:
         adapter.build_execution_request(schedule=schedule, config=_make_config())
 
 
-def test_quel3_adapter_does_not_require_physical_port_metadata_with_alias_map() -> None:
-    """Given alias mapping, when building payload, then physical port metadata is not required."""
+def test_quel3_adapter_requires_box_target_alias_key() -> None:
+    """Given mismatched box key, building request should fail before execution."""
     target = "RQ00"
     schedule = MeasurementSchedule.model_construct(
         pulse_schedule=_FakePulseSchedule(
@@ -1053,14 +1089,11 @@ def test_quel3_adapter_does_not_require_physical_port_metadata_with_alias_map() 
             ),
         ),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: "alias-RQ00"},
+        instrument_alias_map=_alias_map({target: "alias-RQ00"}),
     )
 
-    request = adapter.build_execution_request(schedule=schedule, config=_make_config())
-    payload = request.payload
-    assert isinstance(payload, Quel3ExecutionPayload)
-    assert payload.instrument_bindings[target] == "alias:alias-RQ00"
-    assert payload.capture_port_bindings == {}
+    with pytest.raises(ValueError, match="Missing QuEL-3 instrument alias mapping"):
+        adapter.build_execution_request(schedule=schedule, config=_make_config())
 
 
 def test_quel3_adapter_build_measurement_result_rejects_measurement_result() -> None:
@@ -1122,14 +1155,14 @@ def test_quel3_adapter_build_measurement_result_converts_backend_result() -> Non
     config = _make_config()
     backend_result = Quel3BackendExecutionResult(
         status={},
-        data={alias: [np.array([2.0 + 0.0j], dtype=np.complex128)]},
+        data={_runtime_alias(alias): [np.array([2.0 + 0.0j], dtype=np.complex128)]},
         config={"sampling_period_ns": 0.8},
     )
     adapter = Quel3MeasurementBackendAdapter(
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
     _ = adapter.build_execution_request(schedule=schedule, config=_make_config())
 
@@ -1179,7 +1212,9 @@ def test_quel3_adapter_build_measurement_result_squeezes_avg_mode_waveform() -> 
     backend_result = Quel3BackendExecutionResult(
         status={},
         data={
-            alias: [np.array([[8.0 + 4.0j, 12.0 + 6.0j]], dtype=np.complex128)],
+            _runtime_alias(alias): [
+                np.array([[8.0 + 4.0j, 12.0 + 6.0j]], dtype=np.complex128)
+            ],
         },
         config={"sampling_period_ns": 0.8},
     )
@@ -1187,7 +1222,7 @@ def test_quel3_adapter_build_measurement_result_squeezes_avg_mode_waveform() -> 
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
     _ = adapter.build_execution_request(schedule=schedule, config=config)
 
@@ -1232,7 +1267,7 @@ def test_quel3_adapter_build_measurement_result_normalizes_iq_series_to_1d() -> 
     backend_result = Quel3BackendExecutionResult(
         status={},
         data={
-            alias: [
+            _runtime_alias(alias): [
                 np.array(
                     [
                         [8.0 + 4.0j],
@@ -1248,7 +1283,7 @@ def test_quel3_adapter_build_measurement_result_normalizes_iq_series_to_1d() -> 
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
     _ = adapter.build_execution_request(schedule=schedule, config=config)
 
@@ -1293,7 +1328,7 @@ def test_quel3_adapter_build_measurement_result_accepts_raw_waveform_series() ->
     backend_result = Quel3BackendExecutionResult(
         status={},
         data={
-            alias: [
+            _runtime_alias(alias): [
                 np.array(
                     [
                         [8.0 + 4.0j, 10.0 + 5.0j],
@@ -1309,7 +1344,7 @@ def test_quel3_adapter_build_measurement_result_accepts_raw_waveform_series() ->
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target: alias},
+        instrument_alias_map=_alias_map({target: alias}),
     )
     _ = adapter.build_execution_request(schedule=schedule, config=config)
 
@@ -1387,13 +1422,15 @@ def test_quel3_adapter_build_measurement_result_splits_shared_alias_targets() ->
         backend_controller=_make_backend_controller(),
         experiment_system=cast(Any, _FakeExperimentSystem()),
         constraint_profile=MeasurementConstraintProfile.quel3(0.4),
-        instrument_alias_map={target_a: shared_alias, target_b: shared_alias},
+        instrument_alias_map=_alias_map(
+            {target_a: shared_alias, target_b: shared_alias}
+        ),
     )
     _ = adapter.build_execution_request(schedule=schedule, config=_make_config())
     backend_result = Quel3BackendExecutionResult(
         status={},
         data={
-            shared_alias: [
+            _runtime_alias(shared_alias): [
                 np.array([1.0 + 0.0j], dtype=np.complex128),
                 np.array([2.0 + 0.0j], dtype=np.complex128),
             ]

--- a/tests/system/test_quel3_target_deploy_planner.py
+++ b/tests/system/test_quel3_target_deploy_planner.py
@@ -71,6 +71,7 @@ def test_build_deploy_requests_creates_one_request_per_target() -> None:
 
     read_request = request_by_target["RQ00"]
     assert read_request.port_id == "quel3-02-a01:trx_p00p01"
+    assert read_request.box_id == "BOX1"
     assert read_request.role == "TRANSCEIVER"
     assert read_request.alias == "RQ00"
     assert read_request.frequency_range_min_hz == pytest.approx(5.9e9)
@@ -79,6 +80,7 @@ def test_build_deploy_requests_creates_one_request_per_target() -> None:
 
     ctrl_request = request_by_target["Q00"]
     assert ctrl_request.port_id == "quel3-02-a01:tx_p02"
+    assert ctrl_request.box_id == "BOX1"
     assert ctrl_request.role == "TRANSMITTER"
     assert ctrl_request.alias == "Q00"
     assert ctrl_request.frequency_range_min_hz == pytest.approx(4.10e9)
@@ -87,6 +89,7 @@ def test_build_deploy_requests_creates_one_request_per_target() -> None:
 
     cr_request = request_by_target["Q00-CR"]
     assert cr_request.port_id == "quel3-02-a01:tx_p02"
+    assert cr_request.box_id == "BOX1"
     assert cr_request.role == "TRANSMITTER"
     assert cr_request.alias == "Q00-CR"
     assert cr_request.frequency_range_min_hz == pytest.approx(4.25e9)
@@ -215,6 +218,7 @@ def test_quel3_synchronizer_plans_then_deploys_from_hardware_sync_input() -> Non
             frequency_range_max_hz=4.3e9,
             alias="Q00",
             target_labels=("Q00",),
+            box_id="BOX1",
         ),
     )
 
@@ -272,6 +276,7 @@ def test_quel3_synchronizer_defaults_parallel_deploy_to_true() -> None:
             frequency_range_max_hz=4.3e9,
             alias="Q00",
             target_labels=("Q00",),
+            box_id="BOX1",
         ),
     )
 


### PR DESCRIPTION
## Summary

- Require QuEL-3 runtime payload aliases to be unit-qualified when runtime bindings are provided.
- Scope deployment/runtime alias maps by box and target to avoid cross-unit ambiguity.
- Preserve resource-id fallback through `InstrumentResolver` for unbound resources.

## Impact

QuEL-3 measurement payloads now reject ambiguous runtime alias bindings instead of resolving through an implicit default unit. Deployment caches also keep aliases box-scoped, which prevents a target alias from leaking across units.

## Compatibility

This is a QuEL-3 behavior tightening: configured `alias:` bindings must include a unit label such as `unit0:target_alias`. Unbound resources still fall back through `InstrumentResolver`.

## Docs

No existing user-guide page documents QuEL-3 runtime alias bindings directly. I checked the docs surface and left docs unchanged.

## Root Cause

Runtime execution payload handling accepted aliases that were not tied to a specific QuEL-3 unit, so multi-unit deployments could resolve the wrong target when aliases overlapped.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`
