### PR TITLE
feat: merge backend-scoped system app config

### DIFF
--- a/src/qubex/system/config_loader.py
+++ b/src/qubex/system/config_loader.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import logging
 import math
 import warnings
+from copy import deepcopy
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
@@ -37,6 +38,8 @@ from qubex.system.wiring import split_box_port_specifier
 from qubex.typing import ConfigurationMode
 
 logger = logging.getLogger(__name__)
+
+SYSTEM_APP_CONFIG_KEYS = frozenset(("experiment", "measurement"))
 
 if TYPE_CHECKING:
     from qubex.system.control_parameter_defaults import ControlParameterDefaults
@@ -404,6 +407,15 @@ class ConfigLoader:
     def backend_runtime_config(self) -> dict[str, Any]:
         """Return backend-specific runtime configuration for the loaded system."""
         self._ensure_loaded()
+        backend_config = self._resolve_backend_config_section()
+        return {
+            key: deepcopy(value)
+            for key, value in backend_config.items()
+            if key not in SYSTEM_APP_CONFIG_KEYS
+        }
+
+    def _resolve_backend_config_section(self) -> dict[str, Any]:
+        """Return selected backend config section as a mapping."""
         value = self._system_dict.get(self._backend_kind)
         if value is None:
             return {}
@@ -417,27 +429,50 @@ class ConfigLoader:
     def experiment_config(self) -> dict[str, Any]:
         """Return experiment configuration for the loaded system."""
         self._ensure_loaded()
-        value = self._system_dict.get("experiment")
-        if value is None:
-            return {}
-        if not isinstance(value, dict):
-            raise TypeError(
-                f"`experiment` section in `{self._system_file}` must be a mapping."
-            )
-        return dict(value)
+        return self._resolve_app_config_section("experiment")
 
     @property
     def measurement_config(self) -> dict[str, Any]:
         """Return measurement configuration for the loaded system."""
         self._ensure_loaded()
-        value = self._system_dict.get("measurement")
+        return self._resolve_app_config_section("measurement")
+
+    def _resolve_app_config_section(self, section: str) -> dict[str, Any]:
+        """Return top-level app config overlaid with backend-scoped config."""
+        value = self._system_dict.get(section)
         if value is None:
-            return {}
+            top_level_config: dict[str, Any] = {}
+        elif isinstance(value, dict):
+            top_level_config = deepcopy(value)
+        else:
+            raise TypeError(
+                f"`{section}` section in `{self._system_file}` must be a mapping."
+            )
+
+        backend_config = self._resolve_backend_config_section()
+        value = backend_config.get(section)
+        if value is None:
+            return top_level_config
         if not isinstance(value, dict):
             raise TypeError(
-                f"`measurement` section in `{self._system_file}` must be a mapping."
+                f"`{self._backend_kind}.{section}` section in `{self._system_file}` must be a mapping."
             )
-        return dict(value)
+        return self._merge_mapping_config(top_level_config, value)
+
+    @staticmethod
+    def _merge_mapping_config(
+        base: dict[str, Any],
+        override: dict[str, Any],
+    ) -> dict[str, Any]:
+        """Return `base` recursively overlaid with `override`."""
+        merged = deepcopy(base)
+        for key, value in override.items():
+            current = merged.get(key)
+            if isinstance(current, dict) and isinstance(value, dict):
+                merged[key] = ConfigLoader._merge_mapping_config(current, value)
+            else:
+                merged[key] = deepcopy(value)
+        return merged
 
     @property
     def measurement_defaults(self) -> MeasurementDefaults:

--- a/tests/backend/test_config_loader.py
+++ b/tests/backend/test_config_loader.py
@@ -1289,6 +1289,49 @@ def test_backend_runtime_config_returns_selected_backend_section(
     assert loader.backend_runtime_config == runtime_config
 
 
+def test_backend_runtime_config_excludes_scoped_app_configs(
+    tmp_path: Path,
+) -> None:
+    """Given backend app configs, when loading, then runtime config omits them."""
+    config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)
+    runtime_config = {
+        "endpoint": "192.0.2.10",
+        "port": 50052,
+        "experiment": {"sweep_execution": "batch"},
+        "measurement": {"schedule_packing": {"enabled": True}},
+    }
+
+    _write_yaml(
+        config_dir / "box.yaml",
+        {
+            "BOX1": {
+                "name": "Box One",
+                "type": "quel3",
+            }
+        },
+    )
+    _write_yaml(
+        config_dir / "system.yaml",
+        {
+            "schema_version": 1,
+            "chip_id": chip_id,
+            "backend": BACKEND_KIND_QUEL3,
+            BACKEND_KIND_QUEL3: runtime_config,
+        },
+    )
+
+    loader = ConfigLoader(
+        system_id=chip_id,
+        config_dir=config_dir,
+        params_dir=params_dir,
+    )
+
+    assert loader.backend_runtime_config == {
+        "endpoint": "192.0.2.10",
+        "port": 50052,
+    }
+
+
 def test_experiment_config_returns_top_level_experiment_section(
     tmp_path: Path,
 ) -> None:
@@ -1317,6 +1360,52 @@ def test_experiment_config_returns_top_level_experiment_section(
     assert loaded_config != loader.experiment_config
     assert loader.experiment_config == experiment_config
     assert loader.backend_runtime_config == {}
+
+
+def test_experiment_config_merges_selected_backend_section(
+    tmp_path: Path,
+) -> None:
+    """Given backend experiment settings, ConfigLoader should merge them last."""
+    config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)
+
+    _write_yaml(
+        config_dir / "box.yaml",
+        {
+            "BOX1": {
+                "name": "Box One",
+                "type": "quel3",
+            }
+        },
+    )
+    _write_yaml(
+        config_dir / "system.yaml",
+        {
+            "schema_version": 1,
+            "chip_id": chip_id,
+            "backend": BACKEND_KIND_QUEL3,
+            "experiment": {
+                "sweep_execution": "sequential",
+                "analysis": {"enabled": True, "mode": "quick"},
+            },
+            BACKEND_KIND_QUEL3: {
+                "experiment": {
+                    "sweep_execution": "batch",
+                    "analysis": {"mode": "full"},
+                }
+            },
+        },
+    )
+
+    loader = ConfigLoader(
+        system_id=chip_id,
+        config_dir=config_dir,
+        params_dir=params_dir,
+    )
+
+    assert loader.experiment_config == {
+        "sweep_execution": "batch",
+        "analysis": {"enabled": True, "mode": "full"},
+    }
 
 
 def test_measurement_config_rejects_non_mapping_config(
@@ -1351,6 +1440,41 @@ def test_measurement_config_rejects_non_mapping_config(
     )
 
     with pytest.raises(TypeError):
+        _ = loader.measurement_config
+
+
+def test_measurement_config_rejects_non_mapping_backend_config(
+    tmp_path: Path,
+) -> None:
+    """Given non-mapping backend measurement config, ConfigLoader should reject it."""
+    config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)
+
+    _write_yaml(
+        config_dir / "box.yaml",
+        {
+            "BOX1": {
+                "name": "Box One",
+                "type": "quel3",
+            }
+        },
+    )
+    _write_yaml(
+        config_dir / "system.yaml",
+        {
+            "schema_version": 1,
+            "chip_id": chip_id,
+            "backend": BACKEND_KIND_QUEL3,
+            BACKEND_KIND_QUEL3: {"measurement": True},
+        },
+    )
+
+    loader = ConfigLoader(
+        system_id=chip_id,
+        config_dir=config_dir,
+        params_dir=params_dir,
+    )
+
+    with pytest.raises(TypeError, match="quel3\\.measurement"):
         _ = loader.measurement_config
 
 
@@ -1395,6 +1519,59 @@ def test_measurement_config_returns_top_level_measurement_section(
 
     assert loaded_config != loader.measurement_config
     assert loader.measurement_config == measurement_config
+
+
+def test_measurement_config_merges_selected_backend_section(
+    tmp_path: Path,
+) -> None:
+    """Given backend measurement settings, ConfigLoader should merge them last."""
+    config_dir, params_dir, chip_id = _make_minimal_files(tmp_path)
+
+    _write_yaml(
+        config_dir / "box.yaml",
+        {
+            "BOX1": {
+                "name": "Box One",
+                "type": "quel3",
+            }
+        },
+    )
+    _write_yaml(
+        config_dir / "system.yaml",
+        {
+            "schema_version": 1,
+            "chip_id": chip_id,
+            "backend": BACKEND_KIND_QUEL3,
+            "measurement": {
+                "schedule_packing": {
+                    "enabled": True,
+                    "max_repeated_timeline_duration_ns": 20_000_000_000,
+                },
+                "export": {"enabled": True},
+            },
+            BACKEND_KIND_QUEL3: {
+                "measurement": {
+                    "schedule_packing": {
+                        "enabled": False,
+                    }
+                }
+            },
+        },
+    )
+
+    loader = ConfigLoader(
+        system_id=chip_id,
+        config_dir=config_dir,
+        params_dir=params_dir,
+    )
+
+    assert loader.measurement_config == {
+        "schedule_packing": {
+            "enabled": False,
+            "max_repeated_timeline_duration_ns": 20_000_000_000,
+        },
+        "export": {"enabled": True},
+    }
 
 
 def test_load_configures_quel3_readout_without_lo(tmp_path: Path) -> None:


### PR DESCRIPTION
## Summary

- Merge top-level `experiment` and `measurement` system settings with the selected backend-scoped settings.
- Let backend-scoped `experiment` and `measurement` values override top-level values recursively.
- Exclude backend-scoped app settings from backend runtime config.
- Add ConfigLoader tests for merge behavior, invalid backend-scoped settings, and runtime config filtering.

## Impact

`system.yaml` can now keep backend-specific app settings under the active backend section, for example `quel3.experiment` and `quel3.measurement`, while still allowing shared top-level defaults.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright src/qubex/system/config_loader.py tests/backend/test_config_loader.py`
- `uv run pytest tests/backend/test_config_loader.py`
- `uv run pytest` (`1146 passed`)

Full `uv run pyright` currently reports import resolution errors under the untracked `packages/quelware-client/` tree, which is outside this PR scope.

## Notes

Documentation examples for `system.yaml` still describe only backend runtime keys. They should be updated separately if this config layout is ready to document.