### PR TITLE
build(quel3): update quelware client to 0.4.1

### DIFF
--- a/docs/developer-notes/hardware-validation-template.md
+++ b/docs/developer-notes/hardware-validation-template.md
@@ -15,7 +15,7 @@ Use this template for repeatable QuEL-1 / QuEL-3 hardware checks before beta and
 - Device IDs / aliases:
 - Sampling period (`dt`):
 - Runtime endpoint/port:
-- Trigger wait:
+- Trigger wait (`wait_ms`; `None` uses the client default):
 - Session TTL (`ttl_ms` / `tentative_ttl_ms`):
 - Measurement constraint mode (`strict` / `relaxed`):
 - Notes:

--- a/docs/developer-notes/quel3-adapter-interface-draft.md
+++ b/docs/developer-notes/quel3-adapter-interface-draft.md
@@ -63,7 +63,7 @@ Define a concrete integration draft for QuEL-3 support using `quelware-client` w
 | capture schedule | `Sequencer.add_capture_window` | Capture windows are added in ns, then exported in samples. |
 | backend timeline export | `Sequencer.export_set_fixed_timeline_directive` | Export timeline for one bound alias; final length is aligned to sample-grid constraints. |
 | hardware execution | `InstrumentDriver.apply` + `Session.trigger(instrument_ids=...)` | Apply fixed-timeline directive, then trigger selected instruments via session API. |
-| measured data fetch | `InstrumentDriver.fetch_result` | Read `ResultContainer.iq_result` (`WaveformList` or `IqPointList`). |
+| measured data fetch | `InstrumentDriver.wait_for_result` | Read `ResultContainer.iq_result` (`WaveformList` or `IqPointList`). |
 
 ## Constraint model assumptions
 

--- a/docs/developer-notes/quel3-configuration-design.md
+++ b/docs/developer-notes/quel3-configuration-design.md
@@ -16,13 +16,13 @@ Related policy:
   - `backend_kind="quel1" | "quel3"`
 - QuEL-3 measurement execution path exists in:
   - `src/qubex/backend/quel3/quel3_backend_controller.py`
-- Current runtime defaults are controller built-ins:
+- Current runtime defaults are controller and runtime built-ins:
   - endpoint: `localhost`
   - port: `50051`
-  - trigger wait: `1000000`
-- Session defaults (provisional, aligned with `quelware-client`):
-  - `ttl_ms=4000`
-  - `tentative_ttl_ms=1000`
+  - trigger `wait_ms=None` (use `quelware-client` default handling)
+- Session TTLs are explicit Qubex runtime values:
+  - `ttl_ms=30000`
+  - `tentative_ttl_ms=5000`
 - Target-to-instrument resolution is performed by runtime-side logic.
 - QuEL-3 system synchronizer is currently a no-op:
   - no backend-settings snapshot pull path is implemented yet
@@ -71,7 +71,7 @@ Status legend:
   - runtime:
     - deployment selection and backend-specific runtime settings
       (`system.yaml`: `system_id -> chip_id, backend, backend runtime`)
-    - endpoint, port, wait, ttl_ms, tentative_ttl_ms
+    - endpoint, port, trigger `wait_ms`, ttl_ms, tentative_ttl_ms
 
 ### D2.1 System/chip cardinality
 
@@ -108,11 +108,11 @@ Status legend:
 
 - Status: `IN_PROGRESS`
 - Current policy:
-  - Use `quelware-client` defaults as provisional runtime values for beta:
+  - Use `quelware-client` 0.4.1-compatible runtime values for beta:
     - endpoint=`localhost`
     - port=`50051`
-    - trigger wait=`1000000`
-    - `ttl_ms=4000`, `tentative_ttl_ms=1000`
+    - trigger `wait_ms=None`
+    - `ttl_ms=30000`, `tentative_ttl_ms=5000`
 - Target policy:
   - Move to config-file-first (`system.yaml`) with optional overrides in a later update.
 

--- a/docs/developer-notes/v1-5-0-release-plan.md
+++ b/docs/developer-notes/v1-5-0-release-plan.md
@@ -276,7 +276,8 @@ Calendar note:
 - 2026-02-25: Adopted `InstrumentResolver` as the integration baseline (replacing legacy `InstrumentMapper`) based on current `quelware-client` examples.
 - 2026-02-25: Fixed alias mapping policy to runtime auto-resolution from wiring/port; unresolved/ambiguous resolution must fail fast.
 - 2026-02-25: Fixed capture-mode contract direction for QuEL-3 path: `avg`=`AVERAGED_VALUE`, `single` follows quelware values-per-iteration semantics (legacy `VALUES_PER_LOOP` compatibility), waveform inspection uses `AVERAGED_WAVEFORM`.
-- 2026-02-25: Runtime connection defaults are provisionally aligned to `quelware-client` defaults (`endpoint=localhost`, `port=50051`, `trigger_wait=1000000`, `ttl_ms=4000`, `tentative_ttl_ms=1000`).
+- 2026-02-25: Runtime connection defaults were provisionally aligned to then-current `quelware-client` defaults (`endpoint=localhost`, `port=50051`); trigger/session timing constants were superseded by the 2026-06-16 `quelware-client` 0.4.1 integration.
+- 2026-06-16: Updated QuEL-3 runtime timing constants for `quelware-client` 0.4.1: trigger `wait_ms=None`, `ttl_ms=30000`, and `tentative_ttl_ms=5000`, and switched result collection to `InstrumentDriver.wait_for_result`.
 - 2026-02-25: Superseded prior provisional notes that required explicit `instrument_alias_map` or deferred DF-03/DF-04; resolver-based auto-resolution and DF-03/DF-04 are now fixed beta contract decisions.
 - 2026-02-25: Added QuEL-3 `tx/rx/trx` handling decision and `system` package boundary note (`quel1`/`quel3` common-vs-split).
 - 2026-02-25: Added demo-readiness gap note for QuEL-3 `CharacterizationService` frequency identification path (`LO/CNCO`-retune assumptions) and linked required contract work.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ dependencies = [
 [project.optional-dependencies]
 backend = ["qxdriver-quel1 == 1.5.0b4"]
 quel1 = ["qxdriver-quel1 == 1.5.0b4"]
-quel3 = ["quelware-client >= 0.2.0"]
+quel3 = ["quelware-client >= 0.4.1"]
 
 [project.scripts]
 qubex = "qubex.cli:main"

--- a/src/qubex/backend/quel3/interfaces/client.py
+++ b/src/qubex/backend/quel3/interfaces/client.py
@@ -206,8 +206,8 @@ class SessionProtocol(Protocol):
     async def trigger(
         self,
         instrument_ids: Iterable[ResourceIdProtocol],
-        wait: int = 1_000_000,
-    ) -> None:
+        wait_ms: int | None = None,
+    ) -> int:
         """Trigger one fixed-timeline session run."""
         ...
 
@@ -236,6 +236,8 @@ class QuelwareClientProtocol(Protocol):
     def create_session(
         self,
         resource_ids: Iterable[ResourceIdProtocol],
+        ttl_ms: int = 4_000,
+        tentative_ttl_ms: int = 1_000,
     ) -> AbstractAsyncContextManager[SessionProtocol]:
         """Create one execution session for selected resources."""
         ...

--- a/src/qubex/backend/quel3/interfaces/driver.py
+++ b/src/qubex/backend/quel3/interfaces/driver.py
@@ -70,8 +70,8 @@ class InstrumentDriverProtocol(Protocol):
         """Initialize instrument state before apply/trigger flow."""
         ...
 
-    async def fetch_result(self) -> ResultContainerProtocol:
-        """Fetch one fixed-timeline execution result."""
+    async def wait_for_result(self) -> ResultContainerProtocol:
+        """Wait for one fixed-timeline execution result."""
         ...
 
 

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -51,6 +51,7 @@ from qubex.core.async_bridge import DEFAULT_TIMEOUT_SECONDS, get_shared_async_br
 T = TypeVar("T")
 
 QUEL3_SESSION_REQUEST_MAX_ATTEMPTS = 4
+QUEL3_SESSION_TRIGGER_WAIT_MS: int | None = None
 
 logger = logging.getLogger(__name__)
 
@@ -527,11 +528,14 @@ class Quel3ExecutionManager:
             alias: {window.name: [] for window in timeline.capture_windows}
             for alias, timeline in payload.fixed_timelines.items()
         }
-        await session_state.session.trigger(instrument_ids=instrument_resource_ids)
+        await session_state.session.trigger(
+            instrument_ids=instrument_resource_ids,
+            wait_ms=QUEL3_SESSION_TRIGGER_WAIT_MS,
+        )
         if parallel:
             results = await asyncio.gather(
                 *(
-                    session_state.alias_to_driver[alias].fetch_result()
+                    session_state.alias_to_driver[alias].wait_for_result()
                     for alias in aliases
                 )
             )
@@ -541,7 +545,7 @@ class Quel3ExecutionManager:
             for alias in aliases:
                 alias_results[alias] = await session_state.alias_to_driver[
                     alias
-                ].fetch_result()
+                ].wait_for_result()
 
         for alias, timeline in payload.fixed_timelines.items():
             result = alias_results[alias]

--- a/src/qubex/backend/quel3/managers/session_workarounds.py
+++ b/src/qubex/backend/quel3/managers/session_workarounds.py
@@ -13,6 +13,8 @@ from qubex.backend.quel3.interfaces.client import (
     SessionProtocol,
 )
 
+QUELWARE_SESSION_CREATE_TTL_MS = 30_000
+QUELWARE_SESSION_CREATE_TENTATIVE_TTL_MS = 5_000
 QUELWARE_SESSION_CREATE_MAX_ATTEMPTS = 4
 QUELWARE_SESSION_CREATE_INITIAL_RETRY_DELAY_SECONDS = 0.5
 QUELWARE_SESSION_CREATE_MAX_RETRY_DELAY_SECONDS = 4.0
@@ -113,7 +115,11 @@ async def enter_quelware_session_with_resource_retry(
     for attempt in range(max_attempts):
         session_cm: AbstractAsyncContextManager[SessionProtocol] | None = None
         try:
-            session_cm = client.create_session(normalized_resource_ids)
+            session_cm = client.create_session(
+                normalized_resource_ids,
+                ttl_ms=QUELWARE_SESSION_CREATE_TTL_MS,
+                tentative_ttl_ms=QUELWARE_SESSION_CREATE_TENTATIVE_TTL_MS,
+            )
             session = await session_cm.__aenter__()
         except Exception as exc:
             session_token = quelware_session_token(session_cm)

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -828,9 +828,18 @@ def test_execute_rejects_invalid_payload_before_opening_session(
             )
 
     class _OrderProbeClient(_FakeClient):
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(
+            self,
+            resource_ids: list[str],
+            ttl_ms: int = 4_000,
+            tentative_ttl_ms: int = 1_000,
+        ) -> _FakeSession:
             create_session_calls.append(tuple(resource_ids))
-            return super().create_session(resource_ids)
+            return super().create_session(
+                resource_ids,
+                ttl_ms=ttl_ms,
+                tentative_ttl_ms=tentative_ttl_ms,
+            )
 
     def _create_driver(
         session: object,
@@ -892,7 +901,7 @@ class _FakeInstrumentDriver:
     async def initialize(self) -> None:
         self.initialized = True
 
-    async def fetch_result(self) -> object:
+    async def wait_for_result(self) -> object:
         return _FakeResultContainer()
 
 
@@ -992,7 +1001,7 @@ class _ParallelInstrumentDriver:
     async def initialize(self) -> None:
         await self._initialize_barrier.wait()
 
-    async def fetch_result(self) -> object:
+    async def wait_for_result(self) -> object:
         await self._fetch_barrier.wait()
         return _ParallelResultContainer(self._alias, self._value)
 
@@ -1037,7 +1046,7 @@ class _SerialProbeInstrumentDriver:
     async def initialize(self) -> None:
         await self._initialize_probe.step()
 
-    async def fetch_result(self) -> object:
+    async def wait_for_result(self) -> object:
         await self._fetch_probe.step()
         return _ParallelResultContainer(self._alias, self._value)
 
@@ -1058,8 +1067,14 @@ class _FakeSession:
     ) -> None:
         del exc_type, exc, tb
 
-    async def trigger(self, instrument_ids: list[str]) -> None:
+    async def trigger(
+        self,
+        instrument_ids: list[str],
+        wait_ms: int | None = None,
+    ) -> int:
+        del wait_ms
         self.trigger_calls.append(list(instrument_ids))
+        return 0
 
 
 class _FakeClient:
@@ -1079,8 +1094,13 @@ class _FakeClient:
         del exc_type, exc, tb
         self.exit_calls += 1
 
-    def create_session(self, resource_ids: list[str]) -> _FakeSession:
-        del resource_ids
+    def create_session(
+        self,
+        resource_ids: list[str],
+        ttl_ms: int = 4_000,
+        tentative_ttl_ms: int = 1_000,
+    ) -> _FakeSession:
+        del resource_ids, ttl_ms, tentative_ttl_ms
         return self._session
 
 
@@ -1145,13 +1165,18 @@ class _FlakyTriggerSession(_FakeSession):
         del exc_type, exc, tb
         self.exit_calls += 1
 
-    async def trigger(self, instrument_ids: list[str]) -> None:
-        await super().trigger(instrument_ids)
+    async def trigger(
+        self,
+        instrument_ids: list[str],
+        wait_ms: int | None = None,
+    ) -> int:
+        trigger_id = await super().trigger(instrument_ids, wait_ms=wait_ms)
         if self._fail_once:
             self._fail_once = False
             if self._failed_session_id is not None:
                 self.token = self._failed_session_id
             raise RuntimeError("quelware request failed")
+        return trigger_id
 
 
 class _CloseFailingSession(_FakeSession):
@@ -1175,10 +1200,15 @@ class _CloseFailingSession(_FakeSession):
         self.exit_calls += 1
         raise RuntimeError("quelware close failed")
 
-    async def trigger(self, instrument_ids: list[str]) -> None:
-        await super().trigger(instrument_ids)
+    async def trigger(
+        self,
+        instrument_ids: list[str],
+        wait_ms: int | None = None,
+    ) -> int:
+        trigger_id = await super().trigger(instrument_ids, wait_ms=wait_ms)
         if self._fail_trigger:
             raise RuntimeError("quelware request failed")
+        return trigger_id
 
 
 def test_execute_recreates_session_after_transient_request_failure(
@@ -1743,9 +1773,18 @@ def test_execute_batch_async_reopens_session_per_payload(
     create_session_calls: list[tuple[str, ...]] = []
 
     class _CountingClient(_FakeClient):
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(
+            self,
+            resource_ids: list[str],
+            ttl_ms: int = 4_000,
+            tentative_ttl_ms: int = 1_000,
+        ) -> _FakeSession:
             create_session_calls.append(tuple(resource_ids))
-            return super().create_session(resource_ids)
+            return super().create_session(
+                resource_ids,
+                ttl_ms=ttl_ms,
+                tentative_ttl_ms=tentative_ttl_ms,
+            )
 
     client = _CountingClient(session)
 

--- a/tests/backend/test_quel3_configuration_manager.py
+++ b/tests/backend/test_quel3_configuration_manager.py
@@ -138,7 +138,7 @@ def test_deploy_instruments_calls_session_api(
         ) -> None:
             _ = (exc_type, exc, tb)
 
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(self, resource_ids: list[str], **_: object) -> _FakeSession:
             create_session_calls.append(tuple(resource_ids))
             return _FakeSession()
 
@@ -280,7 +280,7 @@ def test_deploy_instruments_recreates_session_after_transient_request_failure(
             _ = (exc_type, exc, tb)
             self.exit_calls += 1
 
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(self, resource_ids: list[str], **_: object) -> _FakeSession:
             assert tuple(resource_ids) == ("quel3-02-a01:tx_p02",)
             return self._session
 
@@ -423,7 +423,7 @@ def test_deploy_instruments_ignores_session_close_failure_after_success(
             _ = (exc_type, exc, tb)
             self.exit_calls += 1
 
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(self, resource_ids: list[str], **_: object) -> _FakeSession:
             assert tuple(resource_ids) == ("quel3-02-a01:tx_p02",)
             return self._session
 
@@ -531,7 +531,7 @@ def test_deploy_instruments_wraps_final_request_failure(
             _ = (exc_type, exc, tb)
             self.exit_calls += 1
 
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(self, resource_ids: list[str], **_: object) -> _FakeSession:
             assert tuple(resource_ids) == ("quel3-02-a01:tx_p02",)
             return self._session
 
@@ -677,7 +677,7 @@ def test_deploy_instruments_retries_resource_allocation_on_session_create(
         ) -> None:
             _ = (exc_type, exc, tb)
 
-        def create_session(self, resource_ids: list[str]) -> object:
+        def create_session(self, resource_ids: list[str], **_: object) -> object:
             self.create_session_calls.append(tuple(resource_ids))
             if len(self.create_session_calls) == 1:
                 return self.failing_context
@@ -796,7 +796,7 @@ def test_deploy_instruments_accepts_unit_prefixed_returned_alias(
         ) -> None:
             _ = (exc_type, exc, tb)
 
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(self, resource_ids: list[str], **_: object) -> _FakeSession:
             del resource_ids
             return _FakeSession()
 
@@ -933,7 +933,7 @@ def test_deploy_instruments_groups_requests_by_port(
         ) -> None:
             _ = (exc_type, exc, tb)
 
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(self, resource_ids: list[str], **_: object) -> _FakeSession:
             create_session_calls.append(tuple(resource_ids))
             return _FakeSession()
 
@@ -1064,7 +1064,7 @@ def test_deploy_instruments_uses_one_session_for_all_ports(
         ) -> None:
             _ = (exc_type, exc, tb)
 
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(self, resource_ids: list[str], **_: object) -> _FakeSession:
             create_session_calls.append(tuple(resource_ids))
             return _FakeSession()
 
@@ -1191,7 +1191,7 @@ def test_deploy_instruments_parallelizes_ports_by_default(
         ) -> None:
             _ = (exc_type, exc, tb)
 
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(self, resource_ids: list[str], **_: object) -> _FakeSession:
             del resource_ids
             return _FakeSession()
 
@@ -1314,7 +1314,7 @@ def test_deploy_instruments_parallel_false_serializes_ports(
         ) -> None:
             _ = (exc_type, exc, tb)
 
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(self, resource_ids: list[str], **_: object) -> _FakeSession:
             del resource_ids
             return _FakeSession()
 
@@ -1936,7 +1936,7 @@ def test_deploy_instruments_replaces_cached_alias(
         ) -> None:
             _ = (exc_type, exc, tb)
 
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(self, resource_ids: list[str], **_: object) -> _FakeSession:
             del resource_ids
             return _FakeSession()
 
@@ -2061,7 +2061,7 @@ def test_deploy_instruments_replaces_cached_port_in_one_batched_deploy(
         ) -> None:
             _ = (exc_type, exc, tb)
 
-        def create_session(self, resource_ids: list[str]) -> _FakeSession:
+        def create_session(self, resource_ids: list[str], **_: object) -> _FakeSession:
             del resource_ids
             return _FakeSession()
 

--- a/tests/backend/test_quel3_session_manager.py
+++ b/tests/backend/test_quel3_session_manager.py
@@ -72,7 +72,7 @@ class _FakeClient:
         self.failing_contexts: list[_FailingSessionContext] = []
         self.create_session_calls: list[tuple[str, ...]] = []
 
-    def create_session(self, resource_ids: tuple[str, ...]) -> object:
+    def create_session(self, resource_ids: tuple[str, ...], **_: object) -> object:
         self.create_session_calls.append(tuple(resource_ids))
         if len(self.create_session_calls) <= self._failures_before_success:
             context = _FailingSessionContext(
@@ -190,7 +190,7 @@ def test_open_retries_when_failed_session_token_is_unavailable(
             self.failing_context = _FailingUnopenedSession()
             self.create_session_calls: list[tuple[str, ...]] = []
 
-        def create_session(self, resource_ids: tuple[str, ...]) -> object:
+        def create_session(self, resource_ids: tuple[str, ...], **_: object) -> object:
             self.create_session_calls.append(tuple(resource_ids))
             if len(self.create_session_calls) == 1:
                 return self.failing_context

--- a/tests/test_optional_dependencies.py
+++ b/tests/test_optional_dependencies.py
@@ -24,7 +24,7 @@ def test_project_optional_dependencies_split_backend_quel1_quel3() -> None:
         re.MULTILINE,
     )
     assert re.search(
-        r'^quel3\s*=\s*\["quelware-client >= 0\.2\.0"\]',
+        r'^quel3\s*=\s*\["quelware-client >= 0\.4\.1"\]',
         text,
         re.MULTILINE,
     )

--- a/uv.lock
+++ b/uv.lock
@@ -3474,7 +3474,7 @@ requires-dist = [
     { name = "pyserial", specifier = ">=3.5" },
     { name = "pyyaml", specifier = ">=6.0" },
     { name = "qctrl-visualizer", specifier = ">=8.0" },
-    { name = "quelware-client", marker = "extra == 'quel3'", specifier = ">=0.2.0" },
+    { name = "quelware-client", marker = "extra == 'quel3'", specifier = ">=0.4.1" },
     { name = "qxcore", editable = "packages/qxcore" },
     { name = "qxdriver-quel1", marker = "extra == 'backend'", editable = "packages/qxdriver-quel1" },
     { name = "qxdriver-quel1", marker = "extra == 'quel1'", editable = "packages/qxdriver-quel1" },
@@ -3541,7 +3541,7 @@ wheels = [
 
 [[package]]
 name = "quelware-client"
-version = "0.2.0"
+version = "0.4.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "betterproto2" },
@@ -3550,14 +3550,14 @@ dependencies = [
     { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9b/bb/0232743965856f544f14421b2984cf32f87c5216e5941637622529032a64/quelware_client-0.2.0.tar.gz", hash = "sha256:bea752ed2d188bb6fc4373c034f35b3f582cddcd0829a1d5ce10e2e477bdc4de", size = 105908, upload-time = "2026-05-28T04:50:11.598Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4f/98/d8aff99430928ed5c171b9c2d13b2630b28107538805e999a6c78549bc97/quelware_client-0.4.1.tar.gz", hash = "sha256:a884c111b4beedd596b31252a530e4556213354fa6039c23f17b647e93d392f7", size = 108713, upload-time = "2026-06-17T07:29:24.21Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0a/32/0356be3bf95db56ce72a3cad1cb55f8c588b48dc20741327d77dd85523e7/quelware_client-0.2.0-py3-none-any.whl", hash = "sha256:c94fbd2b3b5fe5d09770e68427ba94d2770bfa2afa3bb5ba9bdbeaae9b15a592", size = 38521, upload-time = "2026-05-28T04:50:10.171Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/31/e727f43f9aa9b3535d2c6c4ffad156f4bb574f54adf17be67a962c3bf028/quelware_client-0.4.1-py3-none-any.whl", hash = "sha256:77a9d8296b6be269886680a0b70305d48fd6276c3263404db958dcb9128043e6", size = 42962, upload-time = "2026-06-17T07:29:22.486Z" },
 ]
 
 [[package]]
 name = "quelware-core"
-version = "0.1.4"
+version = "0.4.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "betterproto2" },
@@ -3567,9 +3567,9 @@ dependencies = [
     { name = "numpy" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4d/bc/7da83b41ccab7c109ba34b5ef309816bf5a9e387f1251503ecc6ae2f839b/quelware_core-0.1.4.tar.gz", hash = "sha256:4ecdbc5839b940610ba02a1937327107615a300a929c6a695cd0ae5fc82c2d74", size = 54579, upload-time = "2026-05-28T04:49:47.266Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/fd/b4/b80d158605e1d8814ede439742e51ac42ed8c5ec8b353ecb2da13e31568d/quelware_core-0.4.0.tar.gz", hash = "sha256:36b39ba8262b9c188ba8ef30c8d8f9ea1385ff4a09fa8e1d532760dbcbbce2b0", size = 55080, upload-time = "2026-06-16T04:23:09.763Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/45/0e/0abac65a3fff8afe81c4f635d17985ef5d13f3d8155c0a42ffb177ecbead/quelware_core-0.1.4-py3-none-any.whl", hash = "sha256:f9189b33d6f6941b9d4ff0407e416628e35df44c974320d37075523b9485d2d5", size = 41188, upload-time = "2026-05-28T04:49:45.771Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/b1/8f508dbe6a300709367935900780c0599ce0ab0c77527c254ae4b66be452/quelware_core-0.4.0-py3-none-any.whl", hash = "sha256:07497eafd4e1b1972484dc9e714c3f86eb2d4ca1828a10d23d980f11d8589404", size = 42762, upload-time = "2026-06-16T04:23:08.203Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Update the QuEL-3 optional dependency to `quelware-client >= 0.4.1`.
- Align the QuEL-3 execution path with the 0.4.1 result API by using `InstrumentDriver.wait_for_result`.
- Preserve the 0.4.x session TTL and trigger timing updates.
- Refresh developer notes for the current QuEL-3 timing and result collection contract.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `make check-release-version`
- `uv run pytest tests/test_optional_dependencies.py tests/backend/test_quel3_session_manager.py tests/backend/test_quel3_configuration_manager.py tests/backend/test_quel3_backend_controller.py tests/backend/test_quel3_client_factory.py`
- `uv run pytest`
