### PR TITLE
refactor: reopen Quel3 sessions between batch payloads

### DIFF
--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -6,7 +6,7 @@ import asyncio
 import importlib
 import logging
 from collections import defaultdict
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Sequence
 from dataclasses import dataclass, replace
 from typing import TypeGuard, TypeVar, cast
 
@@ -202,7 +202,7 @@ class Quel3ExecutionManager:
         requests: list[object] | tuple[object, ...],
         parallel: bool = True,
     ) -> list[Quel3BackendExecutionResult]:
-        """Execute multiple QuEL-3 backend requests while reusing one session."""
+        """Execute multiple QuEL-3 backend requests as one resolved batch."""
         payloads: list[Quel3ExecutionPayload] = []
         for request in requests:
             payload = getattr(request, "payload", None)
@@ -374,7 +374,7 @@ class Quel3ExecutionManager:
         quelware_api: _QuelwareExecutionApi,
         parallel: bool,
     ) -> list[Quel3BackendExecutionResult]:
-        """Execute one payload batch using a single fresh quelware session."""
+        """Execute one payload batch with per-payload quelware sessions."""
         runtime, first_resolved_payload = await self._open_execution_runtime(
             payload=payloads[0],
             quelware_api=quelware_api,
@@ -389,14 +389,16 @@ class Quel3ExecutionManager:
             )
         ]
         for payload in payloads[1:]:
-            resolved_payload = self._resolve_payload(payload=payload)
-            resolved_payload = self._filter_runnable_payload(resolved_payload)
-            resolved_aliases = tuple(sorted(resolved_payload.fixed_timelines))
-            if resolved_aliases != expected_aliases:
-                raise ValueError(
-                    "Batched QuEL-3 execution requires all points to resolve "
-                    "to the same instrument alias set."
-                )
+            resolved_payload = self._resolve_batch_payload(
+                payload=payload,
+                expected_aliases=expected_aliases,
+            )
+            runtime = await self._reopen_execution_runtime_session(
+                runtime=runtime,
+                resolved_payload=resolved_payload,
+                quelware_api=quelware_api,
+                aliases=expected_aliases,
+            )
             results.append(
                 await self._execute_resolved_payload(
                     payload=resolved_payload,
@@ -406,6 +408,70 @@ class Quel3ExecutionManager:
                 )
             )
         return results
+
+    def _resolve_batch_payload(
+        self,
+        *,
+        payload: Quel3ExecutionPayload,
+        expected_aliases: Sequence[str],
+    ) -> Quel3ExecutionPayload:
+        """Resolve one batched payload and verify it matches the batch shape."""
+        resolved_payload = self._resolve_payload(payload=payload)
+        resolved_payload = self._filter_runnable_payload(resolved_payload)
+        resolved_aliases = tuple(sorted(resolved_payload.fixed_timelines))
+        if resolved_aliases != tuple(expected_aliases):
+            raise ValueError(
+                "Batched QuEL-3 execution requires all points to resolve "
+                "to the same instrument alias set."
+            )
+        return resolved_payload
+
+    async def _reopen_execution_runtime_session(
+        self,
+        *,
+        runtime: _ExecutionRuntime,
+        resolved_payload: Quel3ExecutionPayload,
+        quelware_api: _QuelwareExecutionApi,
+        aliases: Sequence[str],
+    ) -> _ExecutionRuntime:
+        """Reopen the quelware session and rebuild session-bound drivers."""
+        instrument_resource_ids = self._resource_ids_for_aliases(
+            alias_to_resource_id=runtime.alias_to_resource_id,
+            aliases=aliases,
+        )
+        session_token = self._active_session_token()
+        try:
+            session = await self._session_manager.reopen_session(
+                instrument_resource_ids,
+            )
+        except QuelwareSessionError:
+            raise
+        except Exception as exc:
+            raise QuelwareSessionError(
+                "QuEL-3 quelware session reopen failed",
+                session_token=session_token,
+                cause=exc,
+            ) from exc
+        if session is None:
+            raise RuntimeError(
+                "QuEL-3 session reopen did not return an execution session."
+            )
+
+        alias_to_instrument_info = self._resolve_alias_to_instrument_info_map(
+            resolver=runtime.resolver,
+            aliases=aliases,
+        )
+        alias_to_driver = self._build_alias_driver_map(
+            session=session,
+            alias_to_instrument_info=alias_to_instrument_info,
+            aliases=aliases,
+            quelware_api=quelware_api,
+        )
+        return replace(
+            runtime,
+            session=session,
+            alias_to_driver=alias_to_driver,
+        )
 
     async def _open_execution_runtime(
         self,
@@ -420,7 +486,7 @@ class Quel3ExecutionManager:
 
         resolved_payload = self._resolve_payload(payload=payload)
         resolved_payload = self._filter_runnable_payload(resolved_payload)
-        aliases = sorted(resolved_payload.fixed_timelines.keys())
+        aliases = tuple(sorted(resolved_payload.fixed_timelines.keys()))
         alias_to_instrument_info = self._resolve_alias_to_instrument_info_map(
             resolver=resolver,
             aliases=aliases,
@@ -430,22 +496,28 @@ class Quel3ExecutionManager:
             alias_to_instrument_info=alias_to_instrument_info,
             aliases=aliases,
         )
-        instrument_resource_ids = [alias_to_resource_id[alias] for alias in aliases]
-        await self._session_manager.open(
+        instrument_resource_ids = self._resource_ids_for_aliases(
+            alias_to_resource_id=alias_to_resource_id,
+            aliases=aliases,
+        )
+        session = await self._session_manager.open(
             instrument_resource_ids,
             client_factory=quelware_api.client_factory,
         )
-        session = self._session_manager.session
+        if session is None:
+            raise RuntimeError(
+                "QuEL-3 session open did not return an execution session."
+            )
 
-        alias_to_driver: dict[str, InstrumentDriverProtocol] = {}
+        alias_to_driver = self._build_alias_driver_map(
+            session=session,
+            alias_to_instrument_info=alias_to_instrument_info,
+            aliases=aliases,
+            quelware_api=quelware_api,
+        )
         capture_sampling_period_ns: float | None = None
         for alias in aliases:
-            instrument_info = alias_to_instrument_info[alias]
-            driver = quelware_api.fixed_timeline_driver_factory(
-                session,
-                instrument_info,
-            )
-            alias_to_driver[alias] = driver
+            driver = alias_to_driver[alias]
             sampling_period_fs = getattr(
                 driver.instrument_config,
                 "sampling_period_fs",
@@ -455,15 +527,16 @@ class Quel3ExecutionManager:
                 raise TypeError(
                     "Instrument config must expose integer `sampling_period_fs`."
                 )
-            if resolved_payload.fixed_timelines[alias].capture_windows:
-                alias_sampling_period_ns = sampling_period_fs / 1e6
-                if capture_sampling_period_ns is None:
-                    capture_sampling_period_ns = alias_sampling_period_ns
-                elif not np.isclose(
-                    capture_sampling_period_ns,
-                    alias_sampling_period_ns,
-                ):
-                    raise ValueError("Capture aliases must agree on sampling period.")
+            if len(resolved_payload.fixed_timelines[alias].capture_windows) == 0:
+                continue
+            alias_sampling_period_ns = sampling_period_fs / 1e6
+            if capture_sampling_period_ns is None:
+                capture_sampling_period_ns = alias_sampling_period_ns
+            elif not np.isclose(
+                capture_sampling_period_ns,
+                alias_sampling_period_ns,
+            ):
+                raise ValueError("Capture aliases must agree on sampling period.")
 
         return (
             _ExecutionRuntime(
@@ -475,6 +548,46 @@ class Quel3ExecutionManager:
             ),
             resolved_payload,
         )
+
+    @staticmethod
+    def _resource_ids_for_aliases(
+        *,
+        alias_to_resource_id: dict[str, ResourceIdProtocol],
+        aliases: Sequence[str],
+    ) -> tuple[ResourceIdProtocol, ...]:
+        """Return resource IDs for aliases with a clear missing-alias error."""
+        try:
+            return tuple(alias_to_resource_id[alias] for alias in aliases)
+        except KeyError as exc:
+            alias = str(exc.args[0])
+            raise ValueError(
+                f"Instrument resource ID is not resolved for alias `{alias}`."
+            ) from exc
+
+    def _build_alias_driver_map(
+        self,
+        *,
+        session: SessionProtocol,
+        alias_to_instrument_info: dict[str, InstrumentInfoProtocol],
+        aliases: Sequence[str],
+        quelware_api: _QuelwareExecutionApi,
+    ) -> dict[str, InstrumentDriverProtocol]:
+        """Build session-bound fixed-timeline drivers by instrument alias."""
+        alias_to_driver: dict[str, InstrumentDriverProtocol] = {}
+        for alias in aliases:
+            instrument_info = alias_to_instrument_info[alias]
+            try:
+                driver = quelware_api.fixed_timeline_driver_factory(
+                    session,
+                    instrument_info,
+                )
+            except Exception as exc:
+                raise RuntimeError(
+                    "QuEL-3 fixed-timeline driver creation failed "
+                    f"for instrument alias `{alias}`."
+                ) from exc
+            alias_to_driver[alias] = driver
+        return alias_to_driver
 
     async def _execute_resolved_payload(
         self,
@@ -646,7 +759,7 @@ class Quel3ExecutionManager:
         cls,
         *,
         resolver: InstrumentResolverProtocol,
-        aliases: list[str],
+        aliases: Sequence[str],
     ) -> dict[str, InstrumentInfoProtocol]:
         """Resolve instrument infos by runtime alias using InstrumentResolver."""
         return {
@@ -662,7 +775,7 @@ class Quel3ExecutionManager:
         *,
         resolver: InstrumentResolverProtocol,
         alias_to_instrument_info: dict[str, InstrumentInfoProtocol],
-        aliases: list[str],
+        aliases: Sequence[str],
     ) -> dict[str, ResourceIdProtocol]:
         """Resolve alias-to-resource-id mapping from resolved instrument infos."""
         alias_to_resource_id: dict[str, ResourceIdProtocol] = {}

--- a/src/qubex/backend/quel3/managers/session_manager.py
+++ b/src/qubex/backend/quel3/managers/session_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 from collections.abc import Collection
+from contextlib import AbstractAsyncContextManager
 from types import TracebackType
 
 from qubex.backend.quel3.infra.quelware_imports import (
@@ -17,6 +18,7 @@ from qubex.backend.quel3.interfaces import (
     SessionProtocol,
 )
 from qubex.backend.quel3.managers.session_workarounds import (
+    QuelwareSessionError,
     enter_quelware_session_with_resource_retry,
     quelware_session_token,
 )
@@ -40,9 +42,11 @@ class Quel3SessionManager:
         self._quelware_port = quelware_port
         self._client_mode: Quel3ClientMode = normalized_client_mode
         self._quelware_pat_path = quelware_pat_path
-        self._client_cm = None
+        self._client_cm: AbstractAsyncContextManager[QuelwareClientProtocol] | None = (
+            None
+        )
         self._client: QuelwareClientProtocol | None = None
-        self._session_cm = None
+        self._session_cm: AbstractAsyncContextManager[SessionProtocol] | None = None
         self._session: SessionProtocol | None = None
         self._session_token: str | None = None
         self._resource_ids: tuple[ResourceIdProtocol, ...] | None = None
@@ -151,13 +155,26 @@ class Quel3SessionManager:
         self._resource_ids = normalized_resource_ids
         return self._session
 
+    async def reopen_session(
+        self,
+        resource_ids: Collection[ResourceIdProtocol] | None = None,
+    ) -> SessionProtocol | None:
+        """Close the current session and open a replacement on the same client."""
+        session_cm, session_token = self._detach_session_context()
+        if session_cm is not None:
+            try:
+                await session_cm.__aexit__(None, None, None)
+            except Exception as exc:
+                raise QuelwareSessionError(
+                    "QuEL-3 quelware session close failed before reopening",
+                    session_token=session_token,
+                    cause=exc,
+                ) from exc
+        return await self.open(resource_ids)
+
     async def close(self) -> None:
         """Close any open quelware session and client contexts."""
-        session_cm = self._session_cm
-        self._session_cm = None
-        self._session = None
-        self._session_token = None
-        self._resource_ids = None
+        session_cm, _ = self._detach_session_context()
         try:
             if session_cm is not None:
                 await session_cm.__aexit__(None, None, None)
@@ -168,6 +185,18 @@ class Quel3SessionManager:
 
             if client_cm is not None:
                 await client_cm.__aexit__(None, None, None)
+
+    def _detach_session_context(
+        self,
+    ) -> tuple[AbstractAsyncContextManager[SessionProtocol] | None, str]:
+        """Clear stored session state and return the previous context."""
+        session_cm = self._session_cm
+        session_token = self._session_token or quelware_session_token(self._session)
+        self._session_cm = None
+        self._session = None
+        self._session_token = None
+        self._resource_ids = None
+        return session_cm, session_token
 
     async def __aenter__(self) -> Quel3SessionManager:
         """Open the underlying quelware client context and return self."""

--- a/src/qubex/backend/quel3/quel3_backend_controller.py
+++ b/src/qubex/backend/quel3/quel3_backend_controller.py
@@ -391,7 +391,7 @@ class Quel3BackendController(BackendController):
         clock_health_checks: bool | None = None,
         parallel: bool = True,
     ) -> list[BackendExecutionResult]:
-        """Execute multiple backend requests while reusing one QuEL-3 session."""
+        """Execute multiple backend requests as one resolved QuEL-3 batch."""
         del execution_mode, clock_health_checks
         return await self._execution_manager.execute_batch_async(
             requests=tuple(requests),

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -1415,7 +1415,7 @@ def test_execute_batch_recreates_session_after_transient_request_failure(
     assert len(results) == 2
     assert len(clients) == 2
     assert [client.exit_calls for client in clients] == [1, 1]
-    assert [session.exit_calls for session in sessions] == [1, 1]
+    assert [session.exit_calls for session in sessions] == [1, 2]
     assert sessions[0].trigger_calls == [["alias-rq00"]]
     assert sessions[1].trigger_calls == [["alias-rq00"], ["alias-rq00"]]
 
@@ -1643,10 +1643,10 @@ def test_execute_parallelizes_driver_phases(
     )
 
 
-def test_execute_batch_async_reuses_one_session(
+def test_execute_batch_async_reopens_session_between_payloads(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Given multiple requests, execute_batch_async should reuse one session and resolver refresh."""
+    """Given multiple requests, execute_batch_async should reopen sessions and reuse resolver refresh."""
     payload_a = _make_payload()
     payload_b = _make_payload()
     manager = Quel3ExecutionManager(
@@ -1694,7 +1694,7 @@ def test_execute_batch_async_reuses_one_session(
     )
 
     assert resolver.refresh_calls == 1
-    assert create_session_calls == [("alias-rq00",)]
+    assert create_session_calls == [("alias-rq00",), ("alias-rq00",)]
     assert len(session.trigger_calls) == 2
     assert len(driver.apply_calls) == 2
     assert len(results) == 2


### PR DESCRIPTION
## Summary
- Reopen the quelware session between `execute_batch_async` payloads while keeping the client and resolver refresh shared for the batch.
- Add session-manager support for detaching and reopening the current session with clearer close/reopen error handling.
- Rebuild session-bound fixed-timeline drivers after each reopened session and keep batch alias-shape validation explicit.
- Update Quel3 backend controller tests for the new per-payload session lifecycle.

## Impact
The public batch execution API is unchanged. Internally, batched Quel3 execution no longer assumes one quelware session can be reused for every payload in the batch.

## Validation
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`