### PR TITLE
fix: use JSON-safe QuEL-1 box config in measurement results

### DIFF
--- a/src/qubex/backend/quel1/managers/connection_manager.py
+++ b/src/qubex/backend/quel1/managers/connection_manager.py
@@ -109,6 +109,35 @@ class Quel1ConnectionManager:
             return {}
         return self.boxpool._box_config_cache
 
+    @staticmethod
+    def _convert_to_string_key_dict(d: Mapping[Any, Any]) -> dict[str, Any]:
+        new_dict: dict[str, Any] = {}
+        for k, v in d.items():
+            new_dict[str(k)] = Quel1ConnectionManager._convert_to_json_safe_value(v)
+        return new_dict
+
+    @staticmethod
+    def _convert_to_json_safe_value(value: Any) -> Any:
+        if isinstance(value, Mapping):
+            return Quel1ConnectionManager._convert_to_string_key_dict(value)
+        if isinstance(value, list):
+            return [
+                Quel1ConnectionManager._convert_to_json_safe_value(item)
+                for item in value
+            ]
+        if isinstance(value, tuple):
+            return tuple(
+                Quel1ConnectionManager._convert_to_json_safe_value(item)
+                for item in value
+            )
+        return value
+
+    def get_json_safe_box_config_cache(self) -> dict[str, dict[str, Any]]:
+        """Return connected box-config cache with stringified mapping keys."""
+        if not self.is_connected:
+            return {}
+        return self._convert_to_string_key_dict(self.get_box_config_cache())
+
     def set_connected_state(
         self,
         *,

--- a/src/qubex/backend/quel1/quel1_backend_controller.py
+++ b/src/qubex/backend/quel1/quel1_backend_controller.py
@@ -157,6 +157,10 @@ class Quel1BackendController(BackendController):
         """Return connected box configuration cache."""
         return self._connection_manager.get_box_config_cache()
 
+    def json_safe_box_config(self) -> dict[str, Any]:
+        """Return JSON-safe box configuration for measurement results."""
+        return self._connection_manager.get_json_safe_box_config_cache()
+
     @property
     def boxpool(self) -> BoxPool:
         """Return connected box pool."""

--- a/src/qubex/measurement/measurement_schedule_runner.py
+++ b/src/qubex/measurement/measurement_schedule_runner.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Mapping
 from typing import Any, cast
 
 from qubex.backend import (
@@ -90,15 +90,16 @@ class MeasurementScheduleRunner:
         if isinstance(backend_result, MeasurementResult):
             return backend_result
 
-        box_config = getattr(
+        json_safe_box_config = getattr(
             self._backend_controller,
             "json_safe_box_config",
             None,
         )
-        if callable(box_config):
-            device_config = cast(dict[str, Any], box_config())
+        if callable(json_safe_box_config):
+            device_config = cast(dict[str, Any], json_safe_box_config())
         else:
-            device_config = {}
+            box_config = getattr(self._backend_controller, "box_config", None)
+            device_config = dict(box_config) if isinstance(box_config, Mapping) else {}
 
         capture_decimation_factor = getattr(
             self._backend_controller,

--- a/src/qubex/measurement/measurement_schedule_runner.py
+++ b/src/qubex/measurement/measurement_schedule_runner.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Awaitable, Callable, Mapping
+from collections.abc import Awaitable, Callable
 from typing import Any, cast
 
 from qubex.backend import (
@@ -90,9 +90,13 @@ class MeasurementScheduleRunner:
         if isinstance(backend_result, MeasurementResult):
             return backend_result
 
-        box_config = getattr(self._backend_controller, "box_config", None)
-        if isinstance(box_config, Mapping):
-            device_config: dict[str, Any] = dict(box_config)
+        box_config = getattr(
+            self._backend_controller,
+            "json_safe_box_config",
+            None,
+        )
+        if callable(box_config):
+            device_config = cast(dict[str, Any], box_config())
         else:
             device_config = {}
 

--- a/tests/backend/test_quel1_backend_controller_cache_sync.py
+++ b/tests/backend/test_quel1_backend_controller_cache_sync.py
@@ -5,6 +5,7 @@
 from __future__ import annotations
 
 import datetime
+import json
 from copy import deepcopy
 from types import SimpleNamespace
 from typing import Any, cast
@@ -94,3 +95,30 @@ def test_cache_update_keeps_input_immutable() -> None:
 
     assert controller.boxpool._box_config_cache == original
     assert system.config_cache == original
+
+
+def test_json_safe_box_config_converts_cached_mapping_keys() -> None:
+    """Given tuple-keyed cached config, when JSON-safe config is requested, then keys are stringified."""
+    controller = _make_controller()
+    system = SimpleNamespace(config_cache={}, config_fetched_at=None)
+    controller._connection_manager.set_quel1system(cast(Any, system))
+
+    controller.boxpool._box_config_cache = {
+        "A": {
+            "ports": {
+                (1, 1): {"channels": {0: {"fnco_freq": 100}}},
+            },
+            "metadata": [{"loopbacks": {(2, 1): "enabled"}}],
+        }
+    }
+
+    config = controller.json_safe_box_config()
+
+    assert config == {
+        "A": {
+            "ports": {"(1, 1)": {"channels": {"0": {"fnco_freq": 100}}}},
+            "metadata": [{"loopbacks": {"(2, 1)": "enabled"}}],
+        }
+    }
+    assert json.dumps(config)
+    assert (1, 1) in controller.boxpool._box_config_cache["A"]["ports"]

--- a/tests/measurement/test_measurement_schedule_runner.py
+++ b/tests/measurement/test_measurement_schedule_runner.py
@@ -126,6 +126,10 @@ def test_execute_async_validates_builds_calls_backend_and_creates_result() -> No
         sampling_period_ns: ClassVar[float] = 2.0
         CAPTURE_DECIMATION_FACTOR: ClassVar[int] = 4
 
+        def json_safe_box_config(self) -> dict[str, object]:
+            """Return JSON-safe device config."""
+            return dict(self.box_config)
+
         async def execute_async(
             self, *, request: BackendExecutionRequest
         ) -> Quel1BackendExecutionResult:
@@ -150,6 +154,74 @@ def test_execute_async_validates_builds_calls_backend_and_creates_result() -> No
     assert result_kwargs["measurement_config"] is config
     assert result_kwargs["device_config"] == {"shots": 2}
     assert result_kwargs["sampling_period"] == 8.0
+    assert result is expected
+
+
+def test_execute_async_uses_json_safe_box_config() -> None:
+    """Given backend JSON-safe box config, when result is built, then that config is used."""
+    called: dict[str, object] = {}
+    request = BackendExecutionRequest(payload=object())
+    backend_result = Quel1BackendExecutionResult(status={}, data={}, config={})
+    expected = MeasurementResultConverter.from_multiple(
+        _make_multiple_result(),
+        measurement_config=_make_config(),
+    )
+
+    class _Adapter:
+        def validate_schedule(self, schedule: MeasurementSchedule) -> None:
+            _ = schedule
+
+        def build_execution_request(
+            self,
+            *,
+            schedule: MeasurementSchedule,
+            config: MeasurementConfig,
+        ) -> BackendExecutionRequest:
+            _ = (schedule, config)
+            return request
+
+        def build_measurement_result(
+            self,
+            *,
+            backend_result: object,
+            measurement_config: MeasurementConfig,
+            device_config: dict[str, object],
+            sampling_period: float,
+        ) -> MeasurementResult:
+            _ = (backend_result, measurement_config, sampling_period)
+            called["device_config"] = device_config
+            return expected
+
+    class _BackendController:
+        box_config: ClassVar[dict[str, object]] = {
+            "A": {"ports": {(1, 1): {"cnco_freq": 100}}}
+        }
+        sampling_period_ns: ClassVar[float] = 2.0
+        CAPTURE_DECIMATION_FACTOR: ClassVar[int] = 4
+
+        def json_safe_box_config(self) -> dict[str, object]:
+            """Return JSON-safe box config for measurement results."""
+            return {"A": {"ports": {"(1, 1)": {"cnco_freq": 100}}}}
+
+        async def execute_async(
+            self, *, request: BackendExecutionRequest
+        ) -> Quel1BackendExecutionResult:
+            _ = request
+            return backend_result
+
+    runner = MeasurementScheduleRunner(
+        measurement_backend_adapter=cast(Any, _Adapter()),
+        backend_controller=cast(Any, _BackendController()),
+    )
+
+    result = asyncio.run(
+        runner.execute_async(
+            schedule=_make_schedule(),
+            config=_make_config(),
+        )
+    )
+
+    assert called["device_config"] == {"A": {"ports": {"(1, 1)": {"cnco_freq": 100}}}}
     assert result is expected
 
 
@@ -519,6 +591,10 @@ def test_execute_async_prefers_adapter_measurement_result_builder_when_available
         box_config: ClassVar[dict[str, str]] = {"kind": "quel3"}
         sampling_period_ns: ClassVar[float] = 0.4
         CAPTURE_DECIMATION_FACTOR: ClassVar[int] = 4
+
+        def json_safe_box_config(self) -> dict[str, object]:
+            """Return JSON-safe device config."""
+            return dict(self.box_config)
 
         async def execute_async(
             self, *, request: BackendExecutionRequest

--- a/tests/measurement/test_measurement_schedule_runner.py
+++ b/tests/measurement/test_measurement_schedule_runner.py
@@ -126,10 +126,6 @@ def test_execute_async_validates_builds_calls_backend_and_creates_result() -> No
         sampling_period_ns: ClassVar[float] = 2.0
         CAPTURE_DECIMATION_FACTOR: ClassVar[int] = 4
 
-        def json_safe_box_config(self) -> dict[str, object]:
-            """Return JSON-safe device config."""
-            return dict(self.box_config)
-
         async def execute_async(
             self, *, request: BackendExecutionRequest
         ) -> Quel1BackendExecutionResult:


### PR DESCRIPTION
## Summary

- Build QuEL-1 measurement `device_config` from the cached box config with mapping keys converted to strings.
- Keep the existing `_box_config_cache` as the single source of truth instead of adding a second JSON-safe cache.
- Route `MeasurementScheduleRunner` through `json_safe_box_config()` so `MeasurementResult` can be saved as JSON/NetCDF when QuEL-1 port keys are tuples.

Fixes #318.

## Compatibility

This keeps the raw `box_config` cache unchanged and only converts keys for the measurement result snapshot. No `boxes()` API or extra BoxPool cache is added.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest tests/backend/test_quel1_backend_controller_cache_sync.py tests/backend/test_qubecalib_compat_contract.py`
- `uv run pytest` (`1070 passed`)
