### PR TITLE
feat: add configure preview workflow

### DIFF
--- a/docs/release-notes/v1-5-0.ja.md
+++ b/docs/release-notes/v1-5-0.ja.md
@@ -27,6 +27,10 @@ QuEL-3 の初期対応を追加し、主要な実行経路から固定 `2 ns`
   `stop_continuous_wave()`、`stop_all_continuous_waves()` により、
   `Measurement` / `Experiment` の facade API を追加せずに、hardware-level の
   検証や aliasing 実験用の CW 経路を使えます。
+- **QuEL-1 system で `Experiment.configure()` の preview ができるようになりました。**
+  `Experiment.preview_configure()` は構造化された `ConfigurePreview` を返し、
+  `Experiment.configure(dry_run=True)` は hardware settings を push せずに
+  summary を表示します。QuEL-3 の configure preview は未対応です。
 - **測定 API に async-first / sweep-first の経路を追加しました。**
   `Measurement` と `Experiment` で `run_measurement()`、
   `run_sweep_measurement()`、`run_ndsweep_measurement()` を公開し、

--- a/docs/release-notes/v1-5-0.md
+++ b/docs/release-notes/v1-5-0.md
@@ -29,6 +29,10 @@ configuration files, backend imports, or contrib-heavy notebooks.
   `stop_continuous_wave()`, and `stop_all_continuous_waves()` provide a
   hardware-level CW path for validation and aliasing experiments without adding
   `Measurement` or `Experiment` facade APIs.
+- **`Experiment.configure()` can be previewed for QuEL-1 systems.**
+  `Experiment.preview_configure()` returns a structured `ConfigurePreview`, and
+  `Experiment.configure(dry_run=True)` prints a summary without pushing
+  hardware settings. Configure previews remain unsupported for QuEL-3.
 - **Measurement APIs now support async-first and sweep-first workflows.**
   `Measurement` and `Experiment` expose `run_measurement()`,
   `run_sweep_measurement()`, and `run_ndsweep_measurement()`, and the

--- a/docs/user-guide/getting-started/quickstart.ja.md
+++ b/docs/user-guide/getting-started/quickstart.ja.md
@@ -46,8 +46,21 @@ exp.connect()
 exp.configure()
 ```
 
+QuEL-1 で反映予定の差分を確認したい場合は、push する前に preview できます。
+preview は比較のために現在の hardware settings を取得しますが、更新は push しません。
+QuEL-3 の configure preview は未実装です。
+
+```python
+preview = exp.preview_configure()
+preview.print_summary()
+preview.print_full()
+
+exp.configure(dry_run=True)
+```
+
 > [!CAUTION]
-> この操作は装置の状態を変更します。共有システムでは、同じ装置を利用している他ユーザーに影響する可能性があります。
+> `dry_run=True` なしで `configure()` を呼ぶと装置の状態を変更します。
+> 共有システムでは、同じ装置を利用している他ユーザーに影響する可能性があります。
 
 ## 4. `measure` で基本測定を実行する
 

--- a/docs/user-guide/getting-started/quickstart.md
+++ b/docs/user-guide/getting-started/quickstart.md
@@ -52,9 +52,22 @@ parameter settings to the instruments.
 exp.configure()
 ```
 
+Preview the planned QuEL-1 changes before pushing when you need to check what
+would change. The preview fetches current hardware settings for comparison, but
+it does not push updates. Configure previews are not implemented for QuEL-3.
+
+```python
+preview = exp.preview_configure()
+preview.print_summary()
+preview.print_full()
+
+exp.configure(dry_run=True)
+```
+
 > [!CAUTION]
-> This operation changes the state of the instruments. On shared systems, it
-> can affect other users who are using the same instruments.
+> Calling `configure()` without `dry_run=True` changes the state of the
+> instruments. On shared systems, it can affect other users who are using the
+> same instruments.
 
 ## 4. Run a basic measurement with `measure`
 

--- a/src/qubex/backend/quel1/managers/connection_manager.py
+++ b/src/qubex/backend/quel1/managers/connection_manager.py
@@ -232,7 +232,7 @@ class Quel1ConnectionManager:
             parallel = _DEFAULT_PARALLEL_MODE
         resolved_box_names = self._resolve_box_names(box_names)
         if self.is_connected:
-            connected_box_names = self._connected_box_names()
+            connected_box_names = self.connected_box_names()
             requested_box_names = set(resolved_box_names)
             if requested_box_names.issubset(connected_box_names):
                 logger.info("Already connected. Skipping backend reconnect.")
@@ -262,7 +262,7 @@ class Quel1ConnectionManager:
         if not self.is_connected:
             return False
         resolved_box_names = self._resolve_box_names(box_names)
-        connected_box_names = self._connected_box_names()
+        connected_box_names = self.connected_box_names()
         requested_box_names = set(resolved_box_names)
         return not requested_box_names.issubset(connected_box_names)
 
@@ -494,7 +494,7 @@ class Quel1ConnectionManager:
             return [box_names]
         return list(box_names)
 
-    def _connected_box_names(self) -> set[str]:
+    def connected_box_names(self) -> set[str]:
         """Return currently connected box names from the active boxpool."""
         if not self.is_connected:
             return set()

--- a/src/qubex/backend/quel1/quel1_backend_controller.py
+++ b/src/qubex/backend/quel1/quel1_backend_controller.py
@@ -166,6 +166,10 @@ class Quel1BackendController(BackendController):
         """Return connected box pool."""
         return self._connection_manager.boxpool
 
+    def connected_box_names(self) -> set[str]:
+        """Return box names present in the connected box pool."""
+        return self._connection_manager.connected_box_names()
+
     @property
     def quel1system(self) -> Quel1System:
         """Return connected Quel1 system."""

--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -46,6 +46,7 @@ from qubex.system import (
     Box,
     Chip,
     ConfigLoader,
+    ConfigurePreview,
     ControlParameters,
     ControlSystem,
     ExperimentSystem,
@@ -813,6 +814,7 @@ class Experiment:
         exclude: str | list[str] | None = None,
         mode: ConfigurationMode | None = None,
         confirm: bool = True,
+        dry_run: bool = False,
     ) -> None:
         """Configure hardware targets and push settings to devices."""
         return self.session_service.configure(
@@ -820,6 +822,27 @@ class Experiment:
             exclude=exclude,
             mode=mode,
             confirm=confirm,
+            dry_run=dry_run,
+        )
+
+    def preview_configure(
+        self,
+        box_ids: str | list[str] | None = None,
+        exclude: str | list[str] | None = None,
+        mode: ConfigurationMode | None = None,
+    ) -> ConfigurePreview:
+        """
+        Preview QuEL-1 hardware settings that `configure()` would change.
+
+        Raises
+        ------
+        NotImplementedError
+            If the active backend is QuEL-3.
+        """
+        return self.session_service.preview_configure(
+            box_ids=box_ids,
+            exclude=exclude,
+            mode=mode,
         )
 
     def reload(self) -> None:

--- a/src/qubex/experiment/services/session_service.py
+++ b/src/qubex/experiment/services/session_service.py
@@ -9,6 +9,7 @@ from collections.abc import Collection
 from qubex.experiment.experiment_context import ExperimentContext
 from qubex.measurement import Measurement
 from qubex.pulse import set_sampling_period
+from qubex.system import ConfigurePreview
 from qubex.typing import ConfigurationMode
 
 logger = logging.getLogger(__name__)
@@ -154,6 +155,7 @@ class SessionService:
         exclude: str | list[str] | None = None,
         mode: ConfigurationMode | None = None,
         confirm: bool = True,
+        dry_run: bool = False,
     ) -> None:
         """Reload configuration through SystemManager and push to boxes."""
         if isinstance(box_ids, str):
@@ -162,6 +164,15 @@ class SessionService:
             exclude = [exclude]
         if mode is None:
             mode = self.ctx.configuration_mode
+
+        if dry_run:
+            preview = self.preview_configure(
+                box_ids=box_ids,
+                exclude=exclude,
+                mode=mode,
+            )
+            preview.print_summary()
+            return
 
         system_manager = self.ctx.system_manager
         system_manager.load(
@@ -179,6 +190,35 @@ class SessionService:
             confirm=confirm,
         )
         self._sync_pulse_sampling_period()
+
+    def preview_configure(
+        self,
+        *,
+        box_ids: str | list[str] | None = None,
+        exclude: str | list[str] | None = None,
+        mode: ConfigurationMode | None = None,
+    ) -> ConfigurePreview:
+        """Preview configuration changes without pushing them to hardware."""
+        if isinstance(box_ids, str):
+            box_ids = [box_ids]
+        if box_ids == []:
+            box_ids = None
+        if isinstance(exclude, str):
+            exclude = [exclude]
+        if mode is None:
+            mode = self.ctx.configuration_mode
+
+        return self.ctx.system_manager.preview_configure(
+            chip_id=self.ctx.chip_id,
+            system_id=self.ctx.config_loader.system_id,
+            config_dir=self.ctx.config_path,
+            params_dir=self.ctx.params_path,
+            targets_to_exclude=exclude,
+            configuration_mode=mode,
+            box_ids=box_ids,
+            target_labels=list(self.ctx.targets),
+            qubit_labels=self.ctx.qubit_labels,
+        )
 
     def reset_awg_and_capunits(
         self,

--- a/src/qubex/system/__init__.py
+++ b/src/qubex/system/__init__.py
@@ -1,6 +1,7 @@
 """System orchestration components across backends."""
 
 from .config_loader import ConfigLoader
+from .configure_preview import ConfigurePreview, ConfigureStateChange
 from .control_parameter_defaults import ControlParameterDefaults
 from .control_parameters import ControlParameters
 from .control_system import (
@@ -37,6 +38,8 @@ __all__ = [
     "Channel",
     "Chip",
     "ConfigLoader",
+    "ConfigurePreview",
+    "ConfigureStateChange",
     "ControlParameterDefaults",
     "ControlParameters",
     "ControlSystem",

--- a/src/qubex/system/configure_preview.py
+++ b/src/qubex/system/configure_preview.py
@@ -1,0 +1,164 @@
+"""Preview models for `configure()`."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Protocol
+
+from rich.console import Console
+from rich.table import Table
+
+from qubex.backend.backend_controller import BackendKind
+from qubex.typing import ConfigurationMode
+
+if TYPE_CHECKING:
+    from qubex.system.experiment_system import ExperimentSystem
+
+
+@dataclass(frozen=True)
+class ConfigureStateChange:
+    """One field comparison between current and post-`configure()` device state."""
+
+    box_id: str
+    component: str
+    field: str
+    before: object
+    after: object
+    unit: str | None = None
+    is_frequency: bool = False
+
+    @property
+    def has_change(self) -> bool:
+        """Return whether the compared field would change."""
+        return self.before != self.after
+
+
+@dataclass(frozen=True)
+class ConfigurePreview:
+    """Structured preview of post-`configure()` device state changes."""
+
+    backend_kind: BackendKind
+    box_ids: tuple[str, ...]
+    mode: ConfigurationMode | None
+    entries: tuple[ConfigureStateChange, ...] = ()
+    missing_box_ids: tuple[str, ...] = ()
+
+    @property
+    def changes(self) -> tuple[ConfigureStateChange, ...]:
+        """Return field-level comparisons that would change."""
+        return tuple(entry for entry in self.entries if entry.has_change)
+
+    @property
+    def has_changes(self) -> bool:
+        """Return whether `configure()` would change any tracked fields."""
+        return len(self.changes) > 0
+
+    @property
+    def has_frequency_changes(self) -> bool:
+        """Return whether `configure()` would change frequency-related fields."""
+        return any(change.is_frequency for change in self.changes)
+
+    @property
+    def is_complete(self) -> bool:
+        """Return whether all requested boxes were fetched for comparison."""
+        return len(self.missing_box_ids) == 0
+
+    def print_summary(self, console: Console | None = None) -> None:
+        """Print field-level changes that `configure()` would apply."""
+        if console is None:
+            console = Console()
+
+        table = Table(
+            show_header=True,
+            header_style="bold",
+            title="Configure Preview Changes",
+        )
+        table.add_column("BOX", justify="left")
+        table.add_column("COMPONENT", justify="left")
+        table.add_column("FIELD", justify="left")
+        table.add_column("BEFORE", justify="right")
+        table.add_column("AFTER", justify="right")
+        table.add_column("UNIT", justify="left")
+        table.add_column("FREQ", justify="center")
+
+        self._add_rows(table, self.changes, include_change=False)
+        console.print(table)
+
+    def print_full(self, console: Console | None = None) -> None:
+        """Print all previewed field-level comparisons."""
+        if console is None:
+            console = Console()
+
+        table = Table(
+            show_header=True,
+            header_style="bold",
+            title="Configure Preview Full",
+        )
+        table.add_column("BOX", justify="left")
+        table.add_column("COMPONENT", justify="left")
+        table.add_column("FIELD", justify="left")
+        table.add_column("BEFORE", justify="right")
+        table.add_column("AFTER", justify="right")
+        table.add_column("UNIT", justify="left")
+        table.add_column("FREQ", justify="center")
+        table.add_column("CHANGE", justify="center")
+
+        self._add_rows(table, self.entries, include_change=True)
+        console.print(table)
+
+    def _add_rows(
+        self,
+        table: Table,
+        entries: Sequence[ConfigureStateChange],
+        *,
+        include_change: bool,
+    ) -> None:
+        """Add preview rows to `table`."""
+        for entry in entries:
+            row = [
+                entry.box_id,
+                entry.component,
+                entry.field,
+                _format_value(entry.before),
+                _format_value(entry.after),
+                entry.unit or "",
+                "yes" if entry.is_frequency else "",
+            ]
+            if include_change:
+                row.append("yes" if entry.has_change else "no")
+            table.add_row(*row)
+        for box_id in self.missing_box_ids:
+            row = [box_id, "box", "fetch", "failed", "", "", ""]
+            if include_change:
+                row.append("")
+            table.add_row(*row)
+        if not entries and not self.missing_box_ids:
+            row = ["-", "-", "-", "no changes", "", "", ""]
+            if include_change:
+                row.append("")
+            table.add_row(*row)
+
+
+class ConfigurePreviewSynchronizer(Protocol):
+    """Synchronizer capability for backends that support configure previews."""
+
+    def preview_configure(
+        self,
+        *,
+        experiment_system: ExperimentSystem,
+        box_ids: Sequence[str],
+        mode: ConfigurationMode | None,
+        parallel: bool | None = None,
+        target_labels: Sequence[str] | None = None,
+    ) -> ConfigurePreview:
+        """Preview backend-specific hardware changes for `configure()`."""
+        ...
+
+
+def _format_value(value: object) -> str:
+    if value is None:
+        return ""
+    if isinstance(value, int):
+        return f"{value:_}"
+    return str(value)

--- a/src/qubex/system/quel1/quel1_configure_preview.py
+++ b/src/qubex/system/quel1/quel1_configure_preview.py
@@ -1,0 +1,579 @@
+# ruff: noqa: SLF001
+
+"""QuEL-1 configure preview backed by temporary `Quel1Box` mocks."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, MutableMapping, Sequence
+from copy import deepcopy
+from dataclasses import dataclass
+from threading import RLock
+from types import TracebackType
+from typing import TYPE_CHECKING, Any, ClassVar, Final, TypeAlias, cast
+
+from qubex.backend.backend_controller import BACKEND_KIND_QUEL1
+from qubex.system.configure_preview import ConfigurePreview, ConfigureStateChange
+from qubex.system.control_system import BoxType
+from qubex.typing import ConfigurationMode
+
+if TYPE_CHECKING:
+    from qubex.backend.quel1.quel1_backend_controller import Quel1BackendController
+
+_PortNumber: TypeAlias = int | tuple[int, int]
+_Snapshot: TypeAlias = Mapping[object, object]
+_MutableSnapshot: TypeAlias = MutableMapping[object, object]
+
+_GENERATOR_FIELDS: Final = (
+    "lo_freq",
+    "cnco_freq",
+    "vatt",
+    "sideband",
+    "fullscale_current",
+    "rfswitch",
+)
+_CAPTURE_FIELDS: Final = ("lo_freq", "cnco_freq", "rfswitch")
+_FREQUENCY_FIELDS: Final = frozenset({"lo_freq", "cnco_freq", "fnco_freq"})
+
+# These groups mirror quel_ic_config's port-to-line, LO, and RF-switch maps.
+_SHARED_RESOURCE_PORT_GROUPS: Final[
+    dict[str, dict[str, tuple[tuple[int, ...], ...]]]
+] = {
+    BoxType.QUEL1SE_A.value: {
+        "lo_freq": ((0, 1), (3, 5), (7, 8), (10, 12)),
+        "rfswitch": ((0, 1), (7, 8)),
+    },
+    BoxType.QUEL1SE_B.value: {
+        "lo_freq": ((3, 5), (10, 12)),
+    },
+    BoxType.QUEL1SE_R8.value: {
+        "lo_freq": ((0, 1), (4, 10)),
+        "rfswitch": ((0, 1),),
+    },
+    BoxType.QUEL1_A.value: {
+        "lo_freq": ((0, 1), (3, 5), (7, 8), (10, 12)),
+        "rfswitch": ((0, 1), (7, 8)),
+    },
+    BoxType.QUEL1_B.value: {
+        "lo_freq": ((2, 5), (9, 12)),
+    },
+    BoxType.QUBE_RIKEN_A.value: {
+        "lo_freq": ((0, 1), (2, 4), (12, 13), (9, 11)),
+        "rfswitch": ((0, 1), (12, 13)),
+    },
+    BoxType.QUBE_RIKEN_B.value: {
+        "lo_freq": ((2, 4), (9, 11)),
+    },
+    BoxType.QUBE_OU_A.value: {
+        "lo_freq": ((0, 1), (12, 13)),
+    },
+}
+
+
+@dataclass(frozen=True)
+class _WaveSubsystemMock:
+    """Expose the address needed by driver-side box registration."""
+
+    ipaddr_sss: str
+
+
+class Quel1BoxMock:
+    """Emulate the configuration subset of `Quel1Box` on a copied dump."""
+
+    _instances_by_wss_ip: ClassVar[dict[str, Quel1BoxMock]] = {}
+
+    def __init__(
+        self,
+        *,
+        box_name: str,
+        boxtype: str,
+        ipaddr_sss: str,
+        snapshot: Mapping[object, object],
+    ) -> None:
+        self.box_name = box_name
+        self.boxtype = boxtype
+        self.wss = _WaveSubsystemMock(ipaddr_sss=ipaddr_sss)
+        self._initial = deepcopy(snapshot)
+        self._configured = deepcopy(snapshot)
+
+    @classmethod
+    def create(cls, *, ipaddr_wss: object, **_: object) -> Quel1BoxMock:
+        """Return the mock registered for one WSS address."""
+        return cls._instances_by_wss_ip[str(ipaddr_wss)]
+
+    @property
+    def is_complete(self) -> bool:
+        """Return whether the initial dump contains a ports mapping."""
+        return isinstance(self._initial.get("ports"), Mapping)
+
+    def reconnect(self, *_: Any, **__: Any) -> dict[int, bool]:
+        """Emulate reconnect without touching hardware."""
+        return {}
+
+    def relinkup(self, *_: Any, **__: Any) -> dict[int, bool]:
+        """Emulate relinkup without touching hardware."""
+        return {}
+
+    def link_status(self) -> dict[int, bool]:
+        """Return an empty successful-enough link-status payload."""
+        return {}
+
+    def get_input_ports(self) -> list[Any]:
+        """Return ports marked as inputs in the copied dump."""
+        return self._ports_with_direction("in")
+
+    def get_output_ports(self) -> list[Any]:
+        """Return ports marked as outputs in the copied dump."""
+        return self._ports_with_direction("out")
+
+    def dump_box(self) -> dict[str, Any]:
+        """Return the current simulated box state."""
+        return cast("dict[str, Any]", deepcopy(dict(self._configured)))
+
+    def dump_port(self, port: _PortNumber) -> dict[str, Any]:
+        """Return one simulated port state."""
+        port_config = _as_mapping(_mapping_item(self._ports(), port))
+        return cast("dict[str, Any]", deepcopy(dict(port_config)))
+
+    def config_port(
+        self,
+        *,
+        port: _PortNumber,
+        lo_freq: float | None = None,
+        cnco_freq: float | None = None,
+        vatt: int | None = None,
+        sideband: str | None = None,
+        fullscale_current: int | None = None,
+        rfswitch: str | None = None,
+    ) -> None:
+        """Apply a port configuration to the simulated state."""
+        values = (
+            ("lo_freq", lo_freq),
+            ("cnco_freq", cnco_freq),
+            ("vatt", vatt),
+            ("sideband", sideband),
+            ("fullscale_current", fullscale_current),
+            ("rfswitch", rfswitch),
+        )
+        for field, value in values:
+            if value is not None:
+                self._write_port_resource(
+                    port=port,
+                    field=field,
+                    value=_normalize_value(value),
+                )
+
+    def config_channel(
+        self,
+        *,
+        port: _PortNumber,
+        channel: int,
+        fnco_freq: float | None = None,
+        awg_param: Any | None = None,
+    ) -> None:
+        """Apply a generator-channel configuration to simulated state."""
+        del awg_param
+        self._write_fnco(
+            port=port,
+            collection="channels",
+            child=channel,
+            fnco_freq=fnco_freq,
+        )
+
+    def config_runit(
+        self,
+        *,
+        port: _PortNumber,
+        runit: int,
+        fnco_freq: float | None = None,
+    ) -> None:
+        """Apply a capture-unit configuration to simulated state."""
+        self._write_fnco(
+            port=port,
+            collection="runits",
+            child=runit,
+            fnco_freq=fnco_freq,
+        )
+
+    def preview_entries(self) -> list[ConfigureStateChange]:
+        """Return comparisons between the initial and simulated box states."""
+        initial_ports = _as_mapping(self._initial.get("ports"))
+        configured_ports = _as_mapping(self._configured.get("ports"))
+        entries: list[ConfigureStateChange] = []
+        for port_number, configured_value in configured_ports.items():
+            configured_port = _as_mapping(configured_value)
+            initial_port = _as_mapping(_mapping_item(initial_ports, port_number))
+            direction = configured_port.get("direction")
+            if direction == "out":
+                fields = _GENERATOR_FIELDS
+                child_collection = "channels"
+                child_label = "channel"
+            elif direction == "in":
+                fields = _CAPTURE_FIELDS
+                child_collection = "runits"
+                child_label = "runit"
+            else:
+                continue
+            entries.extend(
+                _compare_fields(
+                    box_id=self.box_name,
+                    component=f"port {port_number}",
+                    fields=fields,
+                    initial=initial_port,
+                    configured=configured_port,
+                )
+            )
+            initial_children = _as_mapping(initial_port.get(child_collection))
+            configured_children = _as_mapping(configured_port.get(child_collection))
+            for child_number, configured_child in configured_children.items():
+                entries.extend(
+                    _compare_fields(
+                        box_id=self.box_name,
+                        component=(f"port {port_number} {child_label} {child_number}"),
+                        fields=("fnco_freq",),
+                        initial=_as_mapping(
+                            _mapping_item(initial_children, child_number)
+                        ),
+                        configured=_as_mapping(configured_child),
+                    )
+                )
+        return entries
+
+    def _ports(self) -> _MutableSnapshot:
+        """Return the mutable simulated ports mapping."""
+        ports = self._configured.get("ports")
+        return ports if isinstance(ports, MutableMapping) else {}
+
+    def _ports_with_direction(self, direction: str) -> list[Any]:
+        """Return normalized port keys having one direction."""
+        return [
+            _normalize_port_number(port_number)
+            for port_number, config in self._ports().items()
+            if _as_mapping(config).get("direction") == direction
+        ]
+
+    def _write_port_resource(
+        self,
+        *,
+        port: _PortNumber,
+        field: str,
+        value: object,
+    ) -> None:
+        """Apply one value to every port sharing its physical resource."""
+        # Shared LOs are approximated as one logical frequency; the preview does
+        # not model independent per-output divider ratios of the physical LMX.
+        physical_value = _encode_resource_value(field=field, value=value)
+        for affected_port in _resource_ports(
+            boxtype=self.boxtype,
+            field=field,
+            port=port,
+        ):
+            port_config = _mapping_item(self._ports(), affected_port)
+            if not isinstance(port_config, MutableMapping):
+                continue
+            port_config[field] = _decode_resource_value(
+                field=field,
+                direction=port_config.get("direction"),
+                value=physical_value,
+            )
+
+    def _write_fnco(
+        self,
+        *,
+        port: _PortNumber,
+        collection: str,
+        child: int,
+        fnco_freq: float | None,
+    ) -> None:
+        """Apply one FNCO value when the configure call specifies it."""
+        if fnco_freq is None:
+            return
+        port_config = _mapping_item(self._ports(), port)
+        if not isinstance(port_config, MutableMapping):
+            return
+        children = _ensure_mapping_item(port_config, collection)
+        child_config = _ensure_mapping_item(children, child)
+        child_config["fnco_freq"] = _normalize_value(fnco_freq)
+
+
+class Quel1BoxPreviewContext:
+    """Temporarily route controller configuration calls to `Quel1BoxMock`."""
+
+    _lock: ClassVar[RLock] = RLock()
+
+    def __init__(
+        self,
+        *,
+        backend_controller: Quel1BackendController,
+        backend_settings: Mapping[str, dict],
+        box_types: Mapping[str, BoxType],
+    ) -> None:
+        """Initialize mock boxes from fetched hardware snapshots."""
+        self._backend_controller = backend_controller
+        self._database = backend_controller.qubecalib.system_config_database
+        self._boxes = self._create_mock_boxes(
+            backend_settings=backend_settings,
+            box_types=box_types,
+        )
+        self._database_globals = self._resolve_database_globals()
+        self._patched_globals: dict[str, object] = {}
+        self._pooled_boxes: MutableMapping[str, tuple[Any, ...]] | None = None
+        self._original_pool_entries: dict[str, tuple[Any, ...]] = {}
+        self._previous_mock_instances: dict[str, Quel1BoxMock] = {}
+
+    def __enter__(self) -> Quel1BoxPreviewContext:
+        """Install the mock class and replace already-pooled box instances."""
+        self._lock.acquire()
+        try:
+            self._previous_mock_instances = Quel1BoxMock._instances_by_wss_ip
+            Quel1BoxMock._instances_by_wss_ip = dict(self._boxes_by_wss_ip())
+            self._patch_database_globals()
+            self._replace_pooled_boxes()
+        except BaseException:
+            try:
+                self._restore()
+            finally:
+                self._lock.release()
+            raise
+        return self
+
+    def __exit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc_value: BaseException | None,
+        traceback: TracebackType | None,
+    ) -> None:
+        """Restore real box classes and instances even after configuration errors."""
+        del exc_type, exc_value, traceback
+        try:
+            self._restore()
+        finally:
+            self._lock.release()
+
+    def build_preview(
+        self,
+        *,
+        box_ids: Sequence[str],
+        mode: ConfigurationMode | None,
+    ) -> ConfigurePreview:
+        """Build a preview from changes recorded inside the mock boxes."""
+        entries: list[ConfigureStateChange] = []
+        missing_box_ids: list[str] = []
+        for box_id in box_ids:
+            box = self._boxes.get(box_id)
+            if box is None or not box.is_complete:
+                missing_box_ids.append(box_id)
+                continue
+            entries.extend(box.preview_entries())
+        return ConfigurePreview(
+            backend_kind=BACKEND_KIND_QUEL1,
+            box_ids=tuple(box_ids),
+            mode=mode,
+            entries=tuple(entries),
+            missing_box_ids=tuple(missing_box_ids),
+        )
+
+    def _create_mock_boxes(
+        self,
+        *,
+        backend_settings: Mapping[str, dict],
+        box_types: Mapping[str, BoxType],
+    ) -> dict[str, Quel1BoxMock]:
+        """Create one stateful mock for each successfully dumped box."""
+        box_settings = self._database._box_settings
+        boxes: dict[str, Quel1BoxMock] = {}
+        for box_name, snapshot in backend_settings.items():
+            setting = box_settings.get(box_name)
+            box_type = box_types.get(box_name)
+            if setting is None or box_type is None:
+                continue
+            boxes[box_name] = Quel1BoxMock(
+                box_name=box_name,
+                boxtype=box_type.value,
+                ipaddr_sss=str(setting.ipaddr_sss),
+                snapshot=snapshot,
+            )
+        return boxes
+
+    def _boxes_by_wss_ip(self) -> list[tuple[str, Quel1BoxMock]]:
+        """Return mock boxes keyed by their configured WSS addresses."""
+        box_settings = self._database._box_settings
+        return [
+            (str(box_settings[box_name].ipaddr_wss), box)
+            for box_name, box in self._boxes.items()
+        ]
+
+    def _resolve_database_globals(self) -> dict[str, object]:
+        """Return globals used by the database's `create_box()` implementation."""
+        create_box = type(self._database).create_box
+        globals_mapping = getattr(create_box, "__globals__", None)
+        if not isinstance(globals_mapping, dict):
+            raise TypeError("Quel1Box preview requires a Python create_box() method.")
+        return globals_mapping
+
+    def _patch_database_globals(self) -> None:
+        """Replace the real driver class referenced by `create_box()`."""
+        real_box_class = self._backend_controller.driver.Quel1Box
+        create_box = type(self._database).create_box
+        referenced_names = set(create_box.__code__.co_names)
+        class_names = [
+            name
+            for name in referenced_names
+            if self._database_globals.get(name) is real_box_class
+        ]
+        if not class_names:
+            raise RuntimeError("Could not locate Quel1Box in create_box() globals.")
+        for name in class_names:
+            self._patched_globals[name] = self._database_globals[name]
+            self._database_globals[name] = Quel1BoxMock
+        if (
+            "register_box" in referenced_names
+            and "register_box" in self._database_globals
+        ):
+            self._patched_globals["register_box"] = self._database_globals[
+                "register_box"
+            ]
+            self._database_globals["register_box"] = _ignore_box_registration
+
+    def _replace_pooled_boxes(self) -> None:
+        """Replace connected boxpool entries that bypass database creation."""
+        if not self._backend_controller.is_connected:
+            return
+        pooled_boxes = self._backend_controller.boxpool._boxes
+        if not isinstance(pooled_boxes, MutableMapping):
+            raise TypeError("Connected boxpool does not expose mutable box entries.")
+        self._pooled_boxes = pooled_boxes
+        for box_name, mock_box in self._boxes.items():
+            entry = pooled_boxes.get(box_name)
+            if not isinstance(entry, tuple) or not entry:
+                continue
+            self._original_pool_entries[box_name] = entry
+            pooled_boxes[box_name] = (mock_box, *entry[1:])
+
+    def _restore(self) -> None:
+        """Restore every global and pooled object replaced by this context."""
+        try:
+            if self._pooled_boxes is not None:
+                self._pooled_boxes.update(self._original_pool_entries)
+        finally:
+            self._original_pool_entries.clear()
+            self._pooled_boxes = None
+            try:
+                for name, value in self._patched_globals.items():
+                    self._database_globals[name] = value
+            finally:
+                self._patched_globals.clear()
+                Quel1BoxMock._instances_by_wss_ip = self._previous_mock_instances
+
+
+def _ignore_box_registration(box: object) -> None:
+    """Avoid leaking preview mocks into driver-global clock registries."""
+    del box
+
+
+def _resource_ports(
+    *,
+    boxtype: str,
+    field: str,
+    port: _PortNumber,
+) -> tuple[_PortNumber, ...]:
+    """Return logical ports backed by the same physical resource."""
+    for port_group in _SHARED_RESOURCE_PORT_GROUPS.get(boxtype, {}).get(field, ()):
+        if port in port_group:
+            return port_group
+    return (port,)
+
+
+def _encode_resource_value(*, field: str, value: object) -> object:
+    """Encode one logical value into shared physical state."""
+    if field != "rfswitch":
+        return value
+    if value in ("open", "pass"):
+        return False
+    if value in ("loop", "block"):
+        return True
+    return value
+
+
+def _decode_resource_value(
+    *,
+    field: str,
+    direction: object,
+    value: object,
+) -> object:
+    """Decode shared physical state for one logical port direction."""
+    if field != "rfswitch" or not isinstance(value, bool):
+        return value
+    if direction == "in":
+        return "loop" if value else "open"
+    return "block" if value else "pass"
+
+
+def _compare_fields(
+    *,
+    box_id: str,
+    component: str,
+    fields: Sequence[str],
+    initial: _Snapshot,
+    configured: _Snapshot,
+) -> list[ConfigureStateChange]:
+    """Return configured field comparisons for one component."""
+    entries: list[ConfigureStateChange] = []
+    for field in fields:
+        if field == "rfswitch" and field not in initial:
+            continue
+        configured_value = _normalize_value(configured.get(field))
+        if configured_value is None:
+            continue
+        entries.append(
+            ConfigureStateChange(
+                box_id=box_id,
+                component=component,
+                field=field,
+                before=_normalize_value(initial.get(field)),
+                after=configured_value,
+                unit="Hz" if field in _FREQUENCY_FIELDS else None,
+                is_frequency=field in _FREQUENCY_FIELDS,
+            )
+        )
+    return entries
+
+
+def _as_mapping(value: object) -> _Snapshot:
+    """Return a value as a mapping or an empty mapping."""
+    return value if isinstance(value, Mapping) else {}
+
+
+def _mapping_item(mapping: _Snapshot, key: object) -> object:
+    """Read a snapshot item that may use numeric or stringified keys."""
+    if key in mapping:
+        return mapping[key]
+    return mapping.get(str(key))
+
+
+def _ensure_mapping_item(
+    mapping: _MutableSnapshot,
+    key: object,
+) -> _MutableSnapshot:
+    """Return a mutable nested snapshot, creating one when absent."""
+    item = _mapping_item(mapping, key)
+    if isinstance(item, MutableMapping):
+        return item
+    child: dict[object, object] = {}
+    mapping[key] = child
+    return child
+
+
+def _normalize_port_number(port: object) -> object:
+    """Convert integer-like string keys back to logical port numbers."""
+    if isinstance(port, str) and port.isdecimal():
+        return int(port)
+    return port
+
+
+def _normalize_value(value: object) -> object:
+    """Normalize integral floating-point dump values for stable comparison."""
+    if isinstance(value, bool | int):
+        return value
+    if isinstance(value, float) and value.is_integer():
+        return int(value)
+    return value

--- a/src/qubex/system/quel1/quel1_configure_preview.py
+++ b/src/qubex/system/quel1/quel1_configure_preview.py
@@ -36,7 +36,7 @@ _FREQUENCY_FIELDS: Final = frozenset({"lo_freq", "cnco_freq", "fnco_freq"})
 
 # These groups mirror quel_ic_config's port-to-line, LO, and RF-switch maps.
 _SHARED_RESOURCE_PORT_GROUPS: Final[
-    dict[str, dict[str, tuple[tuple[int, ...], ...]]]
+    dict[str, dict[str, tuple[tuple[_PortNumber, ...], ...]]]
 ] = {
     BoxType.QUEL1SE_A.value: {
         "lo_freq": ((0, 1), (3, 5), (7, 8), (10, 12)),
@@ -47,7 +47,7 @@ _SHARED_RESOURCE_PORT_GROUPS: Final[
     },
     BoxType.QUEL1SE_R8.value: {
         "lo_freq": ((0, 1), (4, 10)),
-        "rfswitch": ((0, 1),),
+        "rfswitch": ((0, 1, (1, 1)),),
     },
     BoxType.QUEL1_A.value: {
         "lo_freq": ((0, 1), (3, 5), (7, 8), (10, 12)),

--- a/src/qubex/system/quel1/quel1_system_synchronizer.py
+++ b/src/qubex/system/quel1/quel1_system_synchronizer.py
@@ -213,10 +213,17 @@ class Quel1SystemSynchronizer:
         """
         Preview QuEL-1 hardware changes for `configure()`.
 
+        Raises
+        ------
+        RuntimeError
+            If the backend is disconnected or a target box is absent from the
+            connected box pool.
+
         Notes
         -----
         Concurrent QuEL-1 controller operations are not supported during preview.
         """
+        self._require_preview_boxes_connected(box_ids)
         backend_settings = self.fetch_backend_settings_from_hardware(
             experiment_system=experiment_system,
             box_ids=box_ids,
@@ -245,6 +252,23 @@ class Quel1SystemSynchronizer:
             box_ids=box_ids,
             mode=mode,
         )
+
+    def _require_preview_boxes_connected(self, box_ids: Sequence[str]) -> None:
+        """Require every preview target to exist in the connected box pool."""
+        if not self._backend_controller.is_connected:
+            raise RuntimeError(
+                "Configure preview requires all target boxes to be connected."
+            )
+        pooled_box_ids = self._backend_controller.connected_box_names()
+        missing_box_ids = list(
+            dict.fromkeys(box_id for box_id in box_ids if box_id not in pooled_box_ids)
+        )
+        if missing_box_ids:
+            missing = ", ".join(missing_box_ids)
+            raise RuntimeError(
+                "Configure preview requires all target boxes to be connected; "
+                f"missing from the connected pool: {missing}."
+            )
 
     def sync_backend_settings_to_backend_controller(
         self,

--- a/src/qubex/system/quel1/quel1_system_synchronizer.py
+++ b/src/qubex/system/quel1/quel1_system_synchronizer.py
@@ -8,14 +8,17 @@ from typing import TYPE_CHECKING, Any, Literal, TypeGuard
 
 from qubex.core.parallel_executor import run_parallel, run_parallel_map
 from qubex.system.control_system import PortType
+from qubex.system.quel1.quel1_configure_preview import Quel1BoxPreviewContext
 from qubex.system.quel1.quel1_control_parameter_defaults import DEFAULT_CAPTURE_DELAY
 
 logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from qubex.backend.quel1.quel1_backend_controller import Quel1BackendController
+    from qubex.system.configure_preview import ConfigurePreview
     from qubex.system.control_system import Box, CapPort, GenPort
     from qubex.system.experiment_system import ExperimentSystem
+    from qubex.typing import ConfigurationMode
 
 
 class Quel1SystemSynchronizer:
@@ -197,6 +200,51 @@ class Quel1SystemSynchronizer:
             for box_id, box_config in raw_result.items()
             if self._is_valid_dumped_box_config(box_id, box_config)
         }
+
+    def preview_configure(
+        self,
+        *,
+        experiment_system: ExperimentSystem,
+        box_ids: Sequence[str],
+        mode: ConfigurationMode | None,
+        parallel: bool | None = None,
+        target_labels: Sequence[str] | None = None,
+    ) -> ConfigurePreview:
+        """
+        Preview QuEL-1 hardware changes for `configure()`.
+
+        Notes
+        -----
+        Concurrent QuEL-1 controller operations are not supported during preview.
+        """
+        backend_settings = self.fetch_backend_settings_from_hardware(
+            experiment_system=experiment_system,
+            box_ids=box_ids,
+            parallel=parallel,
+        )
+        preview_context = Quel1BoxPreviewContext(
+            backend_controller=self._backend_controller,
+            backend_settings=backend_settings,
+            box_types={
+                box_id: experiment_system.get_box(box_id).type for box_id in box_ids
+            },
+        )
+        boxes = [
+            experiment_system.get_box(box_id)
+            for box_id in box_ids
+            if box_id in backend_settings
+        ]
+        with preview_context:
+            self.sync_experiment_system_to_hardware(
+                experiment_system=experiment_system,
+                boxes=boxes,
+                parallel=parallel,
+                target_labels=target_labels,
+            )
+        return preview_context.build_preview(
+            box_ids=box_ids,
+            mode=mode,
+        )
 
     def sync_backend_settings_to_backend_controller(
         self,

--- a/src/qubex/system/system_manager.py
+++ b/src/qubex/system/system_manager.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, cast
 
 from rich.prompt import Confirm
 from typing_extensions import Self, deprecated
@@ -28,6 +28,7 @@ from qubex.constants import (
 from qubex.typing import ConfigurationMode
 
 from .config_loader import ConfigLoader
+from .configure_preview import ConfigurePreview, ConfigurePreviewSynchronizer
 from .control_system import Box
 from .experiment_system import ExperimentSystem
 from .quel1.quel1_system_synchronizer import Quel1SystemSynchronizer
@@ -440,6 +441,86 @@ class SystemManager:
             raise
         self._update_cached_state()
 
+    def preview_configure(
+        self,
+        *,
+        chip_id: str | None = None,
+        system_id: str | None = None,
+        config_dir: Path | str | None = None,
+        params_dir: Path | str | None = None,
+        targets_to_exclude: list[str] | None = None,
+        configuration_mode: ConfigurationMode | None = None,
+        box_ids: Sequence[str] | None,
+        parallel: bool | None = None,
+        target_labels: Sequence[str] | None = None,
+        qubit_labels: Sequence[str] | None = None,
+    ) -> ConfigurePreview:
+        """
+        Preview device state changes that `configure()` would apply.
+
+        Parameters
+        ----------
+        chip_id : str | None, optional
+            Deprecated chip identifier compatibility input.
+        system_id : str | None, optional
+            Canonical system identifier.
+        config_dir : Path | str | None, optional
+            Directory containing configuration files.
+        params_dir : Path | str | None, optional
+            Directory containing parameter files.
+        targets_to_exclude : list[str] | None, optional
+            Target labels to exclude from the previewed model.
+        configuration_mode : ConfigurationMode | None, optional
+            Configuration mode to preview.
+        box_ids : Sequence[str] | None
+            Box IDs to compare against current hardware settings. If `None`,
+            resolves boxes from the previewed system.
+        parallel : bool | None, optional
+            Whether to fetch per-box hardware settings in parallel.
+        target_labels : Sequence[str] | None, optional
+            Logical target labels to include in the previewed hardware plan.
+        qubit_labels : Sequence[str] | None, optional
+            Active qubit labels used to resolve default boxes.
+
+        Returns
+        -------
+        ConfigurePreview
+            Structured summary of field-level changes.
+
+        Raises
+        ------
+        NotImplementedError
+            If the preview backend does not support configure previews.
+
+        Notes
+        -----
+        This method fetches hardware state but does not mutate manager,
+        backend-controller, or hardware configuration state.
+        """
+        preview_experiment_system, backend_kind = self._load_preview_experiment_system(
+            chip_id=chip_id,
+            system_id=system_id,
+            config_dir=config_dir,
+            params_dir=params_dir,
+            targets_to_exclude=targets_to_exclude,
+            configuration_mode=configuration_mode,
+        )
+        if box_ids is None:
+            boxes = (
+                preview_experiment_system.boxes
+                if qubit_labels is None
+                else preview_experiment_system.get_boxes_for_qubits(qubit_labels)
+            )
+            box_ids = [box.id for box in boxes]
+        system_synchronizer = self._resolve_preview_system_synchronizer(backend_kind)
+        return system_synchronizer.preview_configure(
+            experiment_system=preview_experiment_system,
+            box_ids=box_ids,
+            mode=configuration_mode,
+            parallel=parallel,
+            target_labels=target_labels,
+        )
+
     def push(
         self,
         box_ids: Sequence[str],
@@ -692,6 +773,52 @@ This operation will overwrite the existing backend settings. Do you want to cont
             parallel=parallel,
         )
         return BackendSettings(fetched)
+
+    def _load_preview_experiment_system(
+        self,
+        *,
+        chip_id: str | None,
+        system_id: str | None,
+        config_dir: Path | str | None,
+        params_dir: Path | str | None,
+        targets_to_exclude: list[str] | None,
+        configuration_mode: ConfigurationMode | None,
+    ) -> tuple[ExperimentSystem, BackendKind]:
+        """Load the would-be experiment system without mutating manager state."""
+        config_loader = ConfigLoader(
+            chip_id=chip_id,
+            system_id=system_id,
+            config_dir=config_dir,
+            params_dir=params_dir,
+            autoload=False,
+        )
+        config_loader.load(
+            targets_to_exclude=targets_to_exclude,
+            configuration_mode=configuration_mode,
+        )
+        return config_loader.get_experiment_system(), config_loader.backend_kind
+
+    def _resolve_preview_system_synchronizer(
+        self,
+        backend_kind: BackendKind,
+    ) -> ConfigurePreviewSynchronizer:
+        """Return active synchronizer when it matches the preview backend kind."""
+        active_backend_kind = self.backend_kind
+        if backend_kind != active_backend_kind:
+            raise RuntimeError(
+                "Configure preview backend kind does not match the active session "
+                f"(preview={backend_kind!r}, active={active_backend_kind!r})."
+            )
+        if backend_kind != BACKEND_KIND_QUEL1:
+            raise NotImplementedError(
+                f"Configure preview is not implemented for backend kind: {backend_kind}."
+            )
+        system_synchronizer = self._resolve_system_synchronizer()
+        if system_synchronizer is None:
+            raise NotImplementedError(
+                f"Configure preview is not implemented for backend kind: {backend_kind}."
+            )
+        return cast(ConfigurePreviewSynchronizer, system_synchronizer)
 
     def _sync_backend_settings_to_backend_controller(
         self,

--- a/tests/backend/test_quel1_connection_manager.py
+++ b/tests/backend/test_quel1_connection_manager.py
@@ -141,6 +141,28 @@ def test_connect_skips_when_already_connected() -> None:
     assert called is False
 
 
+def test_connected_box_names_returns_empty_when_disconnected() -> None:
+    """A disconnected manager should report no connected box names."""
+    manager = _make_manager()
+
+    assert manager.connected_box_names() == set()
+
+
+def test_connected_box_names_returns_names_from_active_pool() -> None:
+    """A connected manager should report every box name in its active pool."""
+    manager = _make_manager()
+    boxpool = _FakeBoxPool()
+    boxpool._boxes = {"A": (object(), object()), "B": (object(), object())}
+    manager.set_connected_state(
+        boxpool=boxpool,  # type: ignore[arg-type]
+        quel1system=_FakeQuel1System(),  # type: ignore[arg-type]
+        cap_resource_map={},
+        gen_resource_map={},
+    )
+
+    assert manager.connected_box_names() == {"A", "B"}
+
+
 def test_connect_reconnects_when_requested_boxes_are_missing() -> None:
     """Given connected subset, when connect requests missing boxes, then it reconnects."""
     manager = _make_manager()

--- a/tests/experiment/test_experiment_facade_delegation.py
+++ b/tests/experiment/test_experiment_facade_delegation.py
@@ -127,6 +127,7 @@ class _ExperimentContextStub:
 class _SessionServiceStub:
     def __init__(self) -> None:
         self.calls: list[tuple[str, dict[str, Any]]] = []
+        self.configure_preview = object()
 
     def disconnect(self) -> None:
         self.calls.append(("disconnect", {}))
@@ -146,6 +147,10 @@ class _SessionServiceStub:
 
     def configure(self, **kwargs: Any) -> None:
         self.calls.append(("configure", kwargs))
+
+    def preview_configure(self, **kwargs: Any) -> object:
+        self.calls.append(("preview_configure", kwargs))
+        return self.configure_preview
 
     def linkup(self, **kwargs: Any) -> None:
         self.calls.append(("linkup", kwargs))
@@ -841,6 +846,50 @@ def test_configure_delegates_to_session_service() -> None:
                 "exclude": "Q00",
                 "mode": "ge-cr-cr",
                 "confirm": True,
+                "dry_run": False,
+            },
+        )
+    ]
+
+
+def test_configure_forwards_dry_run_to_session_service() -> None:
+    """Given dry_run configure, when called, then it forwards dry_run to session service."""
+    exp = object.__new__(Experiment)
+    session_stub = _SessionServiceStub()
+    exp.__dict__["_session_service"] = session_stub
+
+    exp.configure(dry_run=True)
+
+    assert session_stub.calls == [
+        (
+            "configure",
+            {
+                "box_ids": None,
+                "exclude": None,
+                "mode": None,
+                "confirm": True,
+                "dry_run": True,
+            },
+        )
+    ]
+
+
+def test_preview_configure_delegates_to_session_service() -> None:
+    """Given preview args, when called, then it delegates to session service."""
+    exp = object.__new__(Experiment)
+    session_stub = _SessionServiceStub()
+    exp.__dict__["_session_service"] = session_stub
+
+    result = exp.preview_configure(box_ids="Q2A", exclude="Q00", mode="ge-cr-cr")
+
+    assert result is session_stub.configure_preview
+    assert session_stub.calls == [
+        (
+            "preview_configure",
+            {
+                "box_ids": "Q2A",
+                "exclude": "Q00",
+                "mode": "ge-cr-cr",
             },
         )
     ]

--- a/tests/experiment/test_session_service.py
+++ b/tests/experiment/test_session_service.py
@@ -15,6 +15,7 @@ class _SystemManagerStub:
     def __init__(self, calls: list[tuple[str, dict[str, object]]]) -> None:
         self._calls = calls
         self.backend_settings: dict[str, object] = {}
+        self.configure_preview = _PreviewStub(calls)
 
     def load(self, **kwargs: object) -> None:
         self._calls.append(("system_manager.load", dict(kwargs)))
@@ -22,8 +23,20 @@ class _SystemManagerStub:
     def push(self, **kwargs: object) -> None:
         self._calls.append(("system_manager.push", dict(kwargs)))
 
+    def preview_configure(self, **kwargs: object) -> _PreviewStub:
+        self._calls.append(("system_manager.preview_configure", dict(kwargs)))
+        return self.configure_preview
+
     def is_synced(self, *, box_ids: list[str]) -> bool:
         return len(box_ids) > 0
+
+
+class _PreviewStub:
+    def __init__(self, calls: list[tuple[str, dict[str, object]]]) -> None:
+        self._calls = calls
+
+    def print_summary(self) -> None:
+        self._calls.append(("preview.print_summary", {}))
 
 
 class _ExperimentSystemStub:
@@ -49,6 +62,7 @@ class _ContextStub:
         self._calls = calls
         self.configuration_mode: ConfigurationMode = "ge-cr-cr"
         self.box_ids = ["Q2A", "Q2B"]
+        self.qubit_labels = ["Q00"]
         self.targets = {"Q00": object(), "RQ00": object()}
         self.backend_controller = object()
         self.system_manager = system_manager
@@ -249,6 +263,90 @@ def test_configure_reloads_with_active_system_id(monkeypatch) -> None:
             "configuration_mode": "ge-cr-cr",
         },
     )
+
+
+def test_preview_configure_uses_system_manager_without_push(monkeypatch) -> None:
+    """Given preview request, SessionService should build preview without pushing hardware."""
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    context = _ContextStub(
+        system_manager=_SystemManagerStub(calls),
+        measurement=_MeasurementStub(calls),
+        config_path="config-dir",
+        params_path="params-dir",
+        calls=calls,
+    )
+    monkeypatch.setattr(
+        SessionService,
+        "_sync_pulse_sampling_period",
+        lambda self: 0.4,
+    )
+
+    service = SessionService(
+        experiment_context=cast(ExperimentContext, context),
+    )
+
+    preview = service.preview_configure(exclude="Q00", mode=None)
+
+    assert preview is context.system_manager.configure_preview
+    assert calls == [
+        (
+            "system_manager.preview_configure",
+            {
+                "chip_id": "64Qv2",
+                "system_id": "64Qv2-Q1",
+                "config_dir": "config-dir",
+                "params_dir": "params-dir",
+                "targets_to_exclude": ["Q00"],
+                "configuration_mode": "ge-cr-cr",
+                "box_ids": None,
+                "target_labels": ["Q00", "RQ00"],
+                "qubit_labels": ["Q00"],
+            },
+        )
+    ]
+
+
+def test_configure_dry_run_prints_preview_without_load_or_push(monkeypatch) -> None:
+    """Given dry_run configure, SessionService should print preview and skip push."""
+    calls: list[tuple[str, dict[str, object]]] = []
+
+    context = _ContextStub(
+        system_manager=_SystemManagerStub(calls),
+        measurement=_MeasurementStub(calls),
+        config_path="config-dir",
+        params_path="params-dir",
+        calls=calls,
+    )
+    monkeypatch.setattr(
+        SessionService,
+        "_sync_pulse_sampling_period",
+        lambda self: 0.4,
+    )
+
+    service = SessionService(
+        experiment_context=cast(ExperimentContext, context),
+    )
+
+    service.configure(box_ids="Q2A", exclude="Q00", mode=None, dry_run=True)
+
+    assert calls == [
+        (
+            "system_manager.preview_configure",
+            {
+                "chip_id": "64Qv2",
+                "system_id": "64Qv2-Q1",
+                "config_dir": "config-dir",
+                "params_dir": "params-dir",
+                "targets_to_exclude": ["Q00"],
+                "configuration_mode": "ge-cr-cr",
+                "box_ids": ["Q2A"],
+                "target_labels": ["Q00", "RQ00"],
+                "qubit_labels": ["Q00"],
+            },
+        ),
+        ("preview.print_summary", {}),
+    ]
 
 
 def test_reset_awg_and_capunits_delegates_to_experiment_context(

--- a/tests/system/test_configure_preview.py
+++ b/tests/system/test_configure_preview.py
@@ -1,0 +1,55 @@
+"""Tests for configure preview models."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+
+from qubex.backend.backend_controller import BACKEND_KIND_QUEL1
+from qubex.system import ConfigurePreview, ConfigureStateChange
+
+
+def test_configure_preview_prints_summary_and_full_tables() -> None:
+    """Given preview entries, summary should show changes while full shows all entries."""
+    preview = ConfigurePreview(
+        backend_kind=BACKEND_KIND_QUEL1,
+        box_ids=("A",),
+        mode="ge-cr-cr",
+        entries=(
+            ConfigureStateChange(
+                box_id="A",
+                component="port 1",
+                field="lo_freq",
+                before=10_000_000_000,
+                after=11_000_000_000,
+                unit="Hz",
+                is_frequency=True,
+            ),
+            ConfigureStateChange(
+                box_id="A",
+                component="port 1",
+                field="rfswitch",
+                before="pass",
+                after="pass",
+            ),
+        ),
+    )
+    summary_io = StringIO()
+    full_io = StringIO()
+
+    preview.print_summary(Console(file=summary_io, force_terminal=False, width=120))
+    preview.print_full(Console(file=full_io, force_terminal=False, width=120))
+
+    summary = summary_io.getvalue()
+    full = full_io.getvalue()
+    assert "Configure Preview Changes" in summary
+    assert "A" in summary
+    assert "lo_freq" in summary
+    assert "rfswitch" not in summary
+    assert "Configure Preview Full" in full
+    assert "CHANGE" in full
+    assert "lo_freq" in full
+    assert "rfswitch" in full
+    assert "yes" in full
+    assert "no" in full

--- a/tests/system/test_configure_preview_orchestration.py
+++ b/tests/system/test_configure_preview_orchestration.py
@@ -1,0 +1,151 @@
+"""Tests for configure preview orchestration."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from qubex.backend.backend_controller import BACKEND_KIND_QUEL1, BACKEND_KIND_QUEL3
+from qubex.system import ConfigurePreview
+from qubex.system.system_manager import SystemManager
+
+
+class _PreviewSynchronizerStub:
+    def __init__(self, preview: ConfigurePreview) -> None:
+        self.preview = preview
+        self.calls: list[dict[str, Any]] = []
+
+    def preview_configure(self, **kwargs: Any) -> ConfigurePreview:
+        """Record preview calls and return the configured preview."""
+        self.calls.append(dict(kwargs))
+        return self.preview
+
+
+def test_system_manager_preview_configure_delegates_to_active_synchronizer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given active backend, SystemManager should delegate preview to its synchronizer."""
+    manager = SystemManager.shared()
+    experiment_system = SimpleNamespace(
+        hash=0,
+        get_boxes_for_qubits=lambda _qubits: [SimpleNamespace(id="A")],
+    )
+    preview = ConfigurePreview(
+        backend_kind=BACKEND_KIND_QUEL1,
+        box_ids=("A",),
+        mode="ge-cr-cr",
+    )
+    synchronizer = _PreviewSynchronizerStub(preview)
+    monkeypatch.setattr(
+        SystemManager,
+        "backend_kind",
+        property(lambda _manager: BACKEND_KIND_QUEL1),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_resolve_system_synchronizer",
+        lambda: synchronizer,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_load_preview_experiment_system",
+        lambda **_: (experiment_system, BACKEND_KIND_QUEL1),
+        raising=False,
+    )
+
+    result = manager.preview_configure(
+        chip_id="chip",
+        system_id="system",
+        config_dir="config",
+        params_dir="params",
+        targets_to_exclude=["Q00"],
+        configuration_mode="ge-cr-cr",
+        box_ids=None,
+        parallel=False,
+        target_labels=["Q00"],
+        qubit_labels=["Q00"],
+    )
+
+    assert result is preview
+    assert synchronizer.calls == [
+        {
+            "experiment_system": experiment_system,
+            "box_ids": ["A"],
+            "mode": "ge-cr-cr",
+            "parallel": False,
+            "target_labels": ["Q00"],
+        }
+    ]
+
+
+def test_system_manager_preview_configure_rejects_backend_kind_mismatch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given preview backend differs from active session, SystemManager should fail early."""
+    manager = SystemManager.shared()
+    monkeypatch.setattr(
+        SystemManager,
+        "backend_kind",
+        property(lambda _manager: BACKEND_KIND_QUEL1),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_load_preview_experiment_system",
+        lambda **_: (SimpleNamespace(hash=0), BACKEND_KIND_QUEL3),
+        raising=False,
+    )
+
+    with pytest.raises(RuntimeError, match="does not match the active session"):
+        manager.preview_configure(
+            chip_id="chip",
+            system_id="system",
+            config_dir="config",
+            params_dir="params",
+            targets_to_exclude=None,
+            configuration_mode="ge-cr-cr",
+            box_ids=["A"],
+        )
+
+
+def test_system_manager_preview_configure_rejects_quel3(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """QuEL-3 configure preview should remain explicitly unsupported."""
+    manager = SystemManager.shared()
+    preview = ConfigurePreview(
+        backend_kind=BACKEND_KIND_QUEL3,
+        box_ids=("A",),
+        mode="ge-cr-cr",
+    )
+    synchronizer = _PreviewSynchronizerStub(preview)
+    monkeypatch.setattr(
+        SystemManager,
+        "backend_kind",
+        property(lambda _manager: BACKEND_KIND_QUEL3),
+    )
+    monkeypatch.setattr(
+        manager,
+        "_resolve_system_synchronizer",
+        lambda: synchronizer,
+    )
+    monkeypatch.setattr(
+        manager,
+        "_load_preview_experiment_system",
+        lambda **_: (SimpleNamespace(hash=0), BACKEND_KIND_QUEL3),
+        raising=False,
+    )
+
+    with pytest.raises(NotImplementedError, match="backend kind: quel3"):
+        manager.preview_configure(
+            chip_id="chip",
+            system_id="system",
+            config_dir="config",
+            params_dir="params",
+            targets_to_exclude=None,
+            configuration_mode="ge-cr-cr",
+            box_ids=["A"],
+        )
+
+    assert synchronizer.calls == []

--- a/tests/system/test_quel1_configure_preview.py
+++ b/tests/system/test_quel1_configure_preview.py
@@ -201,10 +201,10 @@ def _make_shared_system(
 
 
 def _shared_backend_settings(
-    *port_configs: tuple[int, str, int | None, str | None],
+    *port_configs: tuple[int | tuple[int, int], str, int | None, str | None],
     include_rfswitch: bool = True,
 ) -> dict[str, dict]:
-    ports: dict[int, dict[str, object]] = {}
+    ports: dict[int | tuple[int, int], dict[str, object]] = {}
     for port_number, direction, lo_freq, rfswitch in port_configs:
         config: dict[str, object] = {
             "direction": direction,
@@ -789,6 +789,64 @@ def test_preview_configure_reports_final_shared_rfswitch_for_each_port() -> None
             field="rfswitch",
             before="pass",
             after="block",
+            unit=None,
+            is_frequency=False,
+        ),
+    )
+
+
+def test_preview_configure_reports_r8_fogi_shared_rfswitch_change() -> None:
+    """R8 preview should report the FOGI port affected by a readout switch."""
+    system = _make_shared_system(
+        box_type=BoxType.QUEL1SE_R8,
+        ports=[
+            _make_port(
+                number=0,
+                port_type=PortType.READ_IN,
+                rfswitch="open",
+            ),
+            _make_port(
+                number=1,
+                port_type=PortType.READ_OUT,
+                rfswitch="pass",
+            ),
+        ],
+    )
+
+    preview = _preview(
+        experiment_system=system,
+        backend_settings=_shared_backend_settings(
+            (0, "in", None, "loop"),
+            (1, "out", None, "block"),
+            ((1, 1), "out", None, "block"),
+        ),
+    )
+
+    assert preview.changes == (
+        ConfigureStateChange(
+            box_id="A",
+            component="port 0",
+            field="rfswitch",
+            before="loop",
+            after="open",
+            unit=None,
+            is_frequency=False,
+        ),
+        ConfigureStateChange(
+            box_id="A",
+            component="port 1",
+            field="rfswitch",
+            before="block",
+            after="pass",
+            unit=None,
+            is_frequency=False,
+        ),
+        ConfigureStateChange(
+            box_id="A",
+            component="port (1, 1)",
+            field="rfswitch",
+            before="block",
+            after="pass",
             unit=None,
             is_frequency=False,
         ),

--- a/tests/system/test_quel1_configure_preview.py
+++ b/tests/system/test_quel1_configure_preview.py
@@ -1,0 +1,768 @@
+"""Tests for QuEL-1 configure preview behavior."""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from types import SimpleNamespace
+from typing import Any, ClassVar, cast
+
+import pytest
+from quel_ic_config import QUEL1_BOXTYPE_ALIAS
+
+from qubex.backend.quel1.quel1_backend_controller import Quel1BackendController
+from qubex.backend.quel1.quel1_runtime_context import Quel1RuntimeContext
+from qubex.system import ConfigurePreview, ConfigureStateChange
+from qubex.system.control_system import BoxType, PortType
+from qubex.system.quel1.quel1_configure_preview import Quel1BoxPreviewContext
+from qubex.system.quel1.quel1_system_synchronizer import Quel1SystemSynchronizer
+
+
+class _HardwareQuel1Box:
+    snapshots_by_ip: ClassVar[dict[str, dict]] = {}
+    config_calls: ClassVar[list[str]] = []
+
+    def __init__(self, *, ipaddr_wss: str, ipaddr_sss: str, boxtype: str) -> None:
+        self._state = deepcopy(self.snapshots_by_ip[ipaddr_wss])
+        self.boxtype = boxtype
+        self.wss = SimpleNamespace(ipaddr_sss=ipaddr_sss)
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        ipaddr_wss: str,
+        ipaddr_sss: str,
+        boxtype: str,
+        **_: object,
+    ) -> _HardwareQuel1Box:
+        return cls(
+            ipaddr_wss=ipaddr_wss,
+            ipaddr_sss=ipaddr_sss,
+            boxtype=boxtype,
+        )
+
+    def reconnect(self, **_: object) -> dict[int, bool]:
+        return {}
+
+    def dump_box(self) -> dict:
+        return deepcopy(self._state)
+
+    def config_port(self, **_: object) -> None:
+        self.config_calls.append("port")
+
+    def config_channel(self, **_: object) -> None:
+        self.config_calls.append("channel")
+
+    def config_runit(self, **_: object) -> None:
+        self.config_calls.append("runit")
+
+
+Quel1Box = _HardwareQuel1Box
+
+
+class _SystemConfigDatabaseStub:
+    def __init__(self, *, box_type: BoxType) -> None:
+        self._box_settings = {
+            "A": SimpleNamespace(
+                ipaddr_wss="192.0.2.1",
+                ipaddr_sss="192.0.2.2",
+                ipaddr_css="192.0.2.3",
+                boxtype=QUEL1_BOXTYPE_ALIAS[box_type.value],
+            )
+        }
+        self.created_box_classes: list[type[object]] = []
+
+    def asdict(self) -> dict[str, object]:
+        return {"box_settings": self._box_settings}
+
+    def create_box(
+        self,
+        box_name: str,
+        reconnect: bool = True,
+    ) -> object:
+        del reconnect
+        setting = self._box_settings[box_name]
+        self.created_box_classes.append(Quel1Box)
+        return Quel1Box.create(
+            ipaddr_wss=setting.ipaddr_wss,
+            ipaddr_sss=setting.ipaddr_sss,
+            ipaddr_css=setting.ipaddr_css,
+            boxtype=setting.boxtype,
+            skip_init=False,
+        )
+
+
+class _ExperimentSystemStub:
+    def __init__(self, boxes: list[Any]) -> None:
+        self._boxes = {box.id: box for box in boxes}
+
+    def get_box(self, box_id: str) -> Any:
+        return self._boxes[box_id]
+
+    @property
+    def hash(self) -> int:
+        return 0
+
+
+def _make_system(
+    *,
+    box_type: BoxType = BoxType.QUEL1SE_R8,
+    port_number: int = 1,
+    port_type: PortType = PortType.CTRL,
+    lo_freq: int | None = 10_000_000_000,
+    cnco_freq: int = 1_500_000_000,
+    fnco_freq: int | None = 100_000_000,
+    rfswitch: str = "pass",
+    vatt: int | None = 2048,
+    sideband: str | None = "L",
+    fullscale_current: int | None = 40527,
+) -> _ExperimentSystemStub:
+    channel = SimpleNamespace(number=0, fnco_freq=fnco_freq)
+    port = SimpleNamespace(
+        number=port_number,
+        type=port_type,
+        lo_freq=lo_freq,
+        cnco_freq=cnco_freq,
+        vatt=vatt,
+        sideband=sideband,
+        fullscale_current=fullscale_current,
+        rfswitch=rfswitch,
+        channels=(channel,),
+    )
+    return _ExperimentSystemStub(
+        [SimpleNamespace(id="A", name="Alpha", type=box_type, ports=(port,))]
+    )
+
+
+def _backend_settings(
+    *,
+    port_number: int = 1,
+    lo_freq: int | None = 10_000_000_000,
+    cnco_freq: int = 1_500_000_000,
+    fnco_freq: int = 100_000_000,
+    rfswitch: str = "pass",
+    vatt: int | None = 2048,
+    sideband: str | None = "L",
+    fullscale_current: int | None = 40527,
+) -> dict[str, dict]:
+    return {
+        "A": {
+            "ports": {
+                port_number: {
+                    "direction": "out",
+                    "lo_freq": lo_freq,
+                    "cnco_freq": cnco_freq,
+                    "vatt": vatt,
+                    "sideband": sideband,
+                    "fullscale_current": fullscale_current,
+                    "rfswitch": rfswitch,
+                    "channels": {0: {"fnco_freq": fnco_freq}},
+                }
+            }
+        }
+    }
+
+
+def _make_port(
+    *,
+    number: int,
+    port_type: PortType,
+    lo_freq: int | None = None,
+    rfswitch: str | None = None,
+) -> SimpleNamespace:
+    return SimpleNamespace(
+        number=number,
+        type=port_type,
+        lo_freq=lo_freq,
+        cnco_freq=None,
+        vatt=None,
+        sideband=None,
+        fullscale_current=None,
+        rfswitch=rfswitch,
+        channels=(),
+    )
+
+
+def _make_shared_system(
+    *,
+    box_type: BoxType,
+    ports: list[SimpleNamespace],
+) -> _ExperimentSystemStub:
+    return _ExperimentSystemStub(
+        [
+            SimpleNamespace(
+                id="A",
+                name="Alpha",
+                type=box_type,
+                ports=tuple(sorted(ports, key=lambda port: port.number)),
+            )
+        ]
+    )
+
+
+def _shared_backend_settings(
+    *port_configs: tuple[int, str, int | None, str | None],
+    include_rfswitch: bool = True,
+) -> dict[str, dict]:
+    ports: dict[int, dict[str, object]] = {}
+    for port_number, direction, lo_freq, rfswitch in port_configs:
+        config: dict[str, object] = {
+            "direction": direction,
+            "lo_freq": lo_freq,
+        }
+        if include_rfswitch:
+            config["rfswitch"] = rfswitch
+        config["channels" if direction == "out" else "runits"] = {}
+        ports[port_number] = config
+    return {"A": {"ports": ports}}
+
+
+def _preview(
+    *,
+    experiment_system: _ExperimentSystemStub,
+    backend_settings: dict[str, dict],
+) -> ConfigurePreview:
+    backend_controller, _ = _make_backend_controller(
+        backend_settings=backend_settings,
+        box_type=experiment_system.get_box("A").type,
+    )
+    synchronizer = Quel1SystemSynchronizer(backend_controller=backend_controller)
+    return synchronizer.preview_configure(
+        experiment_system=cast(Any, experiment_system),
+        box_ids=["A"],
+        mode="ge-cr-cr",
+        parallel=False,
+    )
+
+
+def _make_backend_controller(
+    *,
+    backend_settings: dict[str, dict],
+    box_type: BoxType,
+    connected: bool = False,
+) -> tuple[Quel1BackendController, _SystemConfigDatabaseStub]:
+    database = _SystemConfigDatabaseStub(box_type=box_type)
+    _HardwareQuel1Box.snapshots_by_ip = {
+        "192.0.2.1": deepcopy(backend_settings.get("A", {}))
+    }
+    _HardwareQuel1Box.config_calls = []
+    driver = SimpleNamespace(
+        DEFAULT_SAMPLING_PERIOD=2.0,
+        Quel1Box=_HardwareQuel1Box,
+    )
+    qubecalib = SimpleNamespace(system_config_database=database)
+    runtime_context = Quel1RuntimeContext(
+        driver=cast(Any, driver),
+        qubecalib=cast(Any, qubecalib),
+    )
+    if connected:
+        hardware_box = _HardwareQuel1Box.create(
+            ipaddr_wss="192.0.2.1",
+            ipaddr_sss="192.0.2.2",
+            boxtype=box_type.value,
+        )
+        runtime_context.set_connected_state(
+            boxpool=cast(
+                Any,
+                SimpleNamespace(_boxes={"A": (hardware_box, object())}),
+            ),
+            quel1system=cast(Any, object()),
+            cap_resource_map={},
+            gen_resource_map={},
+        )
+    return Quel1BackendController(runtime_context=runtime_context), database
+
+
+def test_preview_configure_temporarily_replaces_quel1_box() -> None:
+    """Preview should configure a mock box and restore the real box class afterward."""
+    system = _make_system(lo_freq=11_000_000_000)
+    backend_settings = _backend_settings(lo_freq=10_000_000_000)
+    backend_controller, database = _make_backend_controller(
+        backend_settings=backend_settings,
+        box_type=BoxType.QUEL1SE_R8,
+    )
+    synchronizer = Quel1SystemSynchronizer(backend_controller=backend_controller)
+
+    preview = synchronizer.preview_configure(
+        experiment_system=cast(Any, system),
+        box_ids=["A"],
+        mode="ge-cr-cr",
+        parallel=False,
+    )
+
+    assert database.created_box_classes[0] is _HardwareQuel1Box
+    assert any(
+        box_class is not _HardwareQuel1Box
+        for box_class in database.created_box_classes[1:]
+    )
+    assert Quel1Box is _HardwareQuel1Box
+    assert _HardwareQuel1Box.config_calls == []
+    assert preview.changes[0].after == 11_000_000_000
+
+
+def test_preview_configure_uses_hardware_sync_orchestration(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preview should execute the same system-to-hardware orchestration as push."""
+    system = _make_system(lo_freq=11_000_000_000)
+    backend_controller, _ = _make_backend_controller(
+        backend_settings=_backend_settings(lo_freq=10_000_000_000),
+        box_type=BoxType.QUEL1SE_R8,
+    )
+    synchronizer = Quel1SystemSynchronizer(backend_controller=backend_controller)
+    sync_calls: list[tuple[list[str], bool | None, tuple[str, ...] | None]] = []
+    original_sync = synchronizer.sync_experiment_system_to_hardware
+
+    def _record_sync(**kwargs: Any) -> None:
+        sync_calls.append(
+            (
+                [box.id for box in kwargs["boxes"]],
+                kwargs["parallel"],
+                tuple(kwargs["target_labels"]),
+            )
+        )
+        original_sync(**kwargs)
+
+    monkeypatch.setattr(
+        synchronizer,
+        "sync_experiment_system_to_hardware",
+        _record_sync,
+    )
+
+    synchronizer.preview_configure(
+        experiment_system=cast(Any, system),
+        box_ids=["A"],
+        mode="ge-cr-cr",
+        parallel=False,
+        target_labels=["Q00"],
+    )
+
+    assert sync_calls == [(["A"], False, ("Q00",))]
+
+
+def test_preview_configure_restores_connected_boxpool() -> None:
+    """Preview should restore connected boxpool entries after mock configuration."""
+    system = _make_system(lo_freq=11_000_000_000)
+    backend_controller, _ = _make_backend_controller(
+        backend_settings=_backend_settings(lo_freq=10_000_000_000),
+        box_type=BoxType.QUEL1SE_R8,
+        connected=True,
+    )
+    boxpool = cast(Any, backend_controller.boxpool)
+    pooled_boxes = vars(boxpool)["_boxes"]
+    original_box = pooled_boxes["A"][0]
+    synchronizer = Quel1SystemSynchronizer(backend_controller=backend_controller)
+
+    preview = synchronizer.preview_configure(
+        experiment_system=cast(Any, system),
+        box_ids=["A"],
+        mode="ge-cr-cr",
+        parallel=False,
+    )
+
+    assert pooled_boxes["A"][0] is original_box
+    assert _HardwareQuel1Box.config_calls == []
+    assert preview.changes[0].after == 11_000_000_000
+
+
+def test_preview_context_restores_quel1_box_after_exception() -> None:
+    """Preview context should restore the real box class after an exception."""
+    backend_controller, _ = _make_backend_controller(
+        backend_settings=_backend_settings(),
+        box_type=BoxType.QUEL1SE_R8,
+    )
+    context = Quel1BoxPreviewContext(
+        backend_controller=backend_controller,
+        backend_settings=_backend_settings(),
+        box_types={"A": BoxType.QUEL1SE_R8},
+    )
+
+    def _raise_inside_context() -> None:
+        with context:
+            assert Quel1Box is not _HardwareQuel1Box
+            raise RuntimeError("stop preview")
+
+    with pytest.raises(RuntimeError, match="stop preview"):
+        _raise_inside_context()
+
+    assert Quel1Box is _HardwareQuel1Box
+
+
+def test_preview_configure_reports_no_changes() -> None:
+    """Given matching hardware and config, preview should report no changes."""
+    preview = _preview(
+        experiment_system=_make_system(),
+        backend_settings=_backend_settings(),
+    )
+
+    assert preview.is_complete is True
+    assert preview.has_changes is False
+    assert preview.has_frequency_changes is False
+    assert preview.changes == ()
+    assert len(preview.entries) > 0
+    assert all(not entry.has_change for entry in preview.entries)
+
+
+def test_preview_configure_detects_frequency_changes() -> None:
+    """Given changed LO frequency, preview should mark frequency changes."""
+    preview = _preview(
+        experiment_system=_make_system(lo_freq=11_000_000_000),
+        backend_settings=_backend_settings(lo_freq=10_000_000_000),
+    )
+
+    assert preview.has_changes is True
+    assert preview.has_frequency_changes is True
+    assert preview.changes == (
+        ConfigureStateChange(
+            box_id="A",
+            component="port 1",
+            field="lo_freq",
+            before=10_000_000_000,
+            after=11_000_000_000,
+            unit="Hz",
+            is_frequency=True,
+        ),
+    )
+
+
+def test_preview_configure_before_uses_fetched_dump() -> None:
+    """Given changed CNCO frequency, preview before should use fetched hardware state."""
+    preview = _preview(
+        experiment_system=_make_system(cnco_freq=2_109_375_000),
+        backend_settings=_backend_settings(cnco_freq=2_320_312_500),
+    )
+
+    assert preview.changes == (
+        ConfigureStateChange(
+            box_id="A",
+            component="port 1",
+            field="cnco_freq",
+            before=2_320_312_500,
+            after=2_109_375_000,
+            unit="Hz",
+            is_frequency=True,
+        ),
+    )
+
+
+def test_preview_configure_detects_non_frequency_changes() -> None:
+    """Given changed RF switch, preview should not mark frequency changes."""
+    preview = _preview(
+        experiment_system=_make_system(rfswitch="pass"),
+        backend_settings=_backend_settings(rfswitch="block"),
+    )
+
+    assert preview.has_changes is True
+    assert preview.has_frequency_changes is False
+    assert preview.changes == (
+        ConfigureStateChange(
+            box_id="A",
+            component="port 1",
+            field="rfswitch",
+            before="block",
+            after="pass",
+            unit=None,
+            is_frequency=False,
+        ),
+    )
+
+
+def test_preview_configure_uses_effective_r8_generator_port_values() -> None:
+    """Given R8 non-mixer CTRL port VATT, preview should not report backend-ignored values."""
+    preview = _preview(
+        experiment_system=_make_system(
+            port_number=6,
+            lo_freq=10_000_000_000,
+            vatt=3072,
+            sideband="L",
+            fnco_freq=0,
+        ),
+        backend_settings=_backend_settings(
+            port_number=6,
+            lo_freq=None,
+            vatt=None,
+            sideband=None,
+            fnco_freq=0,
+        ),
+    )
+
+    assert preview.changes == ()
+
+
+def test_preview_configure_ignores_unspecified_fnco() -> None:
+    """Given planned FNCO is unspecified, preview should not show zero-to-blank changes."""
+    preview = _preview(
+        experiment_system=_make_system(fnco_freq=None),
+        backend_settings=_backend_settings(fnco_freq=0),
+    )
+
+    assert preview.changes == ()
+
+
+def test_preview_configure_ignores_unspecified_port_fields() -> None:
+    """Given a planned port field is unspecified, preview should preserve hardware."""
+    preview = _preview(
+        experiment_system=_make_system(
+            box_type=BoxType.QUEL1SE_A,
+            lo_freq=None,
+        ),
+        backend_settings=_backend_settings(lo_freq=10_000_000_000),
+    )
+
+    assert preview.changes == ()
+
+
+def test_preview_configure_marks_missing_fetch_incomplete() -> None:
+    """Given missing hardware fetch result, preview should be incomplete."""
+    preview = _preview(
+        experiment_system=_make_system(),
+        backend_settings={},
+    )
+
+    assert preview.is_complete is False
+    assert preview.missing_box_ids == ("A",)
+    assert preview.changes == ()
+
+
+@pytest.mark.parametrize(
+    ("box_type", "capture_port_number", "generator_port_number"),
+    [
+        (BoxType.QUEL1SE_A, 0, 1),
+        (BoxType.QUEL1SE_A, 5, 3),
+        (BoxType.QUEL1SE_A, 7, 8),
+        (BoxType.QUEL1SE_A, 12, 10),
+        (BoxType.QUEL1SE_B, 5, 3),
+        (BoxType.QUEL1SE_B, 12, 10),
+        (BoxType.QUEL1_A, 0, 1),
+        (BoxType.QUEL1_A, 5, 3),
+        (BoxType.QUEL1_A, 7, 8),
+        (BoxType.QUEL1_A, 12, 10),
+        (BoxType.QUEL1_B, 5, 2),
+        (BoxType.QUEL1_B, 12, 9),
+        (BoxType.QUEL1SE_R8, 0, 1),
+        (BoxType.QUBE_RIKEN_A, 1, 0),
+        (BoxType.QUBE_RIKEN_A, 4, 2),
+        (BoxType.QUBE_RIKEN_A, 12, 13),
+        (BoxType.QUBE_RIKEN_A, 9, 11),
+        (BoxType.QUBE_RIKEN_B, 4, 2),
+        (BoxType.QUBE_RIKEN_B, 9, 11),
+        (BoxType.QUBE_OU_A, 1, 0),
+        (BoxType.QUBE_OU_A, 12, 13),
+    ],
+)
+def test_preview_configure_uses_final_generator_lo_for_shared_resource(
+    box_type: BoxType,
+    capture_port_number: int,
+    generator_port_number: int,
+) -> None:
+    """Given a shared LO restored by a generator, preview should use its final value."""
+    system = _make_shared_system(
+        box_type=box_type,
+        ports=[
+            _make_port(
+                number=capture_port_number,
+                port_type=PortType.READ_IN,
+                lo_freq=9_000_000_000,
+            ),
+            _make_port(
+                number=generator_port_number,
+                port_type=PortType.CTRL,
+                lo_freq=11_000_000_000,
+            ),
+        ],
+    )
+
+    preview = _preview(
+        experiment_system=system,
+        backend_settings=_shared_backend_settings(
+            (capture_port_number, "in", 11_000_000_000, None),
+            (generator_port_number, "out", 11_000_000_000, None),
+        ),
+    )
+
+    assert preview.changes == ()
+    assert preview.has_frequency_changes is False
+
+
+def test_preview_configure_uses_last_capture_lo_for_shared_r8_resource() -> None:
+    """Given R8 monitor ports sharing an LO, preview should use the last capture write."""
+    system = _make_shared_system(
+        box_type=BoxType.QUEL1SE_R8,
+        ports=[
+            _make_port(
+                number=4,
+                port_type=PortType.MNTR_IN,
+                lo_freq=9_000_000_000,
+            ),
+            _make_port(
+                number=10,
+                port_type=PortType.MNTR_IN,
+                lo_freq=11_000_000_000,
+            ),
+        ],
+    )
+
+    preview = _preview(
+        experiment_system=system,
+        backend_settings=_shared_backend_settings(
+            (4, "in", 11_000_000_000, None),
+            (10, "in", 11_000_000_000, None),
+        ),
+    )
+
+    assert preview.changes == ()
+
+
+def test_preview_configure_reports_final_shared_lo_for_each_port() -> None:
+    """Given a changing shared LO, preview should retain rows for every logical port."""
+    system = _make_shared_system(
+        box_type=BoxType.QUBE_RIKEN_B,
+        ports=[
+            _make_port(
+                number=2,
+                port_type=PortType.CTRL,
+                lo_freq=11_000_000_000,
+            ),
+            _make_port(
+                number=4,
+                port_type=PortType.MNTR_IN,
+                lo_freq=None,
+            ),
+        ],
+    )
+
+    preview = _preview(
+        experiment_system=system,
+        backend_settings=_shared_backend_settings(
+            (2, "out", 10_000_000_000, None),
+            (4, "in", 10_000_000_000, None),
+        ),
+    )
+
+    assert preview.changes == (
+        ConfigureStateChange(
+            box_id="A",
+            component="port 2",
+            field="lo_freq",
+            before=10_000_000_000,
+            after=11_000_000_000,
+            unit="Hz",
+            is_frequency=True,
+        ),
+        ConfigureStateChange(
+            box_id="A",
+            component="port 4",
+            field="lo_freq",
+            before=10_000_000_000,
+            after=11_000_000_000,
+            unit="Hz",
+            is_frequency=True,
+        ),
+    )
+
+
+def test_preview_configure_normalizes_shared_rfswitch_values() -> None:
+    """Given a restored shared RF switch, preview should compare its final state."""
+    system = _make_shared_system(
+        box_type=BoxType.QUEL1SE_A,
+        ports=[
+            _make_port(
+                number=0,
+                port_type=PortType.READ_IN,
+                rfswitch="loop",
+            ),
+            _make_port(
+                number=1,
+                port_type=PortType.READ_OUT,
+                rfswitch="pass",
+            ),
+        ],
+    )
+
+    preview = _preview(
+        experiment_system=system,
+        backend_settings=_shared_backend_settings(
+            (0, "in", None, "open"),
+            (1, "out", None, "pass"),
+        ),
+    )
+
+    assert preview.changes == ()
+
+
+def test_preview_configure_reports_final_shared_rfswitch_for_each_port() -> None:
+    """Given a changing shared RF switch, preview should decode each logical port."""
+    system = _make_shared_system(
+        box_type=BoxType.QUEL1SE_A,
+        ports=[
+            _make_port(
+                number=0,
+                port_type=PortType.READ_IN,
+                rfswitch="open",
+            ),
+            _make_port(
+                number=1,
+                port_type=PortType.READ_OUT,
+                rfswitch="block",
+            ),
+        ],
+    )
+
+    preview = _preview(
+        experiment_system=system,
+        backend_settings=_shared_backend_settings(
+            (0, "in", None, "open"),
+            (1, "out", None, "pass"),
+        ),
+    )
+
+    assert preview.changes == (
+        ConfigureStateChange(
+            box_id="A",
+            component="port 0",
+            field="rfswitch",
+            before="open",
+            after="loop",
+            unit=None,
+            is_frequency=False,
+        ),
+        ConfigureStateChange(
+            box_id="A",
+            component="port 1",
+            field="rfswitch",
+            before="pass",
+            after="block",
+            unit=None,
+            is_frequency=False,
+        ),
+    )
+
+
+def test_preview_configure_ignores_unreported_rfswitch_state() -> None:
+    """Given a dump without RF switches, preview should not infer their changes."""
+    system = _make_shared_system(
+        box_type=BoxType.QUEL1_A,
+        ports=[
+            _make_port(
+                number=0,
+                port_type=PortType.READ_IN,
+                rfswitch="open",
+            ),
+            _make_port(
+                number=1,
+                port_type=PortType.READ_OUT,
+                rfswitch="pass",
+            ),
+        ],
+    )
+
+    preview = _preview(
+        experiment_system=system,
+        backend_settings=_shared_backend_settings(
+            (0, "in", None, None),
+            (1, "out", None, None),
+            include_rfswitch=False,
+        ),
+    )
+
+    assert preview.changes == ()

--- a/tests/system/test_quel1_configure_preview.py
+++ b/tests/system/test_quel1_configure_preview.py
@@ -239,7 +239,7 @@ def _make_backend_controller(
     *,
     backend_settings: dict[str, dict],
     box_type: BoxType,
-    connected: bool = False,
+    connected: bool = True,
 ) -> tuple[Quel1BackendController, _SystemConfigDatabaseStub]:
     database = _SystemConfigDatabaseStub(box_type=box_type)
     _HardwareQuel1Box.snapshots_by_ip = {
@@ -273,8 +273,8 @@ def _make_backend_controller(
     return Quel1BackendController(runtime_context=runtime_context), database
 
 
-def test_preview_configure_temporarily_replaces_quel1_box() -> None:
-    """Preview should configure a mock box and restore the real box class afterward."""
+def test_preview_configure_routes_configuration_away_from_hardware() -> None:
+    """Preview should configure only a mock of an already-connected box."""
     system = _make_system(lo_freq=11_000_000_000)
     backend_settings = _backend_settings(lo_freq=10_000_000_000)
     backend_controller, database = _make_backend_controller(
@@ -290,14 +290,71 @@ def test_preview_configure_temporarily_replaces_quel1_box() -> None:
         parallel=False,
     )
 
-    assert database.created_box_classes[0] is _HardwareQuel1Box
-    assert any(
-        box_class is not _HardwareQuel1Box
-        for box_class in database.created_box_classes[1:]
-    )
+    assert database.created_box_classes == []
     assert Quel1Box is _HardwareQuel1Box
     assert _HardwareQuel1Box.config_calls == []
     assert preview.changes[0].after == 11_000_000_000
+
+
+def test_preview_configure_rejects_disconnected_before_hardware_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preview should fail before fetching hardware when the backend is disconnected."""
+    system = _make_system()
+    backend_controller, _ = _make_backend_controller(
+        backend_settings=_backend_settings(),
+        box_type=BoxType.QUEL1SE_R8,
+        connected=False,
+    )
+    dump_calls: list[str] = []
+
+    def _dump_box(box_id: str) -> dict:
+        dump_calls.append(box_id)
+        return _backend_settings()[box_id]
+
+    monkeypatch.setattr(backend_controller, "dump_box", _dump_box)
+    synchronizer = Quel1SystemSynchronizer(backend_controller=backend_controller)
+
+    with pytest.raises(RuntimeError, match="requires all target boxes to be connected"):
+        synchronizer.preview_configure(
+            experiment_system=cast(Any, system),
+            box_ids=["A"],
+            mode="ge-cr-cr",
+            parallel=False,
+        )
+
+    assert dump_calls == []
+
+
+def test_preview_configure_rejects_box_missing_from_pool_before_hardware_fetch(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Preview should fail before fetching a target absent from the connected pool."""
+    system = _make_system()
+    backend_controller, _ = _make_backend_controller(
+        backend_settings=_backend_settings(),
+        box_type=BoxType.QUEL1SE_R8,
+    )
+    pooled_boxes = vars(backend_controller.boxpool)["_boxes"]
+    pooled_boxes.clear()
+    dump_calls: list[str] = []
+
+    def _dump_box(box_id: str) -> dict:
+        dump_calls.append(box_id)
+        return _backend_settings()[box_id]
+
+    monkeypatch.setattr(backend_controller, "dump_box", _dump_box)
+    synchronizer = Quel1SystemSynchronizer(backend_controller=backend_controller)
+
+    with pytest.raises(RuntimeError, match="missing from the connected pool: A"):
+        synchronizer.preview_configure(
+            experiment_system=cast(Any, system),
+            box_ids=["A"],
+            mode="ge-cr-cr",
+            parallel=False,
+        )
+
+    assert dump_calls == []
 
 
 def test_preview_configure_uses_hardware_sync_orchestration(


### PR DESCRIPTION
## Background

`Experiment.configure()` currently pushes hardware settings without a structured way to inspect the planned changes first. This adds a backend-owned preview path so users can inspect QuEL-1 box settings and QuEL-3 instrument definitions before applying configuration.

## Summary

- Add shared `ConfigurePreview` / `ConfigureStateChange` models with rich table summaries.
- Add QuEL-1 preview generation from fetched box dumps.
- Add QuEL-3 preview generation from fetched instrument snapshots and planned deployment requests.
- Delegate preview construction through backend synchronizers and expose `Experiment.preview_configure()` plus `configure(dry_run=True)`.
- Document the workflow in quickstart docs and v1.5.0 release notes.

## User Impact

- `Experiment.preview_configure()` returns a structured preview without mutating hardware or manager state.
- `Experiment.configure(dry_run=True)` prints a summary and skips push.
- QuEL-3 preview uses the active target scope so it matches what `configure()` would deploy.

## Compatibility

This is new preview behavior for the v1.5.0 surface. No migration is required.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest -q` (`1090 passed`)

## Notes

Docs build was not run; no navigation or generated API reference files were changed.