### PR TITLE
fix: resume QuEL-3 batch retry from failed payload

### DIFF
--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -224,12 +224,10 @@ class Quel3ExecutionManager:
             for payload in payloads
         ]
 
-        return await self._run_with_session_request_retry(
-            lambda: self._execute_batch_once(
-                payload_plans=payload_plans,
-                quelware_api=quelware_api,
-                parallel=parallel,
-            )
+        return await self._execute_batch_once(
+            payload_plans=payload_plans,
+            quelware_api=quelware_api,
+            parallel=parallel,
         )
 
     async def execute(
@@ -264,52 +262,12 @@ class Quel3ExecutionManager:
             ) from exc
         payload_plan = self._prepare_payload_execution_plan(payload=payload)
 
-        results = await self._run_with_session_request_retry(
-            lambda: self._execute_batch_once(
-                payload_plans=[payload_plan],
-                quelware_api=quelware_api,
-                parallel=parallel,
-            )
+        results = await self._execute_batch_once(
+            payload_plans=[payload_plan],
+            quelware_api=quelware_api,
+            parallel=parallel,
         )
         return results[0]
-
-    async def _run_with_session_request_retry(
-        self,
-        operation: Callable[[], Awaitable[T]],
-    ) -> T:
-        """Run one session request, recreating the session after failures."""
-        max_attempts = max(1, int(QUEL3_SESSION_REQUEST_MAX_ATTEMPTS))
-        for attempt in range(max_attempts):
-            attempt_number = attempt + 1
-            try:
-                result = await operation()
-            except Exception as exc:
-                session_token = (
-                    exc.session_token
-                    if isinstance(exc, QuelwareSessionError)
-                    else self._active_session_token()
-                )
-                await self._close_session_manager_after_attempt()
-                if attempt_number >= max_attempts:
-                    if isinstance(exc, QuelwareSessionError):
-                        raise
-                    raise QuelwareSessionError(
-                        "QuEL-3 quelware session request failed after retries",
-                        session_token=session_token,
-                        cause=exc,
-                    ) from exc
-                logger.warning(
-                    "QuEL-3 quelware session request failed; session_token=%s; "
-                    "attempt=%d/%d; retrying with a fresh session; cause=%s",
-                    session_token,
-                    attempt_number,
-                    max_attempts,
-                    quelware_exception_summary(exc),
-                )
-            else:
-                await self._close_session_manager_after_attempt()
-                return result
-        raise RuntimeError("unreachable QuEL-3 session request retry state")
 
     async def _close_session_manager_after_attempt(self) -> None:
         """Close session state without masking request success or failure."""
@@ -336,38 +294,98 @@ class Quel3ExecutionManager:
     ) -> list[Quel3BackendExecutionResult]:
         """Execute one payload batch with per-payload quelware sessions."""
         # Batch flow:
-        # 1. Open one quelware client and refresh the instrument resolver once.
+        # 1. Lazily open one quelware client and refresh the instrument resolver.
         # 2. Resolve instrument info for each precomputed payload plan.
         # 3. Reopen a per-payload session for the resolved instrument resource IDs.
         # 4. Execute the resolved payload and collect results.
-        await self._session_manager.open(client_factory=quelware_api.client_factory)
+        # 5. Retry only the failed payload after transient session request failures.
         resolver = quelware_api.instrument_resolver_factory()
-        await resolver.refresh(self._session_manager.client)
 
-        results = []
-        for payload_plan in payload_plans:
-            alias_to_instrument_info = {
-                alias: self._find_instrument_info_by_alias(
+        try:
+            return [
+                await self._execute_payload_plan_with_session_request_retry(
+                    payload_plan=payload_plan,
                     resolver=resolver,
-                    alias=alias,
+                    quelware_api=quelware_api,
+                    parallel=parallel,
                 )
-                for alias in payload_plan.aliases
-            }
-            session_state = await self._open_payload_execution_session(
-                alias_to_instrument_info=alias_to_instrument_info,
-                aliases=payload_plan.aliases,
-                aliases_with_captures=payload_plan.aliases_with_captures,
-                quelware_api=quelware_api,
-            )
-            results.append(
-                await self._execute_resolved_payload(
+                for payload_plan in payload_plans
+            ]
+        finally:
+            await self._close_session_manager_after_attempt()
+
+    async def _execute_payload_plan_with_session_request_retry(
+        self,
+        *,
+        payload_plan: _PayloadExecutionPlan,
+        resolver: InstrumentResolverProtocol,
+        quelware_api: _QuelwareExecutionApi,
+        parallel: bool,
+    ) -> Quel3BackendExecutionResult:
+        """Execute one payload plan, recreating the session after failures."""
+        max_attempts = max(1, int(QUEL3_SESSION_REQUEST_MAX_ATTEMPTS))
+        for attempt in range(max_attempts):
+            attempt_number = attempt + 1
+            try:
+                await self._ensure_batch_client_ready(
+                    resolver=resolver,
+                    quelware_api=quelware_api,
+                )
+                alias_to_instrument_info = {
+                    alias: self._find_instrument_info_by_alias(
+                        resolver=resolver,
+                        alias=alias,
+                    )
+                    for alias in payload_plan.aliases
+                }
+                session_state = await self._open_payload_execution_session(
+                    alias_to_instrument_info=alias_to_instrument_info,
+                    aliases=payload_plan.aliases,
+                    aliases_with_captures=payload_plan.aliases_with_captures,
+                    quelware_api=quelware_api,
+                )
+                return await self._execute_resolved_payload(
                     payload=payload_plan.resolved_payload,
                     session_state=session_state,
                     quelware_api=quelware_api,
                     parallel=parallel,
                 )
-            )
-        return results
+            except Exception as exc:
+                session_token = (
+                    exc.session_token
+                    if isinstance(exc, QuelwareSessionError)
+                    else self._active_session_token()
+                )
+                await self._close_session_manager_after_attempt()
+                if attempt_number >= max_attempts:
+                    if isinstance(exc, QuelwareSessionError):
+                        raise
+                    raise QuelwareSessionError(
+                        "QuEL-3 quelware session request failed after retries",
+                        session_token=session_token,
+                        cause=exc,
+                    ) from exc
+                logger.warning(
+                    "QuEL-3 quelware session request failed; session_token=%s; "
+                    "attempt=%d/%d; retrying with a fresh session; cause=%s",
+                    session_token,
+                    attempt_number,
+                    max_attempts,
+                    quelware_exception_summary(exc),
+                )
+        raise RuntimeError("unreachable QuEL-3 session request retry state")
+
+    async def _ensure_batch_client_ready(
+        self,
+        *,
+        resolver: InstrumentResolverProtocol,
+        quelware_api: _QuelwareExecutionApi,
+    ) -> None:
+        """Open the batch client and refresh resolver state when needed."""
+        if self._session_manager.is_open:
+            return
+        await self._session_manager.open(client_factory=quelware_api.client_factory)
+        await resolver.refresh(self._session_manager.client)
 
     async def _open_payload_execution_session(
         self,

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -1471,10 +1471,10 @@ def test_execute_uses_configured_session_request_retry_limit(
     ]
 
 
-def test_execute_batch_recreates_session_after_transient_request_failure(
+def test_execute_batch_retries_only_failed_payload_after_transient_request_failure(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Given transient quelware request failure, batch execute should retry the batch."""
+    """Given one batch payload fails transiently, retry should resume from that payload."""
     payload = _make_payload()
     manager = Quel3ExecutionManager(
         runtime_config=Quel3RuntimeConfig(),
@@ -1490,14 +1490,34 @@ def test_execute_batch_recreates_session_after_transient_request_failure(
         }
     )
     sessions = [
-        _FlakyTriggerSession(fail_once=True),
-        _FlakyTriggerSession(fail_once=False),
+        _FlakyTriggerSession(fail_once=False, session_id="first-payload-session"),
+        _FlakyTriggerSession(
+            fail_once=True, session_id="failed-second-payload-session"
+        ),
+        _FlakyTriggerSession(
+            fail_once=False, session_id="retry-second-payload-session"
+        ),
     ]
-    clients: list[_FakeClient] = []
+    create_session_index = 0
+
+    class _SequencedSessionClient(_FakeClient):
+        def create_session(
+            self,
+            resource_ids: list[str],
+            ttl_ms: int = 4_000,
+            tentative_ttl_ms: int = 1_000,
+        ) -> _FakeSession:
+            nonlocal create_session_index
+            del resource_ids, ttl_ms, tentative_ttl_ms
+            session = sessions[create_session_index]
+            create_session_index += 1
+            return session
+
+    clients: list[_SequencedSessionClient] = []
 
     def _create_client(endpoint: str, port: int) -> _FakeClient:
         del endpoint, port
-        client = _FakeClient(sessions[len(clients)])
+        client = _SequencedSessionClient(_FakeSession())
         clients.append(client)
         return client
 
@@ -1525,9 +1545,10 @@ def test_execute_batch_recreates_session_after_transient_request_failure(
     assert len(results) == 2
     assert len(clients) == 2
     assert [client.exit_calls for client in clients] == [1, 1]
-    assert [session.exit_calls for session in sessions] == [1, 2]
+    assert [session.exit_calls for session in sessions] == [1, 1, 1]
     assert sessions[0].trigger_calls == [["alias-rq00"]]
-    assert sessions[1].trigger_calls == [["alias-rq00"], ["alias-rq00"]]
+    assert sessions[1].trigger_calls == [["alias-rq00"]]
+    assert sessions[2].trigger_calls == [["alias-rq00"]]
 
 
 def test_execute_batches_capture_mode_with_timeline_directive(


### PR DESCRIPTION
## Background

QuEL-3 batch execution retried the entire batch after a transient session request failure. If a later payload failed, earlier successful payloads were triggered again.

## Summary

- Move QuEL-3 session request retry to the individual payload plan.
- Keep successful batch payload results instead of re-running them after a later payload failure.
- Add a regression test proving retry resumes from the failed payload.

## Compatibility

- Public API signatures and result shapes are unchanged.
- The behavior change is limited to QuEL-3 runtime retry semantics.
- No docs update was needed because the old batch retry behavior was not documented as a user-facing contract.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run ruff check`
- `uv run ruff format --check`
- `uv run pytest tests/backend/test_quel3_backend_controller.py`
- `uv run pytest` (`1142 passed`)
- `uv run pyright src/qubex/backend/quel3/managers/execution_manager.py tests/backend/test_quel3_backend_controller.py`

## Known verification notes

- Full `uv run pyright` is currently blocked by unrelated workspace state: an untracked `packages/quelware-client/` tree with missing generated protobuf modules, and an existing `tests/pulse/test_blank.py` private import usage finding.