### PR TITLE
refactor: share QuEL-3 manager runtime config

### DIFF
--- a/src/qubex/backend/quel3/__init__.py
+++ b/src/qubex/backend/quel3/__init__.py
@@ -2,7 +2,7 @@
 
 from .builders import Quel3SequencerBuilder
 from .infra import Quel3ClientMode
-from .managers import Quel3ConfigurationManager
+from .managers import Quel3ConfigurationManager, Quel3RuntimeConfig
 from .models import (
     InstrumentDeployRequest,
     Quel3BackendExecutionResult,
@@ -25,6 +25,7 @@ __all__ = [
     "Quel3ConfigurationManager",
     "Quel3ExecutionPayload",
     "Quel3FixedTimeline",
+    "Quel3RuntimeConfig",
     "Quel3SequencerBuilder",
     "Quel3Waveform",
     "Quel3WaveformEvent",

--- a/src/qubex/backend/quel3/managers/__init__.py
+++ b/src/qubex/backend/quel3/managers/__init__.py
@@ -3,11 +3,13 @@
 from .configuration_manager import Quel3ConfigurationManager
 from .connection_manager import Quel3ConnectionManager
 from .execution_manager import Quel3ExecutionManager
+from .runtime_config import Quel3RuntimeConfig
 from .session_manager import Quel3SessionManager
 
 __all__ = [
     "Quel3ConfigurationManager",
     "Quel3ConnectionManager",
     "Quel3ExecutionManager",
+    "Quel3RuntimeConfig",
     "Quel3SessionManager",
 ]

--- a/src/qubex/backend/quel3/managers/configuration_manager.py
+++ b/src/qubex/backend/quel3/managers/configuration_manager.py
@@ -10,11 +10,7 @@ from collections.abc import Awaitable, Callable, Collection, Mapping, Sequence
 from dataclasses import dataclass
 from typing import TypeVar
 
-from qubex.backend.quel3.infra.quelware_imports import (
-    Quel3ClientMode,
-    load_quelware_client_factory,
-    validate_quelware_client_runtime,
-)
+from qubex.backend.quel3.infra.quelware_imports import Quel3ClientMode
 from qubex.backend.quel3.interfaces.client import (
     FixedTimelineProfileFactory,
     InstrumentDefinitionFactory,
@@ -28,6 +24,7 @@ from qubex.backend.quel3.interfaces.client import (
     ResourceInfoProtocol,
     SessionProtocol,
 )
+from qubex.backend.quel3.managers.runtime_config import Quel3RuntimeConfig
 from qubex.backend.quel3.managers.session_workarounds import (
     QUELWARE_SESSION_REQUEST_MAX_ATTEMPTS,
     QuelwareSessionError,
@@ -117,42 +114,38 @@ class Quel3ConfigurationManager:
     def __init__(
         self,
         *,
-        quelware_endpoint: str,
-        quelware_port: int,
-        client_mode: str = "server",
-        quelware_pat_path: str | None = None,
+        runtime_config: Quel3RuntimeConfig | None = None,
     ) -> None:
-        normalized_client_mode = validate_quelware_client_runtime(
-            client_mode=client_mode,
-        )
-        self._quelware_endpoint = quelware_endpoint
-        self._quelware_port = quelware_port
-        self._client_mode: Quel3ClientMode = normalized_client_mode
-        self._quelware_pat_path = quelware_pat_path
+        self._runtime_config = runtime_config or Quel3RuntimeConfig()
         self._last_deployed_instrument_infos: dict[
             str, tuple[InstrumentInfoProtocol, ...]
         ] = {}
         self._target_alias_map: dict[TargetAliasKey, str] = {}
 
     @property
+    def runtime_config(self) -> Quel3RuntimeConfig:
+        """Return the shared quelware runtime config."""
+        return self._runtime_config
+
+    @property
     def quelware_endpoint(self) -> str:
         """Return quelware endpoint used for deployment."""
-        return self._quelware_endpoint
+        return self._runtime_config.endpoint
 
     @property
     def quelware_port(self) -> int:
         """Return quelware port used for deployment."""
-        return self._quelware_port
+        return self._runtime_config.port
 
     @property
     def client_mode(self) -> Quel3ClientMode:
         """Return configured quelware client mode."""
-        return self._client_mode
+        return self._runtime_config.client_mode_value
 
     @property
     def quelware_pat_path(self) -> str | None:
         """Return configured quelware personal access token path."""
-        return self._quelware_pat_path
+        return self._runtime_config.pat_path
 
     @property
     def last_deployed_instrument_infos(
@@ -315,8 +308,8 @@ class Quel3ConfigurationManager:
     ) -> list[_PortDeployResult]:
         """Deploy port batches in one quelware client/session context."""
         async with client_factory(
-            self._quelware_endpoint,
-            self._quelware_port,
+            self._runtime_config.endpoint,
+            self._runtime_config.port,
         ) as client:
             session_resource_ids = [port_id for port_id, _ in port_request_batches]
             session_cm, session = await enter_quelware_session_with_resource_retry(
@@ -435,8 +428,8 @@ class Quel3ConfigurationManager:
         """Load existing fixed-timeline instruments into local alias caches."""
         client_factory = self._load_quelware_client_factory()
         async with client_factory(
-            self._quelware_endpoint,
-            self._quelware_port,
+            self._runtime_config.endpoint,
+            self._runtime_config.port,
         ) as client:
             instrument_infos = await self._list_instrument_infos(
                 client=client,
@@ -477,8 +470,8 @@ class Quel3ConfigurationManager:
 
         client_factory = self._load_quelware_client_factory()
         async with client_factory(
-            self._quelware_endpoint,
-            self._quelware_port,
+            self._runtime_config.endpoint,
+            self._runtime_config.port,
         ) as client:
             instrument_infos = await self._list_instrument_infos(
                 client=client,
@@ -510,10 +503,7 @@ class Quel3ConfigurationManager:
 
     def _load_quelware_client_factory(self) -> QuelwareClientFactory:
         """Import quelware client factory lazily."""
-        return load_quelware_client_factory(
-            client_mode=self._client_mode,
-            pat_path=self._quelware_pat_path,
-        )
+        return self._runtime_config.load_client_factory()
 
     @staticmethod
     def _is_instrument_resource(resource_info: ResourceInfoProtocol) -> bool:

--- a/src/qubex/backend/quel3/managers/connection_manager.py
+++ b/src/qubex/backend/quel3/managers/connection_manager.py
@@ -5,12 +5,9 @@ from __future__ import annotations
 from collections.abc import Awaitable, Callable
 from typing import TypeVar
 
-from qubex.backend.quel3.infra.quelware_imports import (
-    Quel3ClientMode,
-    load_quelware_client_factory,
-    validate_quelware_client_runtime,
-)
+from qubex.backend.quel3.infra.quelware_imports import Quel3ClientMode
 from qubex.backend.quel3.interfaces import QuelwareClientFactory
+from qubex.backend.quel3.managers.runtime_config import Quel3RuntimeConfig
 from qubex.core.async_bridge import DEFAULT_TIMEOUT_SECONDS, get_shared_async_bridge
 
 T = TypeVar("T")
@@ -32,32 +29,20 @@ class Quel3ConnectionManager:
     def __init__(
         self,
         *,
-        quelware_endpoint: str,
-        quelware_port: int,
-        client_mode: str = "server",
-        quelware_pat_path: str | None = None,
+        runtime_config: Quel3RuntimeConfig | None = None,
     ) -> None:
-        normalized_client_mode = validate_quelware_client_runtime(
-            client_mode=client_mode,
-        )
         self._is_connected = False
-        self._quelware_endpoint = quelware_endpoint
-        self._quelware_port = quelware_port
-        self._client_mode: Quel3ClientMode = normalized_client_mode
-        self._quelware_pat_path = quelware_pat_path
+        self._runtime_config = runtime_config or Quel3RuntimeConfig()
+
+    @property
+    def runtime_config(self) -> Quel3RuntimeConfig:
+        """Return the shared quelware runtime config."""
+        return self._runtime_config
 
     @property
     def hash(self) -> int:
         """Return stable hash for connection-side runtime state."""
-        return hash(
-            (
-                self._is_connected,
-                self._quelware_endpoint,
-                self._quelware_port,
-                self._client_mode,
-                self._quelware_pat_path,
-            )
-        )
+        return hash((self._is_connected, self._runtime_config))
 
     @property
     def is_connected(self) -> bool:
@@ -67,22 +52,22 @@ class Quel3ConnectionManager:
     @property
     def quelware_endpoint(self) -> str:
         """Return quelware endpoint."""
-        return self._quelware_endpoint
+        return self._runtime_config.endpoint
 
     @property
     def quelware_port(self) -> int:
         """Return quelware port."""
-        return self._quelware_port
+        return self._runtime_config.port
 
     @property
     def client_mode(self) -> Quel3ClientMode:
         """Return configured quelware client mode."""
-        return self._client_mode
+        return self._runtime_config.client_mode_value
 
     @property
     def quelware_pat_path(self) -> str | None:
         """Return configured quelware personal access token path."""
-        return self._quelware_pat_path
+        return self._runtime_config.pat_path
 
     def connect(
         self,
@@ -111,14 +96,11 @@ class Quel3ConnectionManager:
             ) from exc
 
         async with client_factory(
-            self._quelware_endpoint,
-            self._quelware_port,
+            self._runtime_config.endpoint,
+            self._runtime_config.port,
         ) as client:
             await client.list_resource_infos()
 
     def load_quelware_client_factory(self) -> QuelwareClientFactory:
         """Import quelware client factory lazily."""
-        return load_quelware_client_factory(
-            client_mode=self._client_mode,
-            pat_path=self._quelware_pat_path,
-        )
+        return self._runtime_config.load_client_factory()

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -13,11 +13,7 @@ from typing import TypeGuard, TypeVar, cast
 import numpy as np
 
 from qubex.backend.quel3.builders.sequencer_builder import Quel3SequencerBuilder
-from qubex.backend.quel3.infra.quelware_imports import (
-    Quel3ClientMode,
-    load_quelware_client_factory,
-    validate_quelware_client_runtime,
-)
+from qubex.backend.quel3.infra.quelware_imports import Quel3ClientMode
 from qubex.backend.quel3.interfaces import (
     CaptureModeNamespaceProtocol,
     CaptureModeProtocol,
@@ -36,6 +32,7 @@ from qubex.backend.quel3.interfaces import (
     SetCaptureModeFactory,
     SetFrequencyFactory,
 )
+from qubex.backend.quel3.managers.runtime_config import Quel3RuntimeConfig
 from qubex.backend.quel3.managers.session_manager import Quel3SessionManager
 from qubex.backend.quel3.managers.session_workarounds import (
     QuelwareSessionError,
@@ -122,44 +119,37 @@ class Quel3ExecutionManager:
     def __init__(
         self,
         *,
-        quelware_endpoint: str,
-        quelware_port: int,
+        runtime_config: Quel3RuntimeConfig | None = None,
         sampling_period_ns: float,
         capture_decimation_factor: int,
-        client_mode: str = "server",
-        quelware_pat_path: str | None = None,
         session_manager: Quel3SessionManager | None = None,
     ) -> None:
-        normalized_client_mode = validate_quelware_client_runtime(
-            client_mode=client_mode,
-        )
-        self._quelware_endpoint = quelware_endpoint
-        self._quelware_port = quelware_port
+        self._runtime_config = runtime_config or Quel3RuntimeConfig()
         self._sampling_period_ns = sampling_period_ns
         self._capture_decimation_factor = capture_decimation_factor
-        self._client_mode: Quel3ClientMode = normalized_client_mode
-        self._quelware_pat_path = quelware_pat_path
         self._sequencer_builder = Quel3SequencerBuilder()
         self._session_manager = (
             session_manager
             if session_manager is not None
             else Quel3SessionManager(
-                quelware_endpoint=quelware_endpoint,
-                quelware_port=quelware_port,
-                client_mode=normalized_client_mode,
-                quelware_pat_path=quelware_pat_path,
+                runtime_config=self._runtime_config,
             )
         )
 
     @property
+    def runtime_config(self) -> Quel3RuntimeConfig:
+        """Return the shared quelware runtime config."""
+        return self._runtime_config
+
+    @property
     def quelware_endpoint(self) -> str:
         """Return quelware endpoint used for execution."""
-        return self._quelware_endpoint
+        return self._runtime_config.endpoint
 
     @property
     def quelware_port(self) -> int:
         """Return quelware port used for execution."""
-        return self._quelware_port
+        return self._runtime_config.port
 
     @property
     def sampling_period_ns(self) -> float:
@@ -169,12 +159,12 @@ class Quel3ExecutionManager:
     @property
     def client_mode(self) -> Quel3ClientMode:
         """Return configured quelware client mode."""
-        return self._client_mode
+        return self._runtime_config.client_mode_value
 
     @property
     def quelware_pat_path(self) -> str | None:
         """Return configured quelware personal access token path."""
-        return self._quelware_pat_path
+        return self._runtime_config.pat_path
 
     def execute_sync(
         self,
@@ -1076,9 +1066,8 @@ class Quel3ExecutionManager:
         driver_module = importlib.import_module(
             "quelware_client.core.instrument_driver"
         )
-        client_factory: QuelwareClientFactory = load_quelware_client_factory(
-            client_mode=self._client_mode,
-            pat_path=self._quelware_pat_path,
+        client_factory: QuelwareClientFactory = (
+            self._runtime_config.load_client_factory()
         )
         instrument_resolver_factory: InstrumentResolverFactory = (
             resolver_module.InstrumentResolver

--- a/src/qubex/backend/quel3/managers/runtime_config.py
+++ b/src/qubex/backend/quel3/managers/runtime_config.py
@@ -1,0 +1,43 @@
+"""Shared runtime configuration for QuEL-3 managers."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+from qubex.backend.quel3.infra.quelware_imports import (
+    Quel3ClientMode,
+    load_quelware_client_factory,
+    validate_quelware_client_runtime,
+)
+from qubex.backend.quel3.interfaces import QuelwareClientFactory
+
+
+@dataclass(frozen=True)
+class Quel3RuntimeConfig:
+    """Hold quelware runtime settings shared by QuEL-3 managers."""
+
+    endpoint: str = "localhost"
+    port: int = 50051
+    client_mode: str = "server"
+    pat_path: str | None = None
+
+    def __post_init__(self) -> None:
+        """Normalize runtime settings after construction."""
+        object.__setattr__(
+            self,
+            "client_mode",
+            validate_quelware_client_runtime(client_mode=self.client_mode),
+        )
+
+    def load_client_factory(self) -> QuelwareClientFactory:
+        """Load the quelware client factory for this runtime config."""
+        return load_quelware_client_factory(
+            client_mode=self.client_mode_value,
+            pat_path=self.pat_path,
+        )
+
+    @property
+    def client_mode_value(self) -> Quel3ClientMode:
+        """Return client mode with the validated literal type."""
+        return cast(Quel3ClientMode, self.client_mode)

--- a/src/qubex/backend/quel3/managers/session_manager.py
+++ b/src/qubex/backend/quel3/managers/session_manager.py
@@ -6,17 +6,14 @@ from collections.abc import Collection
 from contextlib import AbstractAsyncContextManager
 from types import TracebackType
 
-from qubex.backend.quel3.infra.quelware_imports import (
-    Quel3ClientMode,
-    load_quelware_client_factory,
-    validate_quelware_client_runtime,
-)
+from qubex.backend.quel3.infra.quelware_imports import Quel3ClientMode
 from qubex.backend.quel3.interfaces import (
     QuelwareClientFactory,
     QuelwareClientProtocol,
     ResourceIdProtocol,
     SessionProtocol,
 )
+from qubex.backend.quel3.managers.runtime_config import Quel3RuntimeConfig
 from qubex.backend.quel3.managers.session_workarounds import (
     QuelwareSessionError,
     enter_quelware_session_with_resource_retry,
@@ -30,18 +27,9 @@ class Quel3SessionManager:
     def __init__(
         self,
         *,
-        quelware_endpoint: str,
-        quelware_port: int,
-        client_mode: str = "server",
-        quelware_pat_path: str | None = None,
+        runtime_config: Quel3RuntimeConfig | None = None,
     ) -> None:
-        normalized_client_mode = validate_quelware_client_runtime(
-            client_mode=client_mode,
-        )
-        self._quelware_endpoint = quelware_endpoint
-        self._quelware_port = quelware_port
-        self._client_mode: Quel3ClientMode = normalized_client_mode
-        self._quelware_pat_path = quelware_pat_path
+        self._runtime_config = runtime_config or Quel3RuntimeConfig()
         self._client_cm: AbstractAsyncContextManager[QuelwareClientProtocol] | None = (
             None
         )
@@ -52,24 +40,29 @@ class Quel3SessionManager:
         self._resource_ids: tuple[ResourceIdProtocol, ...] | None = None
 
     @property
+    def runtime_config(self) -> Quel3RuntimeConfig:
+        """Return the shared quelware runtime config."""
+        return self._runtime_config
+
+    @property
     def quelware_endpoint(self) -> str:
         """Return quelware endpoint."""
-        return self._quelware_endpoint
+        return self._runtime_config.endpoint
 
     @property
     def quelware_port(self) -> int:
         """Return quelware port."""
-        return self._quelware_port
+        return self._runtime_config.port
 
     @property
     def client_mode(self) -> Quel3ClientMode:
         """Return configured quelware client mode."""
-        return self._client_mode
+        return self._runtime_config.client_mode_value
 
     @property
     def quelware_pat_path(self) -> str | None:
         """Return configured quelware personal access token path."""
-        return self._quelware_pat_path
+        return self._runtime_config.pat_path
 
     @property
     def is_open(self) -> bool:
@@ -120,8 +113,8 @@ class Quel3SessionManager:
                 else client_factory
             )
             self._client_cm = runtime_client_factory(
-                self._quelware_endpoint,
-                self._quelware_port,
+                self._runtime_config.endpoint,
+                self._runtime_config.port,
             )
             try:
                 self._client = await self._client_cm.__aenter__()
@@ -215,7 +208,4 @@ class Quel3SessionManager:
 
     def load_quelware_client_factory(self) -> QuelwareClientFactory:
         """Import quelware client factory lazily."""
-        return load_quelware_client_factory(
-            client_mode=self._client_mode,
-            pat_path=self._quelware_pat_path,
-        )
+        return self._runtime_config.load_client_factory()

--- a/src/qubex/backend/quel3/quel3_backend_controller.py
+++ b/src/qubex/backend/quel3/quel3_backend_controller.py
@@ -8,29 +8,24 @@ built on quelware-client managers.
 from __future__ import annotations
 
 from collections.abc import Sequence
-from typing import TypeVar, cast
 
 from qubex.backend.backend_controller import (
     BackendController,
     BackendExecutionRequest,
     BackendExecutionResult,
 )
-from qubex.backend.quel3.infra import (
-    Quel3ClientMode,
-    validate_quelware_client_runtime,
-)
+from qubex.backend.quel3.infra import Quel3ClientMode
 from qubex.backend.quel3.interfaces.client import InstrumentInfoProtocol
 
 from .managers import (
     Quel3ConfigurationManager,
     Quel3ConnectionManager,
     Quel3ExecutionManager,
+    Quel3RuntimeConfig,
     Quel3SessionManager,
 )
 from .models import InstrumentDeployRequest
 from .quel3_backend_constants import CAPTURE_DECIMATION_FACTOR, SAMPLING_PERIOD_NS
-
-T = TypeVar("T")
 
 
 class Quel3BackendController(BackendController):
@@ -76,176 +71,50 @@ class Quel3BackendController(BackendController):
         execution_manager : Quel3ExecutionManager | None, optional
             Injected execution manager for testing or customization.
         """
-        endpoint = self._resolve_runtime_value(
-            name="quelware_endpoint",
-            explicit_value=quelware_endpoint,
-            candidates=[
-                manager.quelware_endpoint
-                for manager in (
-                    connection_manager,
-                    session_manager,
-                    configuration_manager,
-                    execution_manager,
-                )
-                if manager is not None
-            ],
-            default="localhost",
-        )
-        port = self._resolve_runtime_value(
-            name="quelware_port",
-            explicit_value=quelware_port,
-            candidates=[
-                manager.quelware_port
-                for manager in (
-                    connection_manager,
-                    session_manager,
-                    configuration_manager,
-                    execution_manager,
-                )
-                if manager is not None
-            ],
-            default=50051,
-        )
-        explicit_client_mode = None
-        if client_mode is not None:
-            explicit_client_mode = validate_quelware_client_runtime(
-                client_mode=client_mode,
-            )
-        resolved_client_mode = cast(
-            Quel3ClientMode,
-            self._resolve_runtime_value(
-                name="client_mode",
-                explicit_value=explicit_client_mode,
-                candidates=[
-                    manager.client_mode
-                    for manager in (
-                        connection_manager,
-                        session_manager,
-                        configuration_manager,
-                        execution_manager,
-                    )
-                    if manager is not None
-                ],
-                default="server",
-            ),
-        )
-        resolved_client_mode = validate_quelware_client_runtime(
-            client_mode=resolved_client_mode,
-        )
-        resolved_quelware_pat_path = self._resolve_optional_runtime_value(
-            name="quelware_pat_path",
-            explicit_value=quelware_pat_path,
-            candidates=[
-                getattr(manager, "quelware_pat_path", None)
-                for manager in (
-                    connection_manager,
-                    session_manager,
-                    configuration_manager,
-                    execution_manager,
-                )
-                if manager is not None
-            ],
-            default=None,
+        runtime_config = Quel3RuntimeConfig(
+            endpoint=quelware_endpoint or "localhost",
+            port=50051 if quelware_port is None else quelware_port,
+            client_mode=client_mode or "server",
+            pat_path=quelware_pat_path,
         )
         self._sampling_period_ns = (
             execution_manager.sampling_period_ns
             if execution_manager is not None
             else self.SAMPLING_PERIOD_NS
         )
-        self._quelware_endpoint = endpoint
-        self._quelware_port = port
-        self._client_mode: Quel3ClientMode = resolved_client_mode
-        self._quelware_pat_path = resolved_quelware_pat_path
+        self._runtime_config = runtime_config
 
         self._connection_manager = (
             connection_manager
             if connection_manager is not None
             else Quel3ConnectionManager(
-                quelware_endpoint=endpoint,
-                quelware_port=port,
-                client_mode=resolved_client_mode,
-                quelware_pat_path=resolved_quelware_pat_path,
+                runtime_config=runtime_config,
             )
         )
         self._session_manager = (
             session_manager
             if session_manager is not None
             else Quel3SessionManager(
-                quelware_endpoint=endpoint,
-                quelware_port=port,
-                client_mode=resolved_client_mode,
-                quelware_pat_path=resolved_quelware_pat_path,
+                runtime_config=runtime_config,
             )
         )
         self._configuration_manager = (
             configuration_manager
             if configuration_manager is not None
             else Quel3ConfigurationManager(
-                quelware_endpoint=endpoint,
-                quelware_port=port,
-                client_mode=resolved_client_mode,
-                quelware_pat_path=resolved_quelware_pat_path,
+                runtime_config=runtime_config,
             )
         )
         self._execution_manager = (
             execution_manager
             if execution_manager is not None
             else Quel3ExecutionManager(
-                quelware_endpoint=endpoint,
-                quelware_port=port,
+                runtime_config=runtime_config,
                 sampling_period_ns=self._sampling_period_ns,
                 capture_decimation_factor=self.CAPTURE_DECIMATION_FACTOR,
-                client_mode=resolved_client_mode,
-                quelware_pat_path=resolved_quelware_pat_path,
                 session_manager=self._session_manager,
             )
         )
-
-    @staticmethod
-    def _resolve_runtime_value(
-        *,
-        name: str,
-        explicit_value: T | None,
-        candidates: Sequence[T],
-        default: T,
-    ) -> T:
-        """Resolve one runtime value from explicit input and injected managers."""
-        unique_candidates: list[T] = []
-        for candidate in candidates:
-            if candidate not in unique_candidates:
-                unique_candidates.append(candidate)
-        if explicit_value is not None:
-            if any(candidate != explicit_value for candidate in unique_candidates):
-                raise ValueError(f"Inconsistent `{name}` across injected managers.")
-            return explicit_value
-        if len(unique_candidates) > 1:
-            raise ValueError(f"Inconsistent `{name}` across injected managers.")
-        if len(unique_candidates) == 1:
-            return unique_candidates[0]
-        return default
-
-    @staticmethod
-    def _resolve_optional_runtime_value(
-        *,
-        name: str,
-        explicit_value: T | None,
-        candidates: Sequence[T | None],
-        default: T | None,
-    ) -> T | None:
-        """Resolve one optional runtime value from explicit input and injected managers."""
-        unique_candidates: list[T | None] = []
-        for candidate in candidates:
-            if candidate not in unique_candidates:
-                unique_candidates.append(candidate)
-        if explicit_value is not None:
-            if any(candidate != explicit_value for candidate in unique_candidates):
-                raise ValueError(f"Inconsistent `{name}` across injected managers.")
-            return explicit_value
-        if len(unique_candidates) > 1:
-            raise ValueError(f"Inconsistent `{name}` across injected managers.")
-        if len(unique_candidates) == 1:
-            return unique_candidates[0]
-        return default
 
     @property
     def hash(self) -> int:
@@ -270,22 +139,27 @@ class Quel3BackendController(BackendController):
     @property
     def quelware_endpoint(self) -> str:
         """Return configured quelware endpoint."""
-        return self._quelware_endpoint
+        return self._runtime_config.endpoint
 
     @property
     def quelware_port(self) -> int:
         """Return configured quelware port."""
-        return self._quelware_port
+        return self._runtime_config.port
 
     @property
     def client_mode(self) -> Quel3ClientMode:
         """Return configured quelware client mode."""
-        return self._client_mode
+        return self._runtime_config.client_mode_value
 
     @property
     def quelware_pat_path(self) -> str | None:
         """Return configured quelware personal access token path."""
-        return self._quelware_pat_path
+        return self._runtime_config.pat_path
+
+    @property
+    def runtime_config(self) -> Quel3RuntimeConfig:
+        """Return configured quelware runtime settings."""
+        return self._runtime_config
 
     @property
     def configuration_manager(self) -> Quel3ConfigurationManager:

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -24,6 +24,7 @@ from qubex.backend.quel3 import (
     Quel3CaptureWindow,
     Quel3ExecutionPayload,
     Quel3FixedTimeline,
+    Quel3RuntimeConfig,
     Quel3Waveform,
     Quel3WaveformEvent,
 )
@@ -361,6 +362,10 @@ def test_constructor_accepts_quelware_pat_path_runtime_option() -> None:
     assert controller.session_manager.quelware_pat_path == pat_path
     assert controller.configuration_manager.quelware_pat_path == pat_path
     assert controller.execution_manager.quelware_pat_path == pat_path
+    assert controller.connection_manager.runtime_config is controller.runtime_config
+    assert controller.session_manager.runtime_config is controller.runtime_config
+    assert controller.configuration_manager.runtime_config is controller.runtime_config
+    assert controller.execution_manager.runtime_config is controller.runtime_config
 
 
 def test_constructor_accepts_injected_managers() -> None:
@@ -414,11 +419,11 @@ def test_constructor_accepts_injected_managers() -> None:
     assert controller.session_manager is session_manager
     assert controller.configuration_manager is configuration_manager
     assert controller.execution_manager is execution_manager
-    assert controller.quelware_endpoint == "injected-host"
-    assert controller.quelware_port == 61000
+    assert controller.quelware_endpoint == "localhost"
+    assert controller.quelware_port == 50051
     assert controller.sampling_period_ns == pytest.approx(0.8)
     assert controller.client_mode == "server"
-    assert controller.quelware_pat_path == "/run/secrets/quelware-pat"
+    assert controller.quelware_pat_path is None
 
 
 def test_constructor_accepts_injected_session_manager() -> None:
@@ -514,8 +519,8 @@ def test_deploy_instruments_forwards_parallel_flag_to_configuration_manager() ->
     assert captured == {"requests": requests, "parallel": False}
 
 
-def test_constructor_rejects_mismatched_injected_manager_runtime_values() -> None:
-    """Given mismatched injected manager runtime values, constructor should fail fast."""
+def test_constructor_does_not_infer_runtime_config_from_injected_managers() -> None:
+    """Given injected managers, controller runtime config should stay explicit."""
     connection_manager = SimpleNamespace(
         hash=11,
         is_connected=False,
@@ -536,40 +541,19 @@ def test_constructor_rejects_mismatched_injected_manager_runtime_values() -> Non
         deploy_instruments=lambda *, requests: {},
     )
 
-    with pytest.raises(ValueError, match="quelware_endpoint"):
-        Quel3BackendController(
-            connection_manager=cast(Any, connection_manager),
-            configuration_manager=cast(Any, configuration_manager),
-        )
-
-
-def test_constructor_rejects_mismatched_injected_client_runtime_values() -> None:
-    """Given mismatched client runtime values, controller construction should fail fast."""
-    connection_manager = SimpleNamespace(
-        hash=11,
-        is_connected=False,
-        quelware_endpoint="host-a",
-        quelware_port=50051,
-        client_mode="server",
-        quelware_pat_path=None,
-        connect=lambda box_names=None, parallel=None: None,
-        disconnect=lambda: None,
-    )
-    configuration_manager = SimpleNamespace(
-        quelware_endpoint="host-a",
-        quelware_port=50051,
-        client_mode="standalone",
-        quelware_pat_path=None,
-        target_alias_map={},
-        last_deployed_instrument_infos={},
-        deploy_instruments=lambda *, requests: {},
+    controller = Quel3BackendController(
+        quelware_endpoint="explicit-host",
+        quelware_port=61000,
+        quelware_pat_path="/run/secrets/explicit-pat",
+        connection_manager=cast(Any, connection_manager),
+        configuration_manager=cast(Any, configuration_manager),
     )
 
-    with pytest.raises(ValueError, match="client_mode"):
-        Quel3BackendController(
-            connection_manager=cast(Any, connection_manager),
-            configuration_manager=cast(Any, configuration_manager),
-        )
+    assert controller.connection_manager is connection_manager
+    assert controller.configuration_manager is configuration_manager
+    assert controller.quelware_endpoint == "explicit-host"
+    assert controller.quelware_port == 61000
+    assert controller.quelware_pat_path == "/run/secrets/explicit-pat"
 
 
 def test_resolve_payload_merges_targets_mapped_to_one_alias() -> None:
@@ -700,8 +684,7 @@ def test_execute_resolves_unit_prefixed_alias_binding(
         instrument_bindings={"Q00": "alias:quel3-02-a01:Q00"},
     )
     manager = Quel3ExecutionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
+        runtime_config=Quel3RuntimeConfig(),
         sampling_period_ns=0.4,
         capture_decimation_factor=4,
     )
@@ -1107,8 +1090,7 @@ def test_execute_recreates_session_after_transient_request_failure(
     )
     payload = _make_payload()
     manager = Quel3ExecutionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
+        runtime_config=Quel3RuntimeConfig(),
         sampling_period_ns=0.4,
         capture_decimation_factor=4,
     )
@@ -1188,8 +1170,7 @@ def test_execute_ignores_session_close_failure_after_success(
     )
     payload = _make_payload()
     manager = Quel3ExecutionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
+        runtime_config=Quel3RuntimeConfig(),
         sampling_period_ns=0.4,
         capture_decimation_factor=4,
     )
@@ -1238,8 +1219,7 @@ def test_execute_preserves_request_failure_when_session_close_also_fails(
     """Given request and close both fail, execute should preserve the request cause."""
     payload = _make_payload()
     manager = Quel3ExecutionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
+        runtime_config=Quel3RuntimeConfig(),
         sampling_period_ns=0.4,
         capture_decimation_factor=4,
     )
@@ -1297,8 +1277,7 @@ def test_execute_uses_configured_session_request_retry_limit(
     """Given configured retry limit, execute should stop after that many attempts."""
     payload = _make_payload()
     manager = Quel3ExecutionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
+        runtime_config=Quel3RuntimeConfig(),
         sampling_period_ns=0.4,
         capture_decimation_factor=4,
     )
@@ -1366,8 +1345,7 @@ def test_execute_batch_recreates_session_after_transient_request_failure(
     """Given transient quelware request failure, batch execute should retry the batch."""
     payload = _make_payload()
     manager = Quel3ExecutionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
+        runtime_config=Quel3RuntimeConfig(),
         sampling_period_ns=0.4,
         capture_decimation_factor=4,
     )
@@ -1426,8 +1404,7 @@ def test_execute_batches_capture_mode_with_timeline_directive(
     """Given fixed-timeline execution, execute batches directives per instrument."""
     payload = _make_payload()
     manager = Quel3ExecutionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
+        runtime_config=Quel3RuntimeConfig(),
         sampling_period_ns=0.4,
         capture_decimation_factor=4,
     )
@@ -1474,8 +1451,7 @@ def test_execute_batches_frequency_capture_mode_with_timeline_directive(
     """Given payload frequency, execute should apply frequency before capture mode and timeline."""
     payload = _make_payload(frequency_hz=6.25e9)
     manager = Quel3ExecutionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
+        runtime_config=Quel3RuntimeConfig(),
         sampling_period_ns=0.4,
         capture_decimation_factor=4,
     )
@@ -1518,8 +1494,7 @@ def test_execute_rejects_runtime_without_required_capture_mode(
     """Given missing runtime capture mode, execute raises RuntimeError."""
     payload = _make_payload()
     manager = Quel3ExecutionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
+        runtime_config=Quel3RuntimeConfig(),
         sampling_period_ns=0.4,
         capture_decimation_factor=4,
     )
@@ -1569,8 +1544,7 @@ def test_execute_parallelizes_driver_phases(
         },
     )
     manager = Quel3ExecutionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
+        runtime_config=Quel3RuntimeConfig(),
         sampling_period_ns=0.4,
         capture_decimation_factor=4,
     )
@@ -1650,8 +1624,7 @@ def test_execute_batch_async_reopens_session_between_payloads(
     payload_a = _make_payload()
     payload_b = _make_payload()
     manager = Quel3ExecutionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
+        runtime_config=Quel3RuntimeConfig(),
         sampling_period_ns=0.4,
         capture_decimation_factor=1,
     )
@@ -1713,8 +1686,7 @@ def test_execute_serializes_driver_phases_when_parallel_disabled(
         },
     )
     manager = Quel3ExecutionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
+        runtime_config=Quel3RuntimeConfig(),
         sampling_period_ns=0.4,
         capture_decimation_factor=4,
     )

--- a/tests/backend/test_quel3_client_factory.py
+++ b/tests/backend/test_quel3_client_factory.py
@@ -8,6 +8,13 @@ from types import SimpleNamespace
 import pytest
 
 from qubex.backend.quel3.infra import quelware_imports as quelware_imports_module
+from qubex.backend.quel3.managers import (
+    Quel3ConfigurationManager,
+    Quel3ConnectionManager,
+    Quel3ExecutionManager,
+    Quel3RuntimeConfig,
+    Quel3SessionManager,
+)
 
 
 def test_validate_client_runtime_rejects_standalone_mode() -> None:
@@ -86,3 +93,38 @@ def test_load_client_factory_binds_pat_for_server_mode(
     assert callable(pat_provider)
     assert pat_provider() == "dummy-token"
     assert captured == {"endpoint": "worker-host", "port": 61000}
+
+
+def test_runtime_config_normalizes_client_runtime() -> None:
+    """Given mixed-case runtime input, runtime config should expose canonical values."""
+    config = Quel3RuntimeConfig(
+        endpoint="worker-host",
+        port=61000,
+        client_mode=" Server ",
+        pat_path="/run/secrets/quelware-pat",
+    )
+
+    assert config.endpoint == "worker-host"
+    assert config.port == 61000
+    assert config.client_mode == "server"
+    assert config.pat_path == "/run/secrets/quelware-pat"
+
+
+def test_managers_accept_shared_runtime_config() -> None:
+    """Given one runtime config, all QuEL-3 managers should expose that shared config."""
+    config = Quel3RuntimeConfig(endpoint="worker-host", port=61000)
+    session_manager = Quel3SessionManager(runtime_config=config)
+
+    managers = (
+        Quel3ConnectionManager(runtime_config=config),
+        session_manager,
+        Quel3ConfigurationManager(runtime_config=config),
+        Quel3ExecutionManager(
+            runtime_config=config,
+            sampling_period_ns=0.4,
+            capture_decimation_factor=4,
+            session_manager=session_manager,
+        ),
+    )
+
+    assert all(manager.runtime_config is config for manager in managers)

--- a/tests/backend/test_quel3_configuration_manager.py
+++ b/tests/backend/test_quel3_configuration_manager.py
@@ -11,7 +11,9 @@ import pytest
 
 from qubex.backend.quel3.managers import (
     Quel3ConfigurationManager,
+    Quel3RuntimeConfig,
     configuration_manager as configuration_manager_module,
+    runtime_config as runtime_config_module,
     session_workarounds as session_workarounds_module,
 )
 from qubex.backend.quel3.managers.session_workarounds import QuelwareSessionError
@@ -63,10 +65,7 @@ def test_deploy_instruments_calls_session_api(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given deploy requests, backend configuration manager should call session deploy."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Profile:
         def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
@@ -190,10 +189,7 @@ def test_deploy_instruments_recreates_session_after_transient_request_failure(
         logging.WARNING,
         logger="qubex.backend.quel3.managers.configuration_manager",
     )
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Profile:
         def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
@@ -350,10 +346,7 @@ def test_deploy_instruments_ignores_session_close_failure_after_success(
         logging.WARNING,
         logger="qubex.backend.quel3.managers.configuration_manager",
     )
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Profile:
         def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
@@ -472,10 +465,7 @@ def test_deploy_instruments_wraps_final_request_failure(
 ) -> None:
     """Given retry limit is reached, deploy should raise a token-annotated error."""
     failed_session_id = "failed-deploy-session"
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Profile:
         def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
@@ -591,10 +581,7 @@ def test_deploy_instruments_retries_resource_allocation_on_session_create(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given transient resource allocation failure, deploy should retry session creation."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     async def _skip_sleep(delay: float) -> None:
         del delay
@@ -734,10 +721,7 @@ def test_deploy_instruments_accepts_unit_prefixed_returned_alias(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given quelware prefixes aliases by unit, deploy should keep target bindings usable."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Profile:
         def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
@@ -847,10 +831,7 @@ def test_deploy_instruments_accepts_unit_prefixed_returned_alias(
 
 def test_deploy_instruments_clears_cache_for_empty_requests() -> None:
     """Given empty requests, backend configuration manager should clear deployment cache."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
     request = InstrumentDeployRequest(
         port_id="quel3-02-a01:tx_p02",
         role="TRANSMITTER",
@@ -882,10 +863,7 @@ def test_deploy_instruments_groups_requests_by_port(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given same-port requests, backend configuration manager should batch one deploy call."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Profile:
         def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
@@ -1015,10 +993,7 @@ def test_deploy_instruments_uses_one_session_for_all_ports(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given multiple ports, backend configuration manager should reuse one session."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Profile:
         def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
@@ -1138,10 +1113,7 @@ def test_deploy_instruments_parallelizes_ports_by_default(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given multiple ports, deploy_instruments should run port batches concurrently."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Profile:
         def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
@@ -1264,10 +1236,7 @@ def test_deploy_instruments_parallel_false_serializes_ports(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given parallel false, deploy_instruments should deploy port batches serially."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Profile:
         def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
@@ -1394,7 +1363,7 @@ def test_load_client_factory_uses_configured_client_runtime(
     captured: dict[str, object] = {}
     fake_client_factory = object()
     monkeypatch.setattr(
-        configuration_manager_module,
+        runtime_config_module,
         "load_quelware_client_factory",
         lambda *, client_mode, pat_path=None: (
             captured.update(
@@ -1407,9 +1376,7 @@ def test_load_client_factory_uses_configured_client_runtime(
         ),
     )
     manager = Quel3ConfigurationManager(
-        quelware_endpoint="worker-host",
-        quelware_port=61000,
-        client_mode="server",
+        runtime_config=Quel3RuntimeConfig(endpoint="worker-host", port=61000),
     )
 
     client_factory = manager._load_quelware_client_factory()  # noqa: SLF001
@@ -1439,14 +1406,16 @@ def test_load_client_factory_uses_configured_pat_path(
         return fake_client_factory
 
     monkeypatch.setattr(
-        configuration_manager_module,
+        runtime_config_module,
         "load_quelware_client_factory",
         _load_quelware_client_factory,
     )
     manager = Quel3ConfigurationManager(
-        quelware_endpoint="worker-host",
-        quelware_port=61000,
-        quelware_pat_path=pat_path,
+        runtime_config=Quel3RuntimeConfig(
+            endpoint="worker-host",
+            port=61000,
+            pat_path=pat_path,
+        ),
     )
 
     client_factory = manager._load_quelware_client_factory()  # noqa: SLF001
@@ -1462,10 +1431,7 @@ def test_refresh_instrument_cache_loads_existing_instruments(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given existing quelware instruments, refreshing cache should expose alias mappings."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Category:
         name = "INSTRUMENT"
@@ -1523,10 +1489,7 @@ def test_refresh_instrument_cache_maps_unit_prefixed_aliases(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given cached quelware aliases with unit prefixes, refresh should map local targets to runtime aliases."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Category:
         name = "INSTRUMENT"
@@ -1583,10 +1546,7 @@ def test_fetch_backend_settings_from_hardware_groups_instruments_by_box(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given quelware instruments, hardware fetch should normalize them per box."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _InstrumentCategory:
         name = "INSTRUMENT"
@@ -1763,10 +1723,7 @@ def test_fetch_backend_settings_skips_unselected_unit_instrument_details(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given selected unit labels, hardware fetch should not inspect instruments on other units."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _InstrumentCategory:
         name = "INSTRUMENT"
@@ -1834,10 +1791,7 @@ def test_fetch_backend_settings_skips_unselected_unit_instrument_details(
 
 def test_sync_backend_settings_to_cache_restores_alias_mapping_from_snapshot() -> None:
     """Given hardware snapshot, cache sync should restore alias mappings."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     manager.sync_backend_settings_to_cache(
         backend_settings={
@@ -1908,10 +1862,7 @@ def test_deploy_instruments_replaces_cached_alias(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given cached alias, deploy_instruments should replace it through quelware."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Profile:
         def __init__(self, *, frequency_range_min: float, frequency_range_max: float):
@@ -2024,10 +1975,7 @@ def test_deploy_instruments_replaces_cached_port_in_one_batched_deploy(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given cached port instruments, deploy should replace the port in one call."""
-    manager = Quel3ConfigurationManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3ConfigurationManager()
 
     class _Profile:
         def __init__(self, *, frequency_range_min: float, frequency_range_max: float):

--- a/tests/backend/test_quel3_session_manager.py
+++ b/tests/backend/test_quel3_session_manager.py
@@ -136,10 +136,7 @@ def test_open_retries_transient_resource_allocation_failure(
     client = _FakeClient(successful_session=session)
     client_context = _FakeClientContext(client)
     sleep_delays = _patch_session_retry_sleep(monkeypatch)
-    manager = Quel3SessionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3SessionManager()
 
     async def _run() -> object:
         opened_session = await manager.open(
@@ -202,10 +199,7 @@ def test_open_retries_when_failed_session_token_is_unavailable(
     client = _FakeClientWithUnopenedFailure()
     client_context = _FakeClientContext(cast(Any, client))
     _patch_session_retry_sleep(monkeypatch)
-    manager = Quel3SessionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3SessionManager()
 
     async def _run() -> object:
         opened_session = await manager.open(
@@ -239,10 +233,7 @@ def test_open_logs_session_token_on_session_create_failure(
     client = _FakeClient(successful_session=session, failures_before_success=1)
     client_context = _FakeClientContext(client)
     _patch_session_retry_sleep(monkeypatch)
-    manager = Quel3SessionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3SessionManager()
 
     async def _run() -> None:
         await manager.open(
@@ -266,10 +257,7 @@ def test_open_captures_session_token_on_success(
     session = _SuccessfulSession(session_id="opened-session")
     client = _FakeClient(successful_session=session, failures_before_success=0)
     client_context = _FakeClientContext(client)
-    manager = Quel3SessionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3SessionManager()
 
     async def _run() -> tuple[str | None, str | None]:
         await manager.open(
@@ -319,10 +307,7 @@ def test_open_retries_transient_unit_unavailable_failure(
     )
     client_context = _FakeClientContext(client)
     sleep_delays = _patch_session_retry_sleep(monkeypatch)
-    manager = Quel3SessionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3SessionManager()
 
     async def _run() -> object:
         opened_session = await manager.open(
@@ -357,10 +342,7 @@ def test_open_stops_after_session_create_retry_limit(
     client_context = _FakeClientContext(client)
     sleep_delays = _patch_session_retry_sleep(monkeypatch)
     expected_session_id = "failed-create-session-4"
-    manager = Quel3SessionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3SessionManager()
 
     async def _run() -> QuelwareSessionError:
         with pytest.raises(
@@ -405,10 +387,7 @@ def test_open_succeeds_on_final_session_create_retry(
     )
     client_context = _FakeClientContext(client)
     sleep_delays = _patch_session_retry_sleep(monkeypatch)
-    manager = Quel3SessionManager(
-        quelware_endpoint="localhost",
-        quelware_port=50051,
-    )
+    manager = Quel3SessionManager()
 
     async def _run() -> object:
         opened_session = await manager.open(


### PR DESCRIPTION
## Summary
- Add a shared QuEL-3 manager runtime config object for manager construction.
- Remove duplicated runtime configuration plumbing from the controller and managers.
- Update QuEL-3 backend, configuration, session, and client factory tests for the shared config path.

## Compatibility
No public API change is intended. The change keeps the existing QuEL-3 runtime behavior while centralizing internal manager configuration.

## Validation
- `env UV_CACHE_DIR=/tmp/uv-cache uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest` (1122 passed)
