### PR TITLE
refactor(quel3): prepare payload sessions before alias rewrite

### DIFF
--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -461,15 +461,7 @@ class Quel3ExecutionManager:
         capture_sampling_period_ns: float | None = None
         for alias in aliases:
             driver = alias_to_driver[alias]
-            sampling_period_fs = getattr(
-                driver.instrument_config,
-                "sampling_period_fs",
-                None,
-            )
-            if not isinstance(sampling_period_fs, int):
-                raise TypeError(
-                    "Instrument config must expose integer `sampling_period_fs`."
-                )
+            sampling_period_fs = driver.instrument_config.sampling_period_fs
             if len(payload.fixed_timelines[alias].capture_windows) == 0:
                 continue
             alias_sampling_period_ns = sampling_period_fs / 1e6
@@ -536,24 +528,8 @@ class Quel3ExecutionManager:
         instrument_resource_ids: list[ResourceIdProtocol] = []
         for alias in aliases:
             driver = session_state.alias_to_driver[alias]
-            sampling_period_fs = getattr(
-                driver.instrument_config,
-                "sampling_period_fs",
-                None,
-            )
-            timeline_step_samples = getattr(
-                driver.instrument_config,
-                "timeline_step_samples",
-                None,
-            )
-            if not isinstance(sampling_period_fs, int):
-                raise TypeError(
-                    "Instrument config must expose integer `sampling_period_fs`."
-                )
-            if not isinstance(timeline_step_samples, int):
-                raise TypeError(
-                    "Instrument config must expose integer `timeline_step_samples`."
-                )
+            sampling_period_fs = driver.instrument_config.sampling_period_fs
+            timeline_step_samples = driver.instrument_config.timeline_step_samples
             alias_bindings[alias] = (
                 sampling_period_fs,
                 timeline_step_samples,
@@ -712,26 +688,12 @@ class Quel3ExecutionManager:
     ) -> dict[str, ResourceIdProtocol]:
         """Resolve alias-to-resource-id mapping from resolved instrument infos."""
         alias_to_resource_id: dict[str, ResourceIdProtocol] = {}
-        aliases_without_resource_id: list[str] = []
         for alias in aliases:
             instrument_info = alias_to_instrument_info[alias]
-            resource_id = getattr(instrument_info, "id", None)
+            resource_id = instrument_info.id
             if isinstance(resource_id, str) and len(resource_id) > 0:
                 alias_to_resource_id[alias] = resource_id
-            else:
-                aliases_without_resource_id.append(alias)
 
-        if len(aliases_without_resource_id) == 0:
-            return alias_to_resource_id
-
-        resource_ids = resolver.resolve(aliases_without_resource_id)
-        if len(resource_ids) != len(aliases_without_resource_id):
-            raise ValueError(
-                "InstrumentResolver returned inconsistent alias resolution length."
-            )
-        alias_to_resource_id.update(
-            zip(aliases_without_resource_id, resource_ids, strict=True)
-        )
         return alias_to_resource_id
 
     @classmethod

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -6,7 +6,7 @@ import asyncio
 import importlib
 import logging
 from collections import defaultdict
-from collections.abc import Awaitable, Callable, Sequence
+from collections.abc import Awaitable, Callable, Collection, Sequence
 from dataclasses import dataclass, replace
 from typing import TypeGuard, TypeVar, cast
 
@@ -78,6 +78,15 @@ class _PayloadExecutionSession:
     alias_to_resource_id: dict[str, ResourceIdProtocol]
     alias_to_driver: dict[str, InstrumentDriverProtocol]
     capture_sampling_period_ns: float | None
+
+
+@dataclass(frozen=True)
+class _PayloadExecutionPlan:
+    """Resolved payload and runtime aliases required for one execution."""
+
+    resolved_payload: Quel3ExecutionPayload
+    aliases: tuple[str, ...]
+    aliases_with_captures: frozenset[str]
 
 
 @dataclass(frozen=True)
@@ -209,10 +218,14 @@ class Quel3ExecutionManager:
             raise RuntimeError(
                 "quelware-client is not available. Install compatible quelware packages or configure PYTHONPATH."
             ) from exc
+        payload_plans = [
+            self._prepare_payload_execution_plan(payload=payload)
+            for payload in payloads
+        ]
 
         return await self._run_with_session_request_retry(
             lambda: self._execute_batch_once(
-                payloads=payloads,
+                payload_plans=payload_plans,
                 quelware_api=quelware_api,
                 parallel=parallel,
             )
@@ -257,10 +270,11 @@ class Quel3ExecutionManager:
             raise RuntimeError(
                 "quelware-client is not available. Install compatible quelware packages or configure PYTHONPATH."
             ) from exc
+        payload_plan = self._prepare_payload_execution_plan(payload=payload)
 
         results = await self._run_with_session_request_retry(
             lambda: self._execute_batch_once(
-                payloads=[payload],
+                payload_plans=[payload_plan],
                 quelware_api=quelware_api,
                 parallel=parallel,
             )
@@ -341,7 +355,7 @@ class Quel3ExecutionManager:
     async def _execute_batch_once(
         self,
         *,
-        payloads: list[Quel3ExecutionPayload],
+        payload_plans: list[_PayloadExecutionPlan],
         quelware_api: _QuelwareExecutionApi,
         parallel: bool,
     ) -> list[Quel3BackendExecutionResult]:
@@ -350,19 +364,20 @@ class Quel3ExecutionManager:
             quelware_api=quelware_api,
         )
         results = []
-        for payload in payloads:
-            resolved_payload = self._resolve_execution_payload(
-                payload=payload,
+        for payload_plan in payload_plans:
+            alias_to_instrument_info = self._resolve_alias_to_instrument_info_map(
                 resolver=resolver,
+                aliases=payload_plan.aliases,
             )
             session_state = await self._open_payload_execution_session(
-                resolver=resolver,
-                resolved_payload=resolved_payload,
+                alias_to_instrument_info=alias_to_instrument_info,
+                aliases=payload_plan.aliases,
+                aliases_with_captures=payload_plan.aliases_with_captures,
                 quelware_api=quelware_api,
             )
             results.append(
                 await self._execute_resolved_payload(
-                    payload=resolved_payload,
+                    payload=payload_plan.resolved_payload,
                     session_state=session_state,
                     quelware_api=quelware_api,
                     parallel=parallel,
@@ -370,32 +385,16 @@ class Quel3ExecutionManager:
             )
         return results
 
-    def _resolve_execution_payload(
-        self,
-        *,
-        payload: Quel3ExecutionPayload,
-        resolver: InstrumentResolverProtocol,
-    ) -> Quel3ExecutionPayload:
-        """Resolve one payload to concrete runnable aliases."""
-        del resolver
-        resolved_payload = self._resolve_payload(payload=payload)
-        return self._filter_runnable_payload(resolved_payload)
-
     async def _open_payload_execution_session(
         self,
         *,
-        resolver: InstrumentResolverProtocol,
-        resolved_payload: Quel3ExecutionPayload,
+        alias_to_instrument_info: dict[str, InstrumentInfoProtocol],
+        aliases: Sequence[str],
+        aliases_with_captures: Collection[str],
         quelware_api: _QuelwareExecutionApi,
     ) -> _PayloadExecutionSession:
         """Open a payload session and rebuild session-bound drivers."""
-        aliases = tuple(sorted(resolved_payload.fixed_timelines))
-        alias_to_instrument_info = self._resolve_alias_to_instrument_info_map(
-            resolver=resolver,
-            aliases=aliases,
-        )
         alias_to_resource_id = self._resolve_alias_to_resource_id_map(
-            resolver=resolver,
             alias_to_instrument_info=alias_to_instrument_info,
             aliases=aliases,
         )
@@ -428,7 +427,7 @@ class Quel3ExecutionManager:
             quelware_api=quelware_api,
         )
         capture_sampling_period_ns = self._resolve_capture_sampling_period_ns(
-            payload=resolved_payload,
+            aliases_with_captures=aliases_with_captures,
             alias_to_driver=alias_to_driver,
             aliases=aliases,
         )
@@ -453,17 +452,17 @@ class Quel3ExecutionManager:
     @staticmethod
     def _resolve_capture_sampling_period_ns(
         *,
-        payload: Quel3ExecutionPayload,
+        aliases_with_captures: Collection[str],
         alias_to_driver: dict[str, InstrumentDriverProtocol],
         aliases: Sequence[str],
     ) -> float | None:
         """Resolve the capture sampling period for one resolved payload."""
         capture_sampling_period_ns: float | None = None
         for alias in aliases:
+            if alias not in aliases_with_captures:
+                continue
             driver = alias_to_driver[alias]
             sampling_period_fs = driver.instrument_config.sampling_period_fs
-            if len(payload.fixed_timelines[alias].capture_windows) == 0:
-                continue
             alias_sampling_period_ns = sampling_period_fs / 1e6
             if capture_sampling_period_ns is None:
                 capture_sampling_period_ns = alias_sampling_period_ns
@@ -682,7 +681,6 @@ class Quel3ExecutionManager:
     @staticmethod
     def _resolve_alias_to_resource_id_map(
         *,
-        resolver: InstrumentResolverProtocol,
         alias_to_instrument_info: dict[str, InstrumentInfoProtocol],
         aliases: Sequence[str],
     ) -> dict[str, ResourceIdProtocol]:
@@ -695,6 +693,25 @@ class Quel3ExecutionManager:
                 alias_to_resource_id[alias] = resource_id
 
         return alias_to_resource_id
+
+    @classmethod
+    def _prepare_payload_execution_plan(
+        cls,
+        *,
+        payload: Quel3ExecutionPayload,
+    ) -> _PayloadExecutionPlan:
+        """Resolve and validate one payload before opening a session."""
+        runnable_payload = cls._filter_runnable_payload(payload)
+        resolved_payload = cls._resolve_payload(payload=runnable_payload)
+        return _PayloadExecutionPlan(
+            resolved_payload=resolved_payload,
+            aliases=tuple(sorted(resolved_payload.fixed_timelines)),
+            aliases_with_captures=frozenset(
+                alias
+                for alias, timeline in resolved_payload.fixed_timelines.items()
+                if len(timeline.capture_windows) > 0
+            ),
+        )
 
     @classmethod
     def _resolve_payload(

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -71,10 +71,9 @@ def _has_iq_array(value: object) -> TypeGuard[IqWaveformResultProtocol]:
 
 
 @dataclass(frozen=True)
-class _ExecutionRuntime:
-    """Resolved QuEL-3 runtime state reusable across multiple executions."""
+class _PayloadExecutionSession:
+    """Session-bound QuEL-3 state for one resolved payload."""
 
-    resolver: InstrumentResolverProtocol
     session: SessionProtocol
     alias_to_resource_id: dict[str, ResourceIdProtocol]
     alias_to_driver: dict[str, InstrumentDriverProtocol]
@@ -259,13 +258,14 @@ class Quel3ExecutionManager:
                 "quelware-client is not available. Install compatible quelware packages or configure PYTHONPATH."
             ) from exc
 
-        return await self._run_with_session_request_retry(
-            lambda: self._execute_once(
-                payload=payload,
+        results = await self._run_with_session_request_retry(
+            lambda: self._execute_batch_once(
+                payloads=[payload],
                 quelware_api=quelware_api,
                 parallel=parallel,
             )
         )
+        return results[0]
 
     async def _run_with_session_request_retry(
         self,
@@ -338,25 +338,6 @@ class Quel3ExecutionManager:
             return exc.session_token
         return self._active_session_token()
 
-    async def _execute_once(
-        self,
-        *,
-        payload: Quel3ExecutionPayload,
-        quelware_api: _QuelwareExecutionApi,
-        parallel: bool,
-    ) -> Quel3BackendExecutionResult:
-        """Execute one payload using a single fresh quelware session."""
-        runtime, resolved_payload = await self._open_execution_runtime(
-            payload=payload,
-            quelware_api=quelware_api,
-        )
-        return await self._execute_resolved_payload(
-            payload=resolved_payload,
-            runtime=runtime,
-            quelware_api=quelware_api,
-            parallel=parallel,
-        )
-
     async def _execute_batch_once(
         self,
         *,
@@ -365,68 +346,61 @@ class Quel3ExecutionManager:
         parallel: bool,
     ) -> list[Quel3BackendExecutionResult]:
         """Execute one payload batch with per-payload quelware sessions."""
-        runtime, first_resolved_payload = await self._open_execution_runtime(
-            payload=payloads[0],
+        resolver = await self._open_execution_resolver(
             quelware_api=quelware_api,
         )
-        expected_aliases = tuple(sorted(first_resolved_payload.fixed_timelines))
-        results = [
-            await self._execute_resolved_payload(
-                payload=first_resolved_payload,
-                runtime=runtime,
-                quelware_api=quelware_api,
-                parallel=parallel,
-            )
-        ]
-        for payload in payloads[1:]:
-            resolved_payload = self._resolve_batch_payload(
+        results = []
+        for payload in payloads:
+            resolved_payload = self._resolve_execution_payload(
                 payload=payload,
-                expected_aliases=expected_aliases,
+                resolver=resolver,
             )
-            runtime = await self._reopen_execution_runtime_session(
-                runtime=runtime,
+            session_state = await self._open_payload_execution_session(
+                resolver=resolver,
                 resolved_payload=resolved_payload,
                 quelware_api=quelware_api,
-                aliases=expected_aliases,
             )
             results.append(
                 await self._execute_resolved_payload(
                     payload=resolved_payload,
-                    runtime=runtime,
+                    session_state=session_state,
                     quelware_api=quelware_api,
                     parallel=parallel,
                 )
             )
         return results
 
-    def _resolve_batch_payload(
+    def _resolve_execution_payload(
         self,
         *,
         payload: Quel3ExecutionPayload,
-        expected_aliases: Sequence[str],
+        resolver: InstrumentResolverProtocol,
     ) -> Quel3ExecutionPayload:
-        """Resolve one batched payload and verify it matches the batch shape."""
+        """Resolve one payload to concrete runnable aliases."""
+        del resolver
         resolved_payload = self._resolve_payload(payload=payload)
-        resolved_payload = self._filter_runnable_payload(resolved_payload)
-        resolved_aliases = tuple(sorted(resolved_payload.fixed_timelines))
-        if resolved_aliases != tuple(expected_aliases):
-            raise ValueError(
-                "Batched QuEL-3 execution requires all points to resolve "
-                "to the same instrument alias set."
-            )
-        return resolved_payload
+        return self._filter_runnable_payload(resolved_payload)
 
-    async def _reopen_execution_runtime_session(
+    async def _open_payload_execution_session(
         self,
         *,
-        runtime: _ExecutionRuntime,
+        resolver: InstrumentResolverProtocol,
         resolved_payload: Quel3ExecutionPayload,
         quelware_api: _QuelwareExecutionApi,
-        aliases: Sequence[str],
-    ) -> _ExecutionRuntime:
-        """Reopen the quelware session and rebuild session-bound drivers."""
+    ) -> _PayloadExecutionSession:
+        """Open a payload session and rebuild session-bound drivers."""
+        aliases = tuple(sorted(resolved_payload.fixed_timelines))
+        alias_to_instrument_info = self._resolve_alias_to_instrument_info_map(
+            resolver=resolver,
+            aliases=aliases,
+        )
+        alias_to_resource_id = self._resolve_alias_to_resource_id_map(
+            resolver=resolver,
+            alias_to_instrument_info=alias_to_instrument_info,
+            aliases=aliases,
+        )
         instrument_resource_ids = self._resource_ids_for_aliases(
-            alias_to_resource_id=runtime.alias_to_resource_id,
+            alias_to_resource_id=alias_to_resource_id,
             aliases=aliases,
         )
         session_token = self._active_session_token()
@@ -447,64 +421,43 @@ class Quel3ExecutionManager:
                 "QuEL-3 session reopen did not return an execution session."
             )
 
-        alias_to_instrument_info = self._resolve_alias_to_instrument_info_map(
-            resolver=runtime.resolver,
-            aliases=aliases,
-        )
         alias_to_driver = self._build_alias_driver_map(
             session=session,
             alias_to_instrument_info=alias_to_instrument_info,
             aliases=aliases,
             quelware_api=quelware_api,
         )
-        return replace(
-            runtime,
-            session=session,
+        capture_sampling_period_ns = self._resolve_capture_sampling_period_ns(
+            payload=resolved_payload,
             alias_to_driver=alias_to_driver,
+            aliases=aliases,
+        )
+        return _PayloadExecutionSession(
+            session=session,
+            alias_to_resource_id=alias_to_resource_id,
+            alias_to_driver=alias_to_driver,
+            capture_sampling_period_ns=capture_sampling_period_ns,
         )
 
-    async def _open_execution_runtime(
+    async def _open_execution_resolver(
         self,
         *,
-        payload: Quel3ExecutionPayload,
         quelware_api: _QuelwareExecutionApi,
-    ) -> tuple[_ExecutionRuntime, Quel3ExecutionPayload]:
-        """Open one reusable quelware runtime for a resolved alias set."""
+    ) -> InstrumentResolverProtocol:
+        """Open the quelware client and refresh instrument resolution once."""
         await self._session_manager.open(client_factory=quelware_api.client_factory)
         resolver = quelware_api.instrument_resolver_factory()
         await resolver.refresh(self._session_manager.client)
+        return resolver
 
-        resolved_payload = self._resolve_payload(payload=payload)
-        resolved_payload = self._filter_runnable_payload(resolved_payload)
-        aliases = tuple(sorted(resolved_payload.fixed_timelines.keys()))
-        alias_to_instrument_info = self._resolve_alias_to_instrument_info_map(
-            resolver=resolver,
-            aliases=aliases,
-        )
-        alias_to_resource_id = self._resolve_alias_to_resource_id_map(
-            resolver=resolver,
-            alias_to_instrument_info=alias_to_instrument_info,
-            aliases=aliases,
-        )
-        instrument_resource_ids = self._resource_ids_for_aliases(
-            alias_to_resource_id=alias_to_resource_id,
-            aliases=aliases,
-        )
-        session = await self._session_manager.open(
-            instrument_resource_ids,
-            client_factory=quelware_api.client_factory,
-        )
-        if session is None:
-            raise RuntimeError(
-                "QuEL-3 session open did not return an execution session."
-            )
-
-        alias_to_driver = self._build_alias_driver_map(
-            session=session,
-            alias_to_instrument_info=alias_to_instrument_info,
-            aliases=aliases,
-            quelware_api=quelware_api,
-        )
+    @staticmethod
+    def _resolve_capture_sampling_period_ns(
+        *,
+        payload: Quel3ExecutionPayload,
+        alias_to_driver: dict[str, InstrumentDriverProtocol],
+        aliases: Sequence[str],
+    ) -> float | None:
+        """Resolve the capture sampling period for one resolved payload."""
         capture_sampling_period_ns: float | None = None
         for alias in aliases:
             driver = alias_to_driver[alias]
@@ -517,7 +470,7 @@ class Quel3ExecutionManager:
                 raise TypeError(
                     "Instrument config must expose integer `sampling_period_fs`."
                 )
-            if len(resolved_payload.fixed_timelines[alias].capture_windows) == 0:
+            if len(payload.fixed_timelines[alias].capture_windows) == 0:
                 continue
             alias_sampling_period_ns = sampling_period_fs / 1e6
             if capture_sampling_period_ns is None:
@@ -527,17 +480,7 @@ class Quel3ExecutionManager:
                 alias_sampling_period_ns,
             ):
                 raise ValueError("Capture aliases must agree on sampling period.")
-
-        return (
-            _ExecutionRuntime(
-                resolver=resolver,
-                session=session,
-                alias_to_resource_id=alias_to_resource_id,
-                alias_to_driver=alias_to_driver,
-                capture_sampling_period_ns=capture_sampling_period_ns,
-            ),
-            resolved_payload,
-        )
+        return capture_sampling_period_ns
 
     @staticmethod
     def _resource_ids_for_aliases(
@@ -583,16 +526,16 @@ class Quel3ExecutionManager:
         self,
         *,
         payload: Quel3ExecutionPayload,
-        runtime: _ExecutionRuntime,
+        session_state: _PayloadExecutionSession,
         quelware_api: _QuelwareExecutionApi,
         parallel: bool,
     ) -> Quel3BackendExecutionResult:
-        """Execute one payload using an already-open runtime."""
+        """Execute one payload using an already-open payload session."""
         aliases = sorted(payload.fixed_timelines.keys())
         alias_bindings: dict[str, tuple[int, int]] = {}
         instrument_resource_ids: list[ResourceIdProtocol] = []
         for alias in aliases:
-            driver = runtime.alias_to_driver[alias]
+            driver = session_state.alias_to_driver[alias]
             sampling_period_fs = getattr(
                 driver.instrument_config,
                 "sampling_period_fs",
@@ -615,7 +558,7 @@ class Quel3ExecutionManager:
                 sampling_period_fs,
                 timeline_step_samples,
             )
-            instrument_resource_ids.append(runtime.alias_to_resource_id[alias])
+            instrument_resource_ids.append(session_state.alias_to_resource_id[alias])
 
         sequencer = self._sequencer_builder.build(
             payload=payload,
@@ -635,20 +578,20 @@ class Quel3ExecutionManager:
             for alias in aliases
         }
         await self._initialize_drivers(
-            drivers=tuple(runtime.alias_to_driver.values()),
+            drivers=tuple(session_state.alias_to_driver.values()),
             parallel=parallel,
         )
         await self._apply_drivers(
-            alias_to_driver=runtime.alias_to_driver,
+            alias_to_driver=session_state.alias_to_driver,
             alias_to_directives=alias_to_directives,
             parallel=parallel,
         )
 
         shot_samples = self._initialize_shot_samples(payload)
-        await runtime.session.trigger(instrument_ids=instrument_resource_ids)
+        await session_state.session.trigger(instrument_ids=instrument_resource_ids)
         alias_results = await self._fetch_alias_results(
             aliases=aliases,
-            alias_to_driver=runtime.alias_to_driver,
+            alias_to_driver=session_state.alias_to_driver,
             parallel=parallel,
         )
         for alias, timeline in payload.fixed_timelines.items():
@@ -667,7 +610,7 @@ class Quel3ExecutionManager:
         return self._build_measurement_result(
             payload=payload,
             shot_samples=shot_samples,
-            capture_sampling_period_ns=runtime.capture_sampling_period_ns,
+            capture_sampling_period_ns=session_state.capture_sampling_period_ns,
             backend_sampling_period_ns=self._sampling_period_ns,
             capture_decimation_factor=self._capture_decimation_factor,
         )

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -44,12 +44,14 @@ class _FakeCaptureMode(Enum):
 @dataclass(frozen=True)
 class _FakeInstrumentDefinition:
     role: str
+    alias: str = ""
 
 
 @dataclass(frozen=True)
 class _FakeInstrumentInfo:
     port_id: str
     definition: _FakeInstrumentDefinition
+    id: str = ""
     alias: str | None = None
 
 
@@ -59,8 +61,26 @@ class _FakeInstrumentResolver:
         *,
         alias_to_info: dict[str, _FakeInstrumentInfo],
     ) -> None:
-        self._alias_to_info = dict(alias_to_info)
-        self._alias_to_id = {alias: alias for alias in self._alias_to_info}
+        self._alias_to_info = {
+            alias: self._with_required_fields(alias=alias, instrument_info=info)
+            for alias, info in alias_to_info.items()
+        }
+
+    @staticmethod
+    def _with_required_fields(
+        *,
+        alias: str,
+        instrument_info: _FakeInstrumentInfo,
+    ) -> _FakeInstrumentInfo:
+        runtime_alias = (
+            instrument_info.alias or instrument_info.definition.alias or alias
+        )
+        return replace(
+            instrument_info,
+            id=instrument_info.id or alias,
+            definition=replace(instrument_info.definition, alias=runtime_alias),
+            alias=runtime_alias,
+        )
 
     async def refresh(self, client: object) -> None:
         del client
@@ -1617,10 +1637,10 @@ def test_execute_parallelizes_driver_phases(
     )
 
 
-def test_execute_batch_async_reopens_session_between_payloads(
+def test_execute_batch_async_reopens_session_per_payload(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Given multiple requests, execute_batch_async should reopen sessions and reuse resolver refresh."""
+    """Given multiple requests, execute_batch_async should reopen each payload session."""
     payload_a = _make_payload()
     payload_b = _make_payload()
     manager = Quel3ExecutionManager(

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -778,6 +778,88 @@ def test_execute_resolves_unit_prefixed_alias_binding(
     assert "quel3-02-a01:Q00" in result.data
 
 
+def test_execute_rejects_invalid_payload_before_opening_session(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given invalid payload bindings, execute should fail before session setup."""
+    payload = _make_payload()
+    base_timeline = payload.fixed_timelines["alias-rq00"]
+    payload = replace(
+        payload,
+        fixed_timelines={
+            "RQ00": replace(base_timeline, frequency_hz=6.0e9),
+            "RQ01": replace(base_timeline, frequency_hz=6.1e9),
+        },
+        instrument_bindings={
+            "RQ00": "alias:quel3-02-a01:Q00",
+            "RQ01": "alias:quel3-02-a01:Q00",
+        },
+    )
+    manager = Quel3ExecutionManager(
+        runtime_config=Quel3RuntimeConfig(),
+        sampling_period_ns=0.4,
+        capture_decimation_factor=4,
+    )
+    create_session_calls: list[tuple[str, ...]] = []
+    driver_factory_calls = 0
+
+    class _UnitAwareResolver:
+        async def refresh(self, client: object) -> None:
+            del client
+
+        def resolve(self, aliases: list[str]) -> list[str]:
+            return aliases
+
+        def find_inst_info_by_alias(
+            self,
+            alias: str,
+            *,
+            unit: str | None = None,
+        ) -> _FakeInstrumentInfo:
+            if (alias, unit) != ("Q00", "quel3-02-a01"):
+                raise ValueError(alias)
+            return _FakeInstrumentInfo(
+                id="inst-q00",
+                port_id="quel3-02-a01:tx_p04",
+                definition=_FakeInstrumentDefinition(
+                    alias="Q00",
+                    role="TRANSMITTER",
+                ),
+            )
+
+    class _OrderProbeClient(_FakeClient):
+        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+            create_session_calls.append(tuple(resource_ids))
+            return super().create_session(resource_ids)
+
+    def _create_driver(
+        session: object,
+        instrument_info: object,
+    ) -> _FakeInstrumentDriver:
+        nonlocal driver_factory_calls
+        del session, instrument_info
+        driver_factory_calls += 1
+        return _FakeInstrumentDriver()
+
+    monkeypatch.setattr(
+        manager,
+        "_load_quelware_api",
+        lambda: _make_fake_execution_api(
+            client_factory=lambda endpoint, port: _OrderProbeClient(_FakeSession()),
+            instrument_resolver_factory=_UnitAwareResolver,
+            fixed_timeline_driver_factory=_create_driver,
+        ),
+    )
+
+    with pytest.raises(ValueError, match="Conflicting frequency"):
+        asyncio.run(
+            manager.execute_async(request=BackendExecutionRequest(payload=payload))
+        )
+
+    assert create_session_calls == []
+    assert driver_factory_calls == 0
+
+
 @dataclass(frozen=True)
 class _FakeInstrumentConfig:
     sampling_period_fs: int


### PR DESCRIPTION
## Summary
- Prepare QuEL-3 payload execution plans before opening per-payload sessions.
- Keep unit-qualified runtime alias resolution aligned with the resolved payload.
- Add regression coverage for invalid shared-alias payloads failing before session or driver setup.

## Impact
- No public API signature changes.
- Invalid deterministic payload conflicts now fail before quelware session creation and are not wrapped as session request failures.

## Validation
- `uv run pytest tests/backend/test_quel3_backend_controller.py`
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`