### PR TITLE
feat(experiment): add configurable sweep execution

### DIFF
--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -2246,6 +2246,7 @@ class Experiment:
         readout_post_margin: float | None = None,
         plot: bool | None = None,
         enable_tqdm: bool | None = None,
+        sweep_execution: Literal["sequential", "batch"] | None = None,
         title: str | None = None,
         xlabel: str | None = None,
         ylabel: str | None = None,
@@ -2286,6 +2287,11 @@ class Experiment:
             Whether to plot the measured signals. Defaults to True.
         enable_tqdm : bool, optional
             Whether to show a progress bar. Defaults to False.
+        sweep_execution : Literal["sequential", "batch"], optional
+            Sweep execution mode. `"sequential"` measures one sweep point at a
+            time, and `"batch"` runs sweep points through batch-capable
+            measurement APIs. Defaults to `system.yaml`
+            `experiment.sweep_execution`, or `"sequential"`.
         title : str, optional
             Title of the plot. Defaults to "Sweep result".
         xlabel : str, optional
@@ -2327,6 +2333,7 @@ class Experiment:
             readout_post_margin=readout_post_margin,
             plot=plot,
             enable_tqdm=enable_tqdm,
+            sweep_execution=sweep_execution,
             title=title,
             xlabel=xlabel,
             ylabel=ylabel,

--- a/src/qubex/experiment/services/measurement_service.py
+++ b/src/qubex/experiment/services/measurement_service.py
@@ -8,7 +8,7 @@ from collections import defaultdict
 from collections.abc import Awaitable, Callable, Collection, Mapping, Sequence
 from itertools import product
 from pathlib import Path
-from typing import Any, Literal, TypeVar
+from typing import Any, Literal, TypeVar, cast
 
 import numpy as np
 import plotly.graph_objects as go
@@ -1059,6 +1059,7 @@ class MeasurementService:
         readout_post_margin: float | None = None,
         plot: bool | None = None,
         enable_tqdm: bool | None = None,
+        sweep_execution: Literal["sequential", "batch"] | None = None,
         title: str | None = None,
         xlabel: str | None = None,
         ylabel: str | None = None,
@@ -1077,6 +1078,11 @@ class MeasurementService:
             Values to sweep over.
         repetitions
             Number of repetitions for each sweep point.
+        sweep_execution
+            Sweep execution mode. `"sequential"` measures one sweep point at a
+            time, and `"batch"` runs sweep points through batch-capable
+            measurement APIs. Defaults to `system.yaml`
+            `experiment.sweep_execution`, or `"sequential"`.
         """
         if repetitions is None:
             repetitions = 1
@@ -1086,6 +1092,13 @@ class MeasurementService:
             plot = True
         if enable_tqdm is None:
             enable_tqdm = False
+        if sweep_execution is None:
+            sweep_execution = self._resolve_sweep_parameter_execution()
+        else:
+            sweep_execution = self._validate_sweep_parameter_execution(
+                sweep_execution,
+                option_name="sweep_execution",
+            )
         if title is None:
             title = "Sweep result"
         if xlabel is None:
@@ -1102,7 +1115,13 @@ class MeasurementService:
         if rabi_level not in ("ge", "ef"):
             raise ValueError("Invalid Rabi level.")
 
-        if callable(sequence):
+        is_batch_execution = sweep_execution == "batch"
+        if is_batch_execution:
+            ordered_qubits = self._resolve_sweep_parameter_qubits(
+                sequence=sequence,
+                sweep_value=sweep_range[0],
+            )
+        elif callable(sequence):
             initial_sequence = sequence(sweep_range[0])
             if isinstance(initial_sequence, PulseSchedule):
                 sequences = [
@@ -1138,40 +1157,67 @@ class MeasurementService:
         # initialize awgs and capture units
         self.ctx.reset_awg_and_capunits(qubits=set(ordered_qubits))
 
-        with self.ctx.modified_frequencies(frequencies):
-            for seq in tqdm(
-                sequences,
-                desc="Sweeping parameters",
-                disable=not enable_tqdm,
-            ):
-                result = self.measure(
-                    seq,
-                    initial_states=initial_states,
-                    mode="avg",
-                    n_shots=n_shots,
-                    shot_interval=shot_interval,
-                    readout_amplitudes=readout_amplitudes,
-                    readout_duration=readout_duration,
-                    readout_pre_margin=readout_pre_margin,
-                    readout_post_margin=readout_post_margin,
-                    reset_awg_and_capunits=False,
-                    **deprecated_options,
+        if is_batch_execution:
+            self._run_sweep_parameter_batch(
+                sequence=sequence,
+                sweep_range=sweep_range,
+                repetitions=repetitions,
+                frequencies=frequencies,
+                initial_states=initial_states,
+                n_shots=n_shots,
+                shot_interval=shot_interval,
+                readout_amplitudes=readout_amplitudes,
+                readout_duration=readout_duration,
+                readout_pre_margin=readout_pre_margin,
+                readout_post_margin=readout_post_margin,
+                enable_tqdm=enable_tqdm,
+                deprecated_options=deprecated_options,
+                ordered_qubits=ordered_qubits,
+                signals=signals,
+            )
+            if plot:
+                plotter.update(
+                    {
+                        target: np.asarray(values)
+                        for target, values in signals.items()
+                        if values
+                    }
                 )
-                for target in ordered_qubits:
-                    if target in result.data:
-                        signals[target].append(result.data[target].kerneled)
-                for target, data in result.data.items():
-                    if target in signals:
-                        continue
-                    signals[target] = [data.kerneled]
-                if plot:
-                    plotter.update(
-                        {
-                            target: np.asarray(values)
-                            for target, values in signals.items()
-                            if values
-                        }
+        else:
+            with self.ctx.modified_frequencies(frequencies):
+                for seq in tqdm(
+                    sequences,
+                    desc="Sweeping parameters",
+                    disable=not enable_tqdm,
+                ):
+                    result = self.measure(
+                        seq,
+                        initial_states=initial_states,
+                        mode="avg",
+                        n_shots=n_shots,
+                        shot_interval=shot_interval,
+                        readout_amplitudes=readout_amplitudes,
+                        readout_duration=readout_duration,
+                        readout_pre_margin=readout_pre_margin,
+                        readout_post_margin=readout_post_margin,
+                        reset_awg_and_capunits=False,
+                        **deprecated_options,
                     )
+                    for target in ordered_qubits:
+                        if target in result.data:
+                            signals[target].append(result.data[target].kerneled)
+                    for target, data in result.data.items():
+                        if target in signals:
+                            continue
+                        signals[target] = [data.kerneled]
+                    if plot:
+                        plotter.update(
+                            {
+                                target: np.asarray(values)
+                                for target, values in signals.items()
+                                if values
+                            }
+                        )
 
         if plot:
             plotter.show()
@@ -1202,6 +1248,181 @@ class MeasurementService:
             rabi_params=rabi_params,
         )
         return result
+
+    def _resolve_sweep_parameter_execution(
+        self,
+    ) -> Literal["sequential", "batch"]:
+        """Return the configured sweep execution mode."""
+        try:
+            config_loader = self.ctx.config_loader
+        except (AttributeError, ValueError):
+            return "sequential"
+        experiment_config = getattr(config_loader, "experiment_config", {})
+        if not isinstance(experiment_config, Mapping):
+            raise TypeError("`experiment` section must be a mapping.")
+
+        sweep_execution = experiment_config.get("sweep_execution", "sequential")
+        if not isinstance(sweep_execution, str):
+            raise TypeError("`experiment.sweep_execution` must be a string.")
+        return self._validate_sweep_parameter_execution(
+            sweep_execution,
+            option_name="experiment.sweep_execution",
+        )
+
+    @staticmethod
+    def _validate_sweep_parameter_execution(
+        sweep_execution: str,
+        *,
+        option_name: str,
+    ) -> Literal["sequential", "batch"]:
+        """Return a validated sweep execution mode."""
+        if sweep_execution not in ("sequential", "batch"):
+            raise ValueError(f"`{option_name}` must be 'sequential' or 'batch'.")
+        return cast(Literal["sequential", "batch"], sweep_execution)
+
+    def _resolve_sweep_parameter_qubits(
+        self,
+        *,
+        sequence: ParametricPulseSchedule | ParametricWaveformDict,
+        sweep_value: SweepValue,
+    ) -> list[str]:
+        """Return ordered qubit labels touched by one sweep sequence."""
+        initial_sequence = sequence(sweep_value)
+        if isinstance(initial_sequence, PulseSchedule):
+            return self.ctx.ordered_qubit_labels(initial_sequence.labels)
+        if isinstance(initial_sequence, dict):
+            return self.ctx.ordered_qubit_labels(list(initial_sequence))
+        raise TypeError("Invalid sequence.")
+
+    def _run_sweep_parameter_batch(
+        self,
+        *,
+        sequence: ParametricPulseSchedule | ParametricWaveformDict,
+        sweep_range: NDArray[Any],
+        repetitions: int,
+        frequencies: dict[str, float] | None,
+        initial_states: dict[str, str] | None,
+        n_shots: int | None,
+        shot_interval: float | None,
+        readout_amplitudes: dict[str, float] | None,
+        readout_duration: float | None,
+        readout_pre_margin: float | None,
+        readout_post_margin: float | None,
+        enable_tqdm: bool,
+        deprecated_options: dict[str, Any],
+        ordered_qubits: list[str],
+        signals: dict[str, list[object]],
+    ) -> None:
+        """Run sweep-parameter execution through the async sweep measurement path."""
+        legacy_enable_dsp_demodulation = deprecated_options.pop(
+            "enable_dsp_demodulation",
+            None,
+        )
+        normalized_options = normalize_deprecated_options(
+            values={
+                "n_shots": n_shots,
+                "shot_interval": shot_interval,
+                "readout_ramp_time": None,
+                "readout_amplification": None,
+                "time_integration": None,
+                "state_classification": None,
+            },
+            deprecated_options=deprecated_options,
+            specs=(
+                DeprecatedOptionSpec("shots", "n_shots"),
+                DeprecatedOptionSpec("interval", "shot_interval"),
+                DeprecatedOptionSpec("readout_ramptime", "readout_ramp_time"),
+                DeprecatedOptionSpec("add_pump_pulses", "readout_amplification"),
+                DeprecatedOptionSpec("enable_dsp_sum", "time_integration"),
+                DeprecatedOptionSpec(
+                    "enable_dsp_classification",
+                    "state_classification",
+                ),
+            ),
+            stacklevel=4,
+        )
+        n_shots = normalized_options["n_shots"]
+        shot_interval = normalized_options["shot_interval"]
+        readout_ramp_time = normalized_options["readout_ramp_time"]
+        readout_amplification = normalized_options["readout_amplification"]
+        time_integration = normalized_options["time_integration"]
+        state_classification = normalized_options["state_classification"]
+        if legacy_enable_dsp_demodulation is not None:
+            warnings.warn(
+                "`enable_dsp_demodulation` is deprecated and ignored because demodulation is always enabled.",
+                DeprecationWarning,
+                stacklevel=3,
+            )
+            if legacy_enable_dsp_demodulation is False:
+                raise ValueError(
+                    "enable_dsp_demodulation is deprecated and always enabled; "
+                    "remove this argument or pass None."
+                )
+        if time_integration is None:
+            time_integration = True
+
+        def sweep_schedule(param: SweepValue) -> PulseSchedule:
+            sweep_sequence = sequence(param)
+            if isinstance(sweep_sequence, PulseSchedule):
+                schedule = sweep_sequence.repeated(repetitions)
+            elif isinstance(sweep_sequence, dict):
+                schedule = PulseSchedule.from_waveforms(
+                    {
+                        target: waveform.repeated(repetitions)
+                        for target, waveform in sweep_sequence.items()
+                    }
+                )
+            else:
+                raise TypeError("Invalid sequence.")
+
+            if initial_states is None:
+                return schedule
+
+            labels = self.unique_in_order([*schedule.labels, *initial_states.keys()])
+            with PulseSchedule(labels) as prepared:
+                for target, state in initial_states.items():
+                    if target in self.ctx.qubit_labels:
+                        prepared.add(
+                            target,
+                            self.pulse.get_pulse_for_state(target, state),
+                        )
+                    else:
+                        raise ValueError(f"Invalid init target: {target}")
+                prepared.barrier()
+                prepared.call(schedule)
+            return prepared
+
+        sweep_result = _run_async(
+            lambda: self.run_sweep_measurement(
+                sweep_schedule,
+                sweep_values=sweep_range,
+                frequencies=cast(dict[str, FrequencyLike] | None, frequencies),
+                readout_amplitudes=readout_amplitudes,
+                readout_duration=readout_duration,
+                readout_pre_margin=readout_pre_margin,
+                readout_post_margin=readout_post_margin,
+                readout_ramp_time=readout_ramp_time,
+                readout_amplification=readout_amplification,
+                final_measurement=True,
+                n_shots=n_shots,
+                shot_interval=shot_interval,
+                shot_averaging=True,
+                time_integration=time_integration,
+                state_classification=state_classification,
+                plot=False,
+                enable_tqdm=enable_tqdm,
+            )
+        )
+
+        for point_result in sweep_result.results:
+            result = MeasurementResultConverter.to_measure_result(point_result)
+            for target in ordered_qubits:
+                if target in result.data:
+                    signals[target].append(result.data[target].kerneled)
+            for target, data in result.data.items():
+                if target in signals:
+                    continue
+                signals[target] = [data.kerneled]
 
     def _get_sweep_rabi_params(
         self,

--- a/src/qubex/system/config_loader.py
+++ b/src/qubex/system/config_loader.py
@@ -414,6 +414,19 @@ class ConfigLoader:
         return dict(value)
 
     @property
+    def experiment_config(self) -> dict[str, Any]:
+        """Return experiment configuration for the loaded system."""
+        self._ensure_loaded()
+        value = self._system_dict.get("experiment")
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"`experiment` section in `{self._system_file}` must be a mapping."
+            )
+        return dict(value)
+
+    @property
     def measurement_defaults(self) -> MeasurementDefaults:
         """Return parsed partial measurement defaults for the loaded system."""
         self._ensure_loaded()

--- a/tests/backend/test_config_loader.py
+++ b/tests/backend/test_config_loader.py
@@ -1289,6 +1289,36 @@ def test_backend_runtime_config_returns_selected_backend_section(
     assert loader.backend_runtime_config == runtime_config
 
 
+def test_experiment_config_returns_top_level_experiment_section(
+    tmp_path: Path,
+) -> None:
+    """Given experiment settings, when loading, then ConfigLoader exposes that section."""
+    config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)
+    experiment_config = {"sweep_execution": "batch"}
+
+    _write_yaml(
+        config_dir / "system.yaml",
+        {
+            "schema_version": 1,
+            "chip_id": chip_id,
+            "backend": BACKEND_KIND_QUEL1,
+            "experiment": experiment_config,
+        },
+    )
+
+    loader = ConfigLoader(
+        system_id=chip_id,
+        config_dir=config_dir,
+        params_dir=params_dir,
+    )
+    loaded_config = loader.experiment_config
+    loaded_config["sweep_execution"] = "sequential"
+
+    assert loaded_config != loader.experiment_config
+    assert loader.experiment_config == experiment_config
+    assert loader.backend_runtime_config == {}
+
+
 def test_load_configures_quel3_readout_without_lo(tmp_path: Path) -> None:
     """Given quel3 backend, when loading, then readout ports are configured without LO."""
     config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)

--- a/tests/experiment/test_experiment_facade_delegation.py
+++ b/tests/experiment/test_experiment_facade_delegation.py
@@ -926,6 +926,7 @@ def test_sweep_parameter_delegates_legacy_shot_arguments_to_measurement_service(
                 "readout_post_margin": None,
                 "plot": None,
                 "enable_tqdm": None,
+                "sweep_execution": None,
                 "title": None,
                 "xlabel": None,
                 "ylabel": None,
@@ -933,6 +934,49 @@ def test_sweep_parameter_delegates_legacy_shot_arguments_to_measurement_service(
                 "yaxis_type": None,
                 "shots": 32,
                 "interval": 44.0,
+            },
+        )
+    ]
+
+
+def test_sweep_parameter_delegates_sweep_execution_to_measurement_service() -> None:
+    """Given batch sweep execution, when sweep_parameter is called, then the option is delegated."""
+    exp = object.__new__(Experiment)
+    measurement_stub = _MeasurementServiceStub()
+    exp.__dict__["_measurement_service"] = measurement_stub
+    sequence = cast(Any, lambda value: {"Q00": [value + 0.0j]})
+
+    result = exp.sweep_parameter(
+        sequence=sequence,
+        sweep_range=[0.1, 0.2],
+        sweep_execution="batch",
+    )
+
+    assert result == "sweep_parameter_result"
+    assert measurement_stub.calls == [
+        (
+            "sweep_parameter",
+            {
+                "sequence": sequence,
+                "sweep_range": [0.1, 0.2],
+                "repetitions": None,
+                "frequencies": None,
+                "initial_states": None,
+                "rabi_level": None,
+                "n_shots": None,
+                "shot_interval": None,
+                "readout_amplitudes": None,
+                "readout_duration": None,
+                "readout_pre_margin": None,
+                "readout_post_margin": None,
+                "plot": None,
+                "enable_tqdm": None,
+                "sweep_execution": "batch",
+                "title": None,
+                "xlabel": None,
+                "ylabel": None,
+                "xaxis_type": None,
+                "yaxis_type": None,
             },
         )
     ]

--- a/tests/experiment/test_measurement_service_sweep_rabi_params.py
+++ b/tests/experiment/test_measurement_service_sweep_rabi_params.py
@@ -1,4 +1,4 @@
-"""Tests for sweep-parameter Rabi parameter lookup scope."""
+"""Tests for sweep-parameter measurement execution paths."""
 
 from __future__ import annotations
 
@@ -7,20 +7,36 @@ from types import MethodType, SimpleNamespace
 from typing import Any, cast
 
 import numpy as np
+import pytest
 from qxpulse import Blank, PulseSchedule
 
 from qubex.experiment.models.rabi_param import RabiParam
 from qubex.experiment.services.measurement_service import MeasurementService
-from qubex.experiment.services.pulse_service import PulseService
+from qubex.measurement import MeasurementResultConverter
 
 
-def test_sweep_parameter_reads_rabi_params_only_for_swept_qubits() -> None:
-    """Given unrelated stored params, when sweeping one qubit, then only that qubit is queried."""
+def _stub_measurement_result_converter(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr(
+        MeasurementResultConverter,
+        "to_measure_result",
+        staticmethod(
+            lambda _result: SimpleNamespace(
+                data={"Q33": SimpleNamespace(kerneled=1.0 + 0.0j)}
+            )
+        ),
+    )
+
+
+def test_sweep_parameter_uses_legacy_measurement_by_default() -> None:
+    """Given no batch opt-in, when sweeping, then the legacy measure loop is used."""
     accessed_targets: list[str] = []
+    measured: list[dict[str, Any]] = []
+    frequency_overrides: list[dict[str, float] | None] = []
     rabi_param = RabiParam.nan(target="Q33")
 
     @contextmanager
-    def _modified_frequencies(_frequencies: dict[str, float] | None) -> Any:
+    def _modified_frequencies(frequencies: dict[str, float] | None) -> Any:
+        frequency_overrides.append(frequencies)
         yield
 
     def _get_rabi_param(target: str) -> RabiParam | None:
@@ -32,6 +48,7 @@ def test_sweep_parameter_reads_rabi_params_only_for_swept_qubits() -> None:
             "Q33": SimpleNamespace(is_ge=True, is_ef=False),
             "Q18": SimpleNamespace(is_ge=True, is_ef=False),
         },
+        qubit_labels=["Q33", "Q18"],
         state_centers={},
         ordered_qubit_labels=lambda labels: list(labels),
         reset_awg_and_capunits=lambda *, qubits: None,
@@ -41,12 +58,184 @@ def test_sweep_parameter_reads_rabi_params_only_for_swept_qubits() -> None:
     )
     service = cast(Any, object.__new__(MeasurementService))
     service.__dict__["_ctx"] = ctx
-    service.__dict__["_pulse_service"] = PulseService(cast(Any, ctx))
+    service.__dict__["_pulse_service"] = SimpleNamespace(
+        readout_duration=512.0,
+        readout_pre_margin=16.0,
+        readout_post_margin=96.0,
+        get_pulse_for_state=lambda _target, _state: Blank(0),
+    )
 
-    def _measure(self: MeasurementService, _seq: object, **_kwargs: object) -> Any:
+    def _measure(self: MeasurementService, seq: object, **kwargs: object) -> Any:
+        _ = self
+        measured.append({"sequence": seq, "kwargs": kwargs})
         return SimpleNamespace(data={"Q33": SimpleNamespace(kerneled=1.0 + 0.0j)})
 
+    async def _run_sweep_measurement(
+        self: MeasurementService,
+        _schedule: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        _ = self
+        raise AssertionError("sweep_parameter must use measure by default")
+
     service.measure = MethodType(_measure, service)
+    service.run_sweep_measurement = MethodType(_run_sweep_measurement, service)
+
+    def _sequence(_sweep_value: float) -> PulseSchedule:
+        with PulseSchedule(["Q33"]) as schedule:
+            schedule.add("Q33", Blank(8))
+        return schedule
+
+    result = service.sweep_parameter(
+        sequence=_sequence,
+        sweep_range=np.array([0.0]),
+        frequencies={"Q33": 5.0},
+        readout_ramptime=12.0,
+        time_integration=False,
+        plot=False,
+    )
+
+    assert len(measured) == 1
+    assert set(cast(dict[str, object], measured[0]["sequence"])) == {"Q33"}
+    assert measured[0]["kwargs"] == {
+        "initial_states": None,
+        "mode": "avg",
+        "n_shots": None,
+        "shot_interval": None,
+        "readout_amplitudes": None,
+        "readout_duration": None,
+        "readout_pre_margin": None,
+        "readout_post_margin": None,
+        "reset_awg_and_capunits": False,
+        "readout_ramptime": 12.0,
+        "time_integration": False,
+    }
+    assert frequency_overrides == [{"Q33": 5.0}]
+    assert accessed_targets == ["Q33"]
+    assert result.rabi_params == {"Q33": rabi_param}
+    assert result.data["Q33"].rabi_param is rabi_param
+
+
+def test_sweep_parameter_batch_execution_reads_rabi_params_only_for_swept_qubits(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given batch opt-in, when sweeping one qubit, then async sweep execution is used."""
+    accessed_targets: list[str] = []
+    rabi_param = RabiParam.nan(target="Q33")
+
+    def _get_rabi_param(target: str) -> RabiParam | None:
+        accessed_targets.append(target)
+        return rabi_param if target == "Q33" else RabiParam.nan(target=target)
+
+    _stub_measurement_result_converter(monkeypatch)
+    calls: dict[str, Any] = {}
+
+    async def _run_sweep_measurement(
+        self: MeasurementService,
+        schedule: Any,
+        *,
+        sweep_values: Any,
+        **kwargs: Any,
+    ) -> Any:
+        _ = self
+        calls["sweep_values"] = sweep_values
+        calls["kwargs"] = kwargs
+        _ = schedule(np.asarray(sweep_values)[0])
+        return SimpleNamespace(results=[object()])
+
+    ctx = SimpleNamespace(
+        targets={
+            "Q33": SimpleNamespace(is_ge=True, is_ef=False),
+            "Q18": SimpleNamespace(is_ge=True, is_ef=False),
+        },
+        qubit_labels=["Q33", "Q18"],
+        state_centers={},
+        ordered_qubit_labels=lambda labels: list(labels),
+        reset_awg_and_capunits=lambda *, qubits: None,
+        get_rabi_param=_get_rabi_param,
+        resolve_ef_label=lambda label: f"{label}/ef",
+    )
+    service = cast(Any, object.__new__(MeasurementService))
+    service.__dict__["_ctx"] = ctx
+    service.__dict__["_pulse_service"] = SimpleNamespace(
+        readout_duration=512.0,
+        readout_pre_margin=16.0,
+        readout_post_margin=96.0,
+        get_pulse_for_state=lambda _target, _state: Blank(0),
+    )
+
+    def _measure(self: MeasurementService, _seq: object, **_kwargs: object) -> Any:
+        _ = self
+        raise AssertionError("sweep_execution='batch' must use run_sweep_measurement")
+
+    service.measure = MethodType(_measure, service)
+    service.run_sweep_measurement = MethodType(_run_sweep_measurement, service)
+
+    def _sequence(_sweep_value: float) -> dict[str, Blank]:
+        return {"Q33": Blank(8)}
+
+    result = service.sweep_parameter(
+        sequence=_sequence,
+        sweep_range=np.array([0.0]),
+        sweep_execution="batch",
+        plot=False,
+    )
+
+    assert accessed_targets == ["Q33"]
+    assert result.rabi_params == {"Q33": rabi_param}
+    assert result.data["Q33"].rabi_param is rabi_param
+    assert np.array_equal(calls["sweep_values"], np.array([0.0]))
+    assert calls["kwargs"]["shot_averaging"] is True
+    assert calls["kwargs"]["time_integration"] is True
+
+
+def test_sweep_parameter_uses_configured_experiment_batch_default(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given experiment batch config, omitted sweep_execution uses async sweep."""
+    _stub_measurement_result_converter(monkeypatch)
+    called: dict[str, bool] = {"batch": False}
+
+    async def _run_sweep_measurement(
+        self: MeasurementService,
+        schedule: Any,
+        *,
+        sweep_values: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        _ = self
+        called["batch"] = True
+        _ = schedule(np.asarray(sweep_values)[0])
+        return SimpleNamespace(results=[object()])
+
+    ctx = SimpleNamespace(
+        targets={"Q33": SimpleNamespace(is_ge=True, is_ef=False)},
+        qubit_labels=["Q33"],
+        config_loader=SimpleNamespace(
+            backend_kind="quel1",
+            experiment_config={"sweep_execution": "batch"},
+        ),
+        state_centers={},
+        ordered_qubit_labels=lambda labels: list(labels),
+        reset_awg_and_capunits=lambda *, qubits: None,
+        get_rabi_param=lambda target: RabiParam.nan(target=target),
+        resolve_ef_label=lambda label: f"{label}/ef",
+    )
+    service = cast(Any, object.__new__(MeasurementService))
+    service.__dict__["_ctx"] = ctx
+    service.__dict__["_pulse_service"] = SimpleNamespace(
+        readout_duration=512.0,
+        readout_pre_margin=16.0,
+        readout_post_margin=96.0,
+        get_pulse_for_state=lambda _target, _state: Blank(0),
+    )
+
+    def _measure(self: MeasurementService, _seq: object, **_kwargs: object) -> Any:
+        _ = self
+        raise AssertionError("configured batch default must use run_sweep_measurement")
+
+    service.measure = MethodType(_measure, service)
+    service.run_sweep_measurement = MethodType(_run_sweep_measurement, service)
 
     def _sequence(_sweep_value: float) -> PulseSchedule:
         with PulseSchedule(["Q33"]) as schedule:
@@ -59,6 +248,65 @@ def test_sweep_parameter_reads_rabi_params_only_for_swept_qubits() -> None:
         plot=False,
     )
 
-    assert accessed_targets == ["Q33"]
-    assert result.rabi_params == {"Q33": rabi_param}
-    assert result.data["Q33"].rabi_param is rabi_param
+    assert called["batch"] is True
+    assert result.data["Q33"].target == "Q33"
+
+
+def test_sweep_parameter_prepends_initial_states_in_async_sweep_schedule(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given initial states, when sweeping, then state preparation is inside the async schedule callback."""
+    built_schedules: list[PulseSchedule] = []
+    _stub_measurement_result_converter(monkeypatch)
+
+    async def _run_sweep_measurement(
+        self: MeasurementService,
+        schedule: Any,
+        *,
+        sweep_values: Any,
+        **_kwargs: Any,
+    ) -> Any:
+        _ = self
+        built_schedules.extend(schedule(value) for value in np.asarray(sweep_values))
+        return SimpleNamespace(results=[object()])
+
+    ctx = SimpleNamespace(
+        qubit_labels=["Q33"],
+        state_centers={},
+        ordered_qubit_labels=lambda labels: list(labels),
+        reset_awg_and_capunits=lambda *, qubits: None,
+        get_rabi_param=lambda target: RabiParam.nan(target=target),
+        resolve_ef_label=lambda label: f"{label}/ef",
+    )
+    service = cast(Any, object.__new__(MeasurementService))
+    service.__dict__["_ctx"] = ctx
+    service.__dict__["_pulse_service"] = SimpleNamespace(
+        readout_duration=512.0,
+        readout_pre_margin=16.0,
+        readout_post_margin=96.0,
+        get_pulse_for_state=lambda _target, _state: Blank(4),
+    )
+
+    def _measure(self: MeasurementService, _seq: object, **_kwargs: object) -> Any:
+        _ = self
+        raise AssertionError("sweep_execution='batch' must use run_sweep_measurement")
+
+    service.measure = MethodType(_measure, service)
+    service.run_sweep_measurement = MethodType(_run_sweep_measurement, service)
+
+    def _sequence(_sweep_value: float) -> PulseSchedule:
+        with PulseSchedule(["Q33"]) as schedule:
+            schedule.add("Q33", Blank(8))
+        return schedule
+
+    _ = service.sweep_parameter(
+        sequence=_sequence,
+        sweep_range=np.array([0.0]),
+        initial_states={"Q33": "1"},
+        sweep_execution="batch",
+        plot=False,
+    )
+
+    assert len(built_schedules) == 1
+    assert built_schedules[0].labels == ["Q33"]
+    assert built_schedules[0].duration == 12


### PR DESCRIPTION
## Background

`sweep_parameter` can now choose between the legacy per-point sweep loop and the batch-capable measurement path. The execution mode is exposed as an experiment-level option instead of a QuEL-3-specific setting.

## Summary

- Add `sweep_execution` to `Experiment.sweep_parameter` and `MeasurementService.sweep_parameter`.
- Support `experiment.sweep_execution` in `system.yaml`, with valid values `sequential` and `batch`.
- Default to `sequential` when the option is omitted.
- Keep the setting backend-agnostic and remove the earlier `use_batch_sweep` naming.
- Add tests for config loading, facade delegation, batch execution, and default behavior.

## Impact

This is new, unreleased feature-branch API/config surface. No backward-compatibility alias is included for `use_batch_sweep`.

## Validation

- `uv run ruff check --fix` passed
- `uv run ruff format` passed, 495 files unchanged
- `uv run pyright` passed, 0 errors
- `uv run pytest tests/backend/test_config_loader.py tests/experiment/test_measurement_service_sweep_rabi_params.py tests/experiment/test_experiment_facade_delegation.py` passed, 89 tests
- `uv run pytest` passed, 1128 tests