### PR TITLE
feat(measurement): pack schedules into batch timelines

### DIFF
--- a/src/qubex/backend/quel3/models/result.py
+++ b/src/qubex/backend/quel3/models/result.py
@@ -12,7 +12,11 @@ Quel3BackendResultConfig: TypeAlias = dict[str, float]
 
 @dataclass
 class Quel3BackendExecutionResult:
-    """Backend-level measurement result returned by QuEL-3 execution."""
+    """
+    Backend-level measurement result returned by QuEL-3 execution.
+
+    Each `data[alias]` list preserves the alias capture-window execution order.
+    """
 
     status: dict[str, object]
     data: dict[str, list[np.ndarray]]

--- a/src/qubex/measurement/measurement_config_factory.py
+++ b/src/qubex/measurement/measurement_config_factory.py
@@ -42,6 +42,8 @@ class MeasurementConfigFactory:
         time_integration: bool | None = None,
         state_classification: bool | None = None,
         return_items: Sequence[ReturnItem] | None = None,
+        schedule_packing_enabled: bool = False,
+        max_repeated_timeline_duration_ns: float | None = None,
     ) -> MeasurementConfig:
         """Create `MeasurementConfig` from optional runtime overrides."""
         resolved_return_items: tuple[ReturnItem, ...]
@@ -75,4 +77,6 @@ class MeasurementConfigFactory:
                 DEFAULT_STATE_CLASSIFICATION,
             ),
             return_items=resolved_return_items,
+            schedule_packing_enabled=schedule_packing_enabled,
+            max_repeated_timeline_duration_ns=max_repeated_timeline_duration_ns,
         )

--- a/src/qubex/measurement/models/measurement_config.py
+++ b/src/qubex/measurement/models/measurement_config.py
@@ -28,12 +28,19 @@ class MeasurementConfig(Model):
     time_integration: bool
     state_classification: bool
     return_items: tuple[ReturnItem, ...] = ()
+    schedule_packing_enabled: bool = False
+    max_repeated_timeline_duration_ns: float | None = None
 
     @model_validator(mode="after")
     def _validate_invariants(self) -> MeasurementConfig:
         """Validate mode invariants and `return_items` consistency."""
         if self.n_shots <= 0:
             raise ValueError("n_shots must be positive.")
+        if (
+            self.max_repeated_timeline_duration_ns is not None
+            and self.max_repeated_timeline_duration_ns <= 0
+        ):
+            raise ValueError("max_repeated_timeline_duration_ns must be positive.")
 
         return_items = tuple(self.return_items)
         if len(return_items) == 0:
@@ -62,6 +69,11 @@ class MeasurementConfig(Model):
                 f"return_items must include required entries for this mode: {joined}."
             )
         return self
+
+    @property
+    def should_use_schedule_packing(self) -> bool:
+        """Whether multiple schedules should be packed into fewer execution requests."""
+        return self.schedule_packing_enabled
 
     @property
     def primary_return_item(self) -> ReturnItem:

--- a/src/qubex/measurement/services/measurement_execution_service.py
+++ b/src/qubex/measurement/services/measurement_execution_service.py
@@ -8,7 +8,7 @@ from collections.abc import Awaitable, Callable, Collection, Iterator, Mapping, 
 from contextlib import contextmanager
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Literal, TypeVar, cast
+from typing import Any, Literal, TypeAlias, TypeVar, cast
 
 import numpy as np
 from numpy.typing import ArrayLike
@@ -36,6 +36,8 @@ from qubex.measurement.measurement_schedule_builder import (
     MeasurementScheduleBuilder,
 )
 from qubex.measurement.measurement_schedule_runner import MeasurementScheduleRunner
+from qubex.measurement.models.capture_data import CaptureData
+from qubex.measurement.models.capture_schedule import CaptureSchedule
 from qubex.measurement.models.measure_result import (
     MeasureResult,
     MultipleMeasureResult,
@@ -71,6 +73,7 @@ logger = logging.getLogger(__name__)
 T = TypeVar("T")
 OptionT = TypeVar("OptionT")
 RFSwitchState = Literal["pass", "block", "open", "loop"]
+MeasurementResultSplitPlan: TypeAlias = list[dict[str, int]]
 
 
 def _run_async(
@@ -662,7 +665,7 @@ class MeasurementExecutionService:
             measurement_schedules = [
                 schedule(sweep_value) for sweep_value in normalized_values
             ]
-            results = await self.measurement_schedule_runner.execute_many_async(
+            results = await self._execute_measurement_schedules(
                 schedules=measurement_schedules,
                 config=resolved_config,
             )
@@ -754,7 +757,7 @@ class MeasurementExecutionService:
                 for ndindex in np.ndindex(shape)
             ]
             measurement_schedules = [schedule(point) for point in points]
-            results = await self.measurement_schedule_runner.execute_many_async(
+            results = await self._execute_measurement_schedules(
                 schedules=measurement_schedules,
                 config=resolved_config,
             )
@@ -779,6 +782,338 @@ class MeasurementExecutionService:
             config=resolved_config,
             results=results,
         )
+
+    async def _execute_measurement_schedules(
+        self,
+        *,
+        schedules: list[MeasurementSchedule],
+        config: MeasurementConfig,
+    ) -> list[MeasurementResult]:
+        """Execute multiple schedules either as one packed timeline or batch requests."""
+        runner = self.measurement_schedule_runner
+        if self._should_pack_measurement_schedules(
+            runner=runner,
+            schedules=schedules,
+            config=config,
+        ):
+            return await self._execute_measurement_schedules_as_packed_timeline(
+                runner=runner,
+                schedules=schedules,
+                config=config,
+            )
+        return await runner.execute_many_async(
+            schedules=schedules,
+            config=config,
+        )
+
+    async def _execute_measurement_schedules_as_packed_timeline(
+        self,
+        *,
+        runner: MeasurementScheduleRunner,
+        schedules: list[MeasurementSchedule],
+        config: MeasurementConfig,
+    ) -> list[MeasurementResult]:
+        """Execute packed timeline chunks and split merged results per schedule."""
+        results: list[MeasurementResult] = []
+        for chunk in self._split_measurement_schedules_into_packed_timeline_chunks(
+            schedules=schedules,
+            config=config,
+        ):
+            results.extend(
+                await self._execute_measurement_schedule_chunk_as_packed_timeline(
+                    runner=runner,
+                    schedules=chunk,
+                    config=config,
+                )
+            )
+        return results
+
+    async def _execute_measurement_schedule_chunk_as_packed_timeline(
+        self,
+        *,
+        runner: MeasurementScheduleRunner,
+        schedules: list[MeasurementSchedule],
+        config: MeasurementConfig,
+    ) -> list[MeasurementResult]:
+        """Execute one packed timeline chunk and split merged results per schedule."""
+        split_plan = self._build_measurement_result_split_plan(schedules=schedules)
+        merged_schedule = self._merge_measurement_schedules(
+            schedules=schedules,
+            shot_interval=config.shot_interval,
+        )
+        merged_measurement_result = await runner.execute_async(
+            schedule=merged_schedule,
+            config=config,
+        )
+        return self._split_merged_measurement_result(
+            merged_result=merged_measurement_result,
+            split_plan=split_plan,
+        )
+
+    def _split_measurement_schedules_into_packed_timeline_chunks(
+        self,
+        *,
+        schedules: list[MeasurementSchedule],
+        config: MeasurementConfig,
+    ) -> list[list[MeasurementSchedule]]:
+        """
+        Split packed timeline chunks by the repeated-duration soft limit.
+
+        A single over-limit schedule remains in its own chunk.
+        """
+        limit = config.max_repeated_timeline_duration_ns
+        if limit is None:
+            return [schedules]
+
+        chunks: list[list[MeasurementSchedule]] = []
+        current_chunks: list[MeasurementSchedule] = []
+        for schedule in schedules:
+            if self._packed_timeline_repeated_duration_within_limit(
+                limit, config.n_shots, config.shot_interval, [*current_chunks, schedule]
+            ):
+                current_chunks.append(schedule)
+            else:
+                if len(current_chunks) == 0:
+                    chunks.append([schedule])
+                else:
+                    chunks.append(current_chunks)
+                    current_chunks = [schedule]
+
+        if len(current_chunks) > 0:
+            chunks.append(current_chunks)
+
+        return chunks
+
+    @staticmethod
+    def _packed_timeline_repeated_duration_within_limit(
+        limit: float,
+        n_shots: int,
+        shot_interval: float,
+        schedules: Sequence[MeasurementSchedule],
+    ) -> bool:
+        total_duration = 0.0
+        for schedule in schedules:
+            total_duration += schedule.pulse_schedule.duration
+
+        repeated_total_duration = (
+            total_duration + (len(schedules) - 1) * shot_interval
+        ) * n_shots
+        return repeated_total_duration <= limit
+
+    def _should_pack_measurement_schedules(
+        self,
+        *,
+        runner: MeasurementScheduleRunner,
+        schedules: Sequence[MeasurementSchedule],
+        config: MeasurementConfig,
+    ) -> bool:
+        """Return whether all schedules should be packed into one timeline."""
+        del runner
+        if len(schedules) <= 1:
+            return False
+        if not config.should_use_schedule_packing:
+            return False
+        return self._can_merge_measurement_schedules(schedules=schedules)
+
+    def _can_merge_measurement_schedules(
+        self,
+        *,
+        schedules: Sequence[MeasurementSchedule],
+    ) -> bool:
+        """Return whether schedules can be concatenated without changing channel metadata."""
+        if len(schedules) <= 1:
+            return False
+        first_schedule = schedules[0].pulse_schedule
+        if not isinstance(first_schedule, PulseSchedule):
+            return False
+        labels = first_schedule.labels
+        sampling_periods = self._schedule_sampling_periods(first_schedule)
+        if sampling_periods is None:
+            return False
+        frequencies = self._schedule_frequencies(first_schedule)
+        if frequencies is None:
+            return False
+
+        for schedule in schedules[1:]:
+            pulse_schedule = schedule.pulse_schedule
+            if not isinstance(pulse_schedule, PulseSchedule):
+                return False
+            if pulse_schedule.labels != labels:
+                return False
+            if self._schedule_sampling_periods(pulse_schedule) != sampling_periods:
+                return False
+            next_frequencies = self._schedule_frequencies(pulse_schedule)
+            if next_frequencies is None:
+                return False
+            for label, frequency in frequencies.items():
+                if not self._same_optional_frequency(
+                    frequency,
+                    next_frequencies[label],
+                ):
+                    return False
+        return True
+
+    @staticmethod
+    def _schedule_sampling_periods(
+        pulse_schedule: PulseSchedule,
+    ) -> dict[str, float] | None:
+        """Return sampling periods keyed by label when all channel metadata is valid."""
+        sampling_periods: dict[str, float] = {}
+        for label in pulse_schedule.labels:
+            try:
+                sequence = pulse_schedule.get_sequence(label, copy=False)
+            except KeyError:
+                return None
+            sampling_period = getattr(sequence, "sampling_period", None)
+            if not isinstance(sampling_period, (int, float)):
+                return None
+            sampling_periods[label] = float(sampling_period)
+        return sampling_periods
+
+    @staticmethod
+    def _schedule_frequencies(
+        pulse_schedule: PulseSchedule,
+    ) -> dict[str, float | None] | None:
+        """Return frequencies keyed by label when frequency metadata is valid."""
+        raw_frequencies = pulse_schedule.get_frequencies()
+        if not isinstance(raw_frequencies, Mapping):
+            return None
+        frequencies: dict[str, float | None] = {}
+        labels = set(pulse_schedule.labels)
+        for label, frequency in raw_frequencies.items():
+            if label not in labels:
+                return None
+            if frequency is None:
+                frequencies[label] = None
+                continue
+            if not isinstance(frequency, (int, float)):
+                return None
+            frequencies[label] = float(frequency)
+        return frequencies
+
+    @staticmethod
+    def _same_optional_frequency(
+        left: float | None,
+        right: float | None,
+    ) -> bool:
+        """Return whether two optional schedule frequencies are equivalent."""
+        if left is None or right is None:
+            return left is right
+        return bool(np.isclose(left, right))
+
+    def _build_measurement_result_split_plan(
+        self,
+        *,
+        schedules: list[MeasurementSchedule],
+    ) -> MeasurementResultSplitPlan:
+        """Build per-schedule visible capture counts keyed by canonical output target."""
+        split_plan: MeasurementResultSplitPlan = []
+        for schedule in schedules:
+            capture_counts: dict[str, int] = {}
+            for capture in schedule.capture_schedule.captures:
+                if capture.is_workaround:
+                    continue
+                for channel in capture.channels:
+                    output_target = self._resolve_capture_output_target(channel)
+                    capture_counts[output_target] = (
+                        capture_counts.get(output_target, 0) + 1
+                    )
+            split_plan.append(capture_counts)
+        return split_plan
+
+    def _resolve_capture_output_target(self, capture_channel: str) -> str:
+        """Resolve the canonical measurement-result key for one capture channel."""
+        target_registry = self._context.experiment_system.target_registry
+        return str(target_registry.measurement_output_label(capture_channel))
+
+    def _merge_measurement_schedules(
+        self,
+        *,
+        schedules: list[MeasurementSchedule],
+        shot_interval: float,
+    ) -> MeasurementSchedule:
+        """Build one measurement schedule by concatenating schedules separated by shot interval."""
+        if len(schedules) == 0:
+            raise ValueError("At least one schedule is required.")
+
+        merged_pulse_schedule = schedules[0].pulse_schedule.copy()
+        merged_captures = [
+            capture.model_copy(update={"channels": capture.channels.copy()})
+            for capture in schedules[0].capture_schedule.captures
+        ]
+
+        for schedule in schedules[1:]:
+            # TODO: Base packed shifts on the full capture timeline, not only pulse duration.
+            shift_duration = merged_pulse_schedule.duration + shot_interval
+            merged_pulse_schedule.barrier()
+            merged_pulse_schedule.pad(shift_duration)
+            merged_pulse_schedule.call(schedule.pulse_schedule, copy=True)
+            merged_captures.extend(
+                capture.model_copy(
+                    update={
+                        "start_time": capture.start_time + shift_duration,
+                        "channels": capture.channels.copy(),
+                    }
+                )
+                for capture in schedule.capture_schedule.captures
+            )
+
+        return MeasurementSchedule(
+            pulse_schedule=merged_pulse_schedule,
+            capture_schedule=CaptureSchedule(captures=merged_captures),
+        )
+
+    def _split_merged_measurement_result(
+        self,
+        *,
+        merged_result: MeasurementResult,
+        split_plan: MeasurementResultSplitPlan,
+    ) -> list[MeasurementResult]:
+        """Split one merged measurement result by canonical capture ordering."""
+        remaining_data: dict[str, list[CaptureData]] = {
+            target: [*captures] for target, captures in merged_result.data.items()
+        }
+        split_results: list[MeasurementResult] = []
+
+        for capture_counts in split_plan:
+            chunk_data: dict[str, list[CaptureData]] = {}
+            for target, capture_count in capture_counts.items():
+                captures = remaining_data.setdefault(target, [])
+                if capture_count > len(captures):
+                    raise ValueError(
+                        f"Not enough captures for target `{target}` to split "
+                        "packed timeline: "
+                        f"expected {capture_count}, got {len(captures)}."
+                    )
+                chunk_data[target] = captures[:capture_count]
+                remaining_data[target] = captures[capture_count:]
+
+            classifier_refs = None
+            if merged_result.classifier_refs is not None:
+                classifier_refs = {
+                    target: classifier_ref
+                    for target, classifier_ref in merged_result.classifier_refs.items()
+                    if target in chunk_data
+                }
+                if len(classifier_refs) == 0:
+                    classifier_refs = None
+
+            split_results.append(
+                MeasurementResult(
+                    data=chunk_data,
+                    measurement_config=merged_result.measurement_config,
+                    device_config=merged_result.device_config,
+                    classifier_refs=classifier_refs,
+                )
+            )
+
+        for captures in remaining_data.values():
+            if len(captures) > 0:
+                raise ValueError(
+                    "Packed measurement result contains unmatched captures after split."
+                )
+
+        return split_results
 
     def _can_use_batch_execution(self) -> bool:
         """Return whether backend batch execution can be used safely."""

--- a/src/qubex/measurement/services/measurement_execution_service.py
+++ b/src/qubex/measurement/services/measurement_execution_service.py
@@ -1328,7 +1328,49 @@ class MeasurementExecutionService:
             shot_averaging=shot_averaging,
             time_integration=time_integration,
             state_classification=state_classification,
+            schedule_packing_enabled=self._resolve_schedule_packing_enabled(),
+            max_repeated_timeline_duration_ns=(
+                self._resolve_max_repeated_timeline_duration_ns()
+            ),
         )
+
+    def _resolve_schedule_packing_enabled(self) -> bool:
+        """Return whether measurement schedules should be packed into timelines."""
+        config = self._resolve_schedule_packing_config()
+        value = config.get("enabled", False)
+        if isinstance(value, bool):
+            return value
+        raise TypeError("`measurement.schedule_packing.enabled` must be a boolean.")
+
+    def _resolve_max_repeated_timeline_duration_ns(self) -> float | None:
+        """Return repeated packed-timeline duration limit in ns."""
+        config = self._resolve_schedule_packing_config()
+        value = config.get("max_repeated_timeline_duration_ns")
+        if value is None:
+            return None
+        if isinstance(value, bool) or not isinstance(value, (int, float)):
+            raise TypeError(
+                "`measurement.schedule_packing.max_repeated_timeline_duration_ns` "
+                "must be a number."
+            )
+        if value <= 0:
+            raise ValueError(
+                "`measurement.schedule_packing.max_repeated_timeline_duration_ns` "
+                "must be positive."
+            )
+        return float(value)
+
+    def _resolve_schedule_packing_config(self) -> dict[str, Any]:
+        """Return schedule packing config from generic measurement config."""
+        measurement_config = getattr(self.config_loader, "measurement_config", {})
+        if not isinstance(measurement_config, Mapping):
+            raise TypeError("`measurement` section must be a mapping.")
+        value = measurement_config.get("schedule_packing", {})
+        if value is None:
+            return {}
+        if isinstance(value, dict):
+            return dict(value)
+        raise TypeError("`measurement.schedule_packing` must be a mapping.")
 
     def build_measurement_schedule(
         self,

--- a/src/qubex/system/config_loader.py
+++ b/src/qubex/system/config_loader.py
@@ -427,6 +427,19 @@ class ConfigLoader:
         return dict(value)
 
     @property
+    def measurement_config(self) -> dict[str, Any]:
+        """Return measurement configuration for the loaded system."""
+        self._ensure_loaded()
+        value = self._system_dict.get("measurement")
+        if value is None:
+            return {}
+        if not isinstance(value, dict):
+            raise TypeError(
+                f"`measurement` section in `{self._system_file}` must be a mapping."
+            )
+        return dict(value)
+
+    @property
     def measurement_defaults(self) -> MeasurementDefaults:
         """Return parsed partial measurement defaults for the loaded system."""
         self._ensure_loaded()

--- a/tests/backend/test_config_loader.py
+++ b/tests/backend/test_config_loader.py
@@ -1319,6 +1319,84 @@ def test_experiment_config_returns_top_level_experiment_section(
     assert loader.backend_runtime_config == {}
 
 
+def test_measurement_config_rejects_non_mapping_config(
+    tmp_path: Path,
+) -> None:
+    """Given non-mapping measurement config, ConfigLoader should reject it."""
+    config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)
+
+    _write_yaml(
+        config_dir / "box.yaml",
+        {
+            "BOX1": {
+                "name": "Box One",
+                "type": "quel3",
+            }
+        },
+    )
+    _write_yaml(
+        config_dir / "system.yaml",
+        {
+            "schema_version": 1,
+            "chip_id": chip_id,
+            "backend": BACKEND_KIND_QUEL3,
+            "measurement": True,
+        },
+    )
+
+    loader = ConfigLoader(
+        system_id=chip_id,
+        config_dir=config_dir,
+        params_dir=params_dir,
+    )
+
+    with pytest.raises(TypeError):
+        _ = loader.measurement_config
+
+
+def test_measurement_config_returns_top_level_measurement_section(
+    tmp_path: Path,
+) -> None:
+    """Given measurement config, ConfigLoader should expose a copy of it."""
+    config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)
+    measurement_config = {
+        "schedule_packing": {
+            "enabled": True,
+            "max_repeated_timeline_duration_ns": 20_000_000_000,
+        }
+    }
+
+    _write_yaml(
+        config_dir / "box.yaml",
+        {
+            "BOX1": {
+                "name": "Box One",
+                "type": "quel3",
+            }
+        },
+    )
+    _write_yaml(
+        config_dir / "system.yaml",
+        {
+            "schema_version": 1,
+            "chip_id": chip_id,
+            "backend": BACKEND_KIND_QUEL3,
+            "measurement": measurement_config,
+        },
+    )
+
+    loader = ConfigLoader(
+        system_id=chip_id,
+        config_dir=config_dir,
+        params_dir=params_dir,
+    )
+    loaded_config = loader.measurement_config
+    loaded_config["schedule_packing"] = {}
+
+    assert loaded_config != loader.measurement_config
+    assert loader.measurement_config == measurement_config
+
+
 def test_load_configures_quel3_readout_without_lo(tmp_path: Path) -> None:
     """Given quel3 backend, when loading, then readout ports are configured without LO."""
     config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)

--- a/tests/measurement/test_measurement_config.py
+++ b/tests/measurement/test_measurement_config.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from typing import cast
+from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
 from pydantic import ValidationError
@@ -15,6 +16,9 @@ from qubex.measurement.measurement_defaults import (
     DEFAULT_SHOTS,
 )
 from qubex.measurement.models import MeasurementConfig, ReturnItem
+from qubex.measurement.services.measurement_execution_service import (
+    MeasurementExecutionService,
+)
 from qubex.system import ExperimentSystem
 
 
@@ -111,6 +115,64 @@ def test_factory_maps_boolean_overrides() -> None:
     assert config.shot_averaging is False
     assert config.time_integration is True
     assert config.state_classification is True
+
+
+def test_factory_maps_packed_timeline_limit() -> None:
+    """Given packed timeline limit, when factory builds config, then config keeps it."""
+    experiment_system = type(
+        "_ES",
+        (),
+        {
+            "control_params": type("_CP", (), {"readout_amplitude": {}})(),
+            "measurement_defaults": {},
+        },
+    )()
+    factory = MeasurementConfigFactory(
+        experiment_system=cast(ExperimentSystem, experiment_system)
+    )
+
+    config = factory.create(
+        schedule_packing_enabled=True,
+        max_repeated_timeline_duration_ns=20_000_000_000,
+    )
+
+    assert config.schedule_packing_enabled is True
+    assert config.max_repeated_timeline_duration_ns == 20_000_000_000
+
+
+def test_execution_service_resolves_schedule_packing_config() -> None:
+    """Given measurement config, service should resolve schedule packing options."""
+    service = MeasurementExecutionService.__new__(MeasurementExecutionService)
+    cast(Any, service)._context = SimpleNamespace(  # noqa: SLF001
+        config_loader=SimpleNamespace(
+            measurement_config={
+                "schedule_packing": {
+                    "enabled": True,
+                    "max_repeated_timeline_duration_ns": 20_000_000_000,
+                }
+            }
+        )
+    )
+
+    assert service._resolve_schedule_packing_enabled() is True  # noqa: SLF001
+    assert service._resolve_max_repeated_timeline_duration_ns() == (  # noqa: SLF001
+        20_000_000_000
+    )
+
+
+def test_execution_service_rejects_boolean_schedule_packing_config() -> None:
+    """Given boolean schedule packing config, service should reject it."""
+    service = MeasurementExecutionService.__new__(MeasurementExecutionService)
+    cast(Any, service)._context = SimpleNamespace(  # noqa: SLF001
+        config_loader=SimpleNamespace(
+            measurement_config={
+                "schedule_packing": True,
+            }
+        )
+    )
+
+    with pytest.raises(TypeError, match="measurement\\.schedule_packing"):
+        service._resolve_schedule_packing_enabled()  # noqa: SLF001
 
 
 def test_factory_rejects_frequency_overrides() -> None:

--- a/tests/measurement/test_measurement_execution_service.py
+++ b/tests/measurement/test_measurement_execution_service.py
@@ -1,0 +1,494 @@
+"""Tests for MeasurementExecutionService batch timeline packing behavior."""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any, ClassVar, cast
+
+import numpy as np
+import pytest
+from qxpulse import Blank, PulseSchedule, Rect, get_sampling_period, set_sampling_period
+
+from qubex.backend import BackendExecutionRequest
+from qubex.measurement.models import (
+    CaptureData,
+    MeasurementConfig,
+    MeasurementResult,
+    MeasurementSchedule,
+)
+from qubex.measurement.models.capture_schedule import Capture, CaptureSchedule
+from qubex.measurement.services.measurement_execution_service import (
+    MeasurementExecutionService,
+)
+
+
+def _make_config() -> MeasurementConfig:
+    return MeasurementConfig(
+        n_shots=2,
+        shot_interval=100.0,
+        shot_averaging=False,
+        time_integration=False,
+        state_classification=False,
+    )
+
+
+def _make_schedule(
+    *,
+    label: str,
+    capture_start: float,
+    capture_target: str,
+    pulse_duration: float = 4.0,
+) -> MeasurementSchedule:
+    with PulseSchedule([label]) as pulse_schedule:
+        if pulse_duration > 0.0:
+            pulse_schedule.add(label, Rect(duration=pulse_duration, amplitude=0.1))
+    return MeasurementSchedule(
+        pulse_schedule=pulse_schedule,
+        capture_schedule=CaptureSchedule(
+            captures=[
+                Capture(
+                    channels=[capture_target],
+                    start_time=capture_start,
+                    duration=1.0,
+                )
+            ]
+        ),
+    )
+
+
+@dataclass
+class _BackendResult:
+    status: dict[str, object]
+    data: dict[str, list[Any]]
+    config: dict[str, object]
+
+
+class _FakeBackend:
+    sampling_period_ns: ClassVar[float] = 0.4
+    CAPTURE_DECIMATION_FACTOR: ClassVar[int] = 4
+
+    async def execute_batch_async(
+        self,
+        *,
+        requests: list[BackendExecutionRequest],
+    ) -> list[_BackendResult]:
+        del requests
+        return []
+
+
+class _FakeRunner:
+    def __init__(
+        self,
+        *,
+        _backend_controller: _FakeBackend,
+        **_: Any,
+    ) -> None:
+        self._measurement_backend_adapter = object()
+        self.prepare_calls: list[MeasurementSchedule] = []
+        self.executed_requests: list[BackendExecutionRequest] = []
+        self.build_chunks: list[tuple[str, ...]] = []
+
+    async def _execute_request(
+        self, *, request: BackendExecutionRequest
+    ) -> _BackendResult:
+        self.executed_requests.append(request)
+        schedule = cast(MeasurementSchedule, request.payload)
+        visible_capture_count = sum(
+            0 if capture.is_workaround else len(capture.channels)
+            for capture in schedule.capture_schedule.captures
+        )
+        return _BackendResult(
+            status={},
+            data={
+                "Q00": [
+                    np.array(
+                        [[float(index + 1) + 0.0j], [float(index + 1) + 0.0j]],
+                        dtype=np.complex128,
+                    )
+                    for index in range(visible_capture_count)
+                ],
+            },
+            config={"sampling_period_ns": 0.4},
+        )
+
+    async def execute_async(
+        self,
+        *,
+        schedule: MeasurementSchedule,
+        config: MeasurementConfig,
+    ) -> MeasurementResult:
+        request = self._prepare_execution(schedule=schedule, config=config)
+        backend_result = await self._execute_request(request=request)
+        return self._build_result(backend_result=backend_result, config=config)
+
+    def _prepare_execution(
+        self,
+        *,
+        schedule: MeasurementSchedule,
+        config: MeasurementConfig,
+        quel1_options: Any | None = None,
+    ) -> BackendExecutionRequest:
+        del config
+        del quel1_options
+        self.prepare_calls.append(schedule)
+        return BackendExecutionRequest(payload=cast(object, schedule))
+
+    def _build_result(
+        self,
+        *,
+        backend_result: object,
+        config: MeasurementConfig,
+    ) -> MeasurementResult:
+        assert isinstance(backend_result, _BackendResult)
+        backend_data = cast(dict[str, list[Any]], backend_result.data)
+        self.build_chunks.append(tuple(backend_data.keys()))
+        return MeasurementResult(
+            data={
+                target: [
+                    CaptureData.from_primary_data(
+                        target=target,
+                        data=np.asarray(value),
+                        config=config,
+                        sampling_period=0.4,
+                    )
+                    for value in values
+                ]
+                for target, values in backend_data.items()
+            },
+            measurement_config=config,
+            device_config={
+                "chunk_aliases": tuple(backend_data.keys()),
+            },
+        )
+
+
+def _make_context() -> tuple[SimpleNamespace, _FakeBackend]:
+    backend = _FakeBackend()
+    context = SimpleNamespace(
+        config_loader=SimpleNamespace(measurement_config={}),
+        experiment_system=SimpleNamespace(
+            target_registry=SimpleNamespace(
+                measurement_output_label=lambda target: target,
+            ),
+        ),
+        system_manager=SimpleNamespace(),
+    )
+    return context, backend
+
+
+def _make_service(
+    monkeypatch,
+    backend: _FakeBackend,
+) -> tuple[MeasurementExecutionService, list[_FakeRunner]]:
+    runners: list[_FakeRunner] = []
+
+    def _runner_factory(
+        *,
+        backend_controller: _FakeBackend,
+        **kwargs: Any,
+    ) -> _FakeRunner:
+        _ = backend_controller
+        del kwargs
+        runner = _FakeRunner(_backend_controller=backend)
+        runners.append(runner)
+        return runner
+
+    monkeypatch.setattr(
+        "qubex.measurement.services.measurement_execution_service.MeasurementScheduleRunner",
+        _runner_factory,
+    )
+    context, _ = _make_context()
+    service = MeasurementExecutionService(
+        context=cast(Any, context),
+        session_service=cast(Any, SimpleNamespace(backend_controller=backend)),
+        classifiers={},
+    )
+    return service, runners
+
+
+def test_run_sweep_measurement_with_schedule_packing_merges_and_splits(
+    monkeypatch,
+) -> None:
+    """Given pack option, run_sweep_measurement should execute one merged timeline and split results."""
+    first_schedule = _make_schedule(
+        label="Q00", capture_start=1.0, capture_target="Q00"
+    )
+    second_schedule = _make_schedule(
+        label="Q00", capture_start=2.0, capture_target="Q00"
+    )
+    schedules = [first_schedule, second_schedule]
+
+    backend = _FakeBackend()
+    service, runners = _make_service(monkeypatch=monkeypatch, backend=backend)
+
+    def _schedule_builder(value: object) -> MeasurementSchedule:
+        return schedules[int(cast(float, value))]
+
+    config = _make_config().model_copy(update={"schedule_packing_enabled": True})
+
+    result = asyncio.run(
+        service.run_sweep_measurement(
+            schedule=_schedule_builder,
+            sweep_values=[0, 1],
+            config=config,
+        )
+    )
+
+    runner = runners[0]
+    assert len(runner.prepare_calls) == 1
+    assert len(runner.executed_requests) == 1
+
+    merged_schedule = runner.prepare_calls[-1]
+    expected_shift = first_schedule.pulse_schedule.duration + config.shot_interval
+
+    merged_captures = merged_schedule.capture_schedule.channels
+    assert merged_captures["Q00"][0].start_time == 1.0
+    assert merged_captures["Q00"][1].start_time == pytest.approx(2.0 + expected_shift)
+
+    assert runner.build_chunks == [("Q00",)]
+    assert list(result.results[0].data) == ["Q00"]
+    assert list(result.results[1].data) == ["Q00"]
+    assert np.asarray(result.results[0].data["Q00"][0].data).tolist() == [
+        [1.0 + 0.0j],
+        [1.0 + 0.0j],
+    ]
+    assert np.asarray(result.results[1].data["Q00"][0].data).tolist() == [
+        [2.0 + 0.0j],
+        [2.0 + 0.0j],
+    ]
+
+
+def test_run_sweep_measurement_splits_packed_timelines_by_repeated_duration(
+    monkeypatch,
+) -> None:
+    """Given a packed timeline limit, run_sweep_measurement should split packed chunks."""
+    schedules = [
+        _make_schedule(label="Q00", capture_start=float(index), capture_target="Q00")
+        for index in range(4)
+    ]
+
+    backend = _FakeBackend()
+    service, runners = _make_service(monkeypatch=monkeypatch, backend=backend)
+
+    def _schedule_builder(value: object) -> MeasurementSchedule:
+        return schedules[int(cast(float, value))]
+
+    config = _make_config().model_copy(
+        update={
+            "shot_interval": 2.0,
+            "schedule_packing_enabled": True,
+            "max_repeated_timeline_duration_ns": 24,
+        }
+    )
+
+    result = asyncio.run(
+        service.run_sweep_measurement(
+            schedule=_schedule_builder,
+            sweep_values=[0, 1, 2, 3],
+            config=config,
+        )
+    )
+
+    runner = runners[0]
+    assert len(runner.prepare_calls) == 2
+    assert len(runner.executed_requests) == 2
+    assert [
+        len(schedule.capture_schedule.captures) for schedule in runner.prepare_calls
+    ] == [
+        2,
+        2,
+    ]
+    assert len(result.results) == 4
+
+
+def test_merge_measurement_schedules_rebuilds_capture_channels_after_source_cache() -> (
+    None
+):
+    """Given cached channels, merge should expose captures appended from later schedules."""
+    service = MeasurementExecutionService.__new__(MeasurementExecutionService)
+    first_schedule = _make_schedule(
+        label="Q00", capture_start=1.0, capture_target="Q00"
+    )
+    second_schedule = _make_schedule(
+        label="Q00", capture_start=2.0, capture_target="Q00"
+    )
+    _ = first_schedule.capture_schedule.channels
+
+    merged_schedule = service._merge_measurement_schedules(  # noqa: SLF001
+        schedules=[first_schedule, second_schedule],
+        shot_interval=100.0,
+    )
+
+    merged_captures = merged_schedule.capture_schedule.channels
+    assert set(merged_captures) == {"Q00"}
+    assert len(merged_captures["Q00"]) == 2
+    assert merged_captures["Q00"][1].start_time == pytest.approx(106.0)
+
+
+def test_should_pack_measurement_schedules_rejects_different_labels() -> None:
+    """Given different labels, packing should fall back to batch execution."""
+    service = MeasurementExecutionService.__new__(MeasurementExecutionService)
+    first_schedule = _make_schedule(
+        label="Q00", capture_start=1.0, capture_target="Q00"
+    )
+    second_schedule = _make_schedule(
+        label="Q01", capture_start=2.0, capture_target="Q01"
+    )
+    config = _make_config().model_copy(update={"schedule_packing_enabled": True})
+
+    assert (
+        service._should_pack_measurement_schedules(  # noqa: SLF001
+            runner=cast(Any, _FakeRunner(_backend_controller=_FakeBackend())),
+            schedules=[first_schedule, second_schedule],
+            config=config,
+        )
+        is False
+    )
+
+
+def test_should_pack_measurement_schedules_rejects_different_sampling_periods() -> None:
+    """Given different channel sampling periods, packing should fall back to batch execution."""
+    service = MeasurementExecutionService.__new__(MeasurementExecutionService)
+    original_sampling_period = get_sampling_period()
+    try:
+        set_sampling_period(2.0)
+        first_schedule = _make_schedule(
+            label="Q00", capture_start=1.0, capture_target="Q00"
+        )
+        set_sampling_period(0.8)
+        second_schedule = _make_schedule(
+            label="Q00", capture_start=2.0, capture_target="Q00"
+        )
+    finally:
+        set_sampling_period(original_sampling_period)
+    config = _make_config().model_copy(update={"schedule_packing_enabled": True})
+
+    assert (
+        service._should_pack_measurement_schedules(  # noqa: SLF001
+            runner=cast(Any, _FakeRunner(_backend_controller=_FakeBackend())),
+            schedules=[first_schedule, second_schedule],
+            config=config,
+        )
+        is False
+    )
+
+
+def test_merge_measurement_schedules_appends_same_channels() -> None:
+    """Given matching labels, merge should append pulses with shifted captures."""
+    service = MeasurementExecutionService.__new__(MeasurementExecutionService)
+    first_schedule = _make_schedule(
+        label="Q00", capture_start=1.0, capture_target="Q00"
+    )
+    second_schedule = _make_schedule(
+        label="Q00", capture_start=2.0, capture_target="Q00"
+    )
+
+    merged_schedule = service._merge_measurement_schedules(  # noqa: SLF001
+        schedules=[first_schedule, second_schedule],
+        shot_interval=100.0,
+    )
+
+    q00_waveforms = merged_schedule.pulse_schedule.get_sequence(
+        "Q00",
+        copy=False,
+    ).get_flattened_waveforms(apply_frame_shifts=False)
+    assert len(q00_waveforms) == 3
+    assert isinstance(q00_waveforms[1], Blank)
+    assert q00_waveforms[1].duration == pytest.approx(100.0)
+    assert merged_schedule.capture_schedule.channels["Q00"][1].start_time == (
+        pytest.approx(106.0)
+    )
+    assert merged_schedule.pulse_schedule.is_valid()
+
+
+def test_split_merged_measurement_result_uses_capture_order_contract() -> None:
+    """Given repeated target captures, split should consume captures from the front."""
+    service = MeasurementExecutionService.__new__(MeasurementExecutionService)
+    config = _make_config()
+    merged_result = MeasurementResult(
+        data={
+            "Q00": [
+                CaptureData.from_primary_data(
+                    target="Q00",
+                    data=np.array([[1.0 + 0.0j], [1.0 + 0.0j]], dtype=np.complex128),
+                    config=config,
+                    sampling_period=0.4,
+                ),
+                CaptureData.from_primary_data(
+                    target="Q00",
+                    data=np.array([[2.0 + 0.0j], [2.0 + 0.0j]], dtype=np.complex128),
+                    config=config,
+                    sampling_period=0.4,
+                ),
+            ]
+        },
+        measurement_config=config,
+        device_config={"device": "fake"},
+    )
+
+    results = service._split_merged_measurement_result(  # noqa: SLF001
+        merged_result=merged_result,
+        split_plan=[{"Q00": 1}, {"Q00": 1}],
+    )
+
+    assert np.asarray(results[0].data["Q00"][0].data).tolist() == [
+        [1.0 + 0.0j],
+        [1.0 + 0.0j],
+    ]
+    assert np.asarray(results[1].data["Q00"][0].data).tolist() == [
+        [2.0 + 0.0j],
+        [2.0 + 0.0j],
+    ]
+    assert results[0].device_config == {"device": "fake"}
+
+
+def test_build_measurement_result_split_plan_uses_registry_output_labels() -> None:
+    """Given registry output labels, split plan should use canonical result keys."""
+
+    class _TargetRegistry:
+        @staticmethod
+        def measurement_output_label(target_label: str) -> str:
+            return "Q17" if target_label == "raw-readout-target" else target_label
+
+    service = MeasurementExecutionService.__new__(MeasurementExecutionService)
+    cast(Any, service)._context = SimpleNamespace(  # noqa: SLF001
+        experiment_system=SimpleNamespace(target_registry=_TargetRegistry())
+    )
+    schedule = _make_schedule(
+        label="raw-readout-target",
+        capture_start=1.0,
+        capture_target="raw-readout-target",
+    )
+
+    split_plan = service._build_measurement_result_split_plan(  # noqa: SLF001
+        schedules=[schedule],
+    )
+
+    assert split_plan == [{"Q17": 1}]
+
+
+def test_should_pack_measurement_schedules_rejects_conflicting_frequencies() -> None:
+    """Given per-point frequency changes, packing should fall back to batch execution."""
+    backend = _FakeBackend()
+    runner = _FakeRunner(_backend_controller=backend)
+    service = MeasurementExecutionService.__new__(MeasurementExecutionService)
+    first_schedule = _make_schedule(
+        label="Q00", capture_start=1.0, capture_target="Q00"
+    )
+    second_schedule = _make_schedule(
+        label="Q00", capture_start=2.0, capture_target="Q00"
+    )
+    first_schedule.pulse_schedule.set_frequency("Q00", 5.0)
+    second_schedule.pulse_schedule.set_frequency("Q00", 5.1)
+    config = _make_config().model_copy(update={"schedule_packing_enabled": True})
+
+    assert (
+        service._should_pack_measurement_schedules(  # noqa: SLF001
+            runner=cast(Any, runner),
+            schedules=[first_schedule, second_schedule],
+            config=config,
+        )
+        is False
+    )


### PR DESCRIPTION
## Background

Sweep execution currently sends one backend request per measurement schedule. On QuEL-3, compatible schedules can be concatenated into fewer backend executions when the user opts in.

## Summary

- Add `measurement.schedule_packing` config loading with opt-in enablement and an optional repeated-timeline duration limit.
- Execute compatible multi-point measurement schedules as packed timelines, then split merged capture results back into per-point `MeasurementResult` objects.
- Document QuEL-3 backend capture result ordering and add tests for config validation, packing, chunking, and result splitting.

## Impact

Schedule packing is disabled by default, so existing behavior is unchanged unless `measurement.schedule_packing.enabled` is set. Incompatible schedules continue through the existing batch execution path, and the optional duration limit chunks packed timelines.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest tests/backend/test_config_loader.py tests/measurement/test_measurement_config.py tests/measurement/test_measurement_execution_service.py` (76 passed)
- `uv run pytest` (1142 passed)

## Open Risks

- Packed timeline placement currently shifts subsequent schedules by pulse duration plus `shot_interval`; capture-only timeline gaps remain a follow-up if needed.