### PR TITLE
Add measurement probability accessors

### DIFF
--- a/src/qubex/measurement/models/measurement_result.py
+++ b/src/qubex/measurement/models/measurement_result.py
@@ -3,10 +3,15 @@
 from __future__ import annotations
 
 import warnings
+from collections import Counter
+from collections.abc import Collection
+from functools import reduce
+from itertools import product
 from pathlib import Path
-from typing import Any
+from typing import Any, TypeAlias, TypeGuard
 
 import numpy as np
+from numpy.typing import NDArray
 from pydantic import model_validator
 
 import qubex.visualization as viz
@@ -15,6 +20,20 @@ from qubex.core import DataModel
 from .capture_data import CaptureData
 from .classifier_ref import ClassifierRef
 from .measurement_config import MeasurementConfig
+
+TargetSpecifier: TypeAlias = str | tuple[str, int]
+TargetSelection: TypeAlias = TargetSpecifier | Collection[TargetSpecifier] | None
+_DEFAULT_CAPTURE_INDEX = -1
+
+
+def _is_target_capture_spec(value: object) -> TypeGuard[tuple[str, int]]:
+    """Return whether value is a `(target, capture_index)` selector."""
+    return (
+        isinstance(value, tuple)
+        and len(value) == 2
+        and isinstance(value[0], str)
+        and isinstance(value[1], int)
+    )
 
 
 class MeasurementResult(DataModel):
@@ -72,6 +91,230 @@ class MeasurementResult(DataModel):
         if len(inferred) > 0:
             object.__setattr__(self, "classifier_refs", inferred)
         return self
+
+    def _resolve_target_captures(
+        self,
+        targets: TargetSelection,
+    ) -> list[tuple[str, int]]:
+        """Normalize target/capture selection while preserving caller order."""
+        if len(self.data) == 0:
+            raise ValueError("No measurement data available.")
+        if targets is None:
+            selections: list[object] = list(self.data)
+        elif isinstance(targets, str) or _is_target_capture_spec(targets):
+            selections = [targets]
+        else:
+            selections = list(targets)
+        if len(selections) == 0:
+            raise ValueError("No targets were selected.")
+
+        target_captures: list[tuple[str, int]] = []
+        for selection in selections:
+            if isinstance(selection, str):
+                target_captures.append((selection, _DEFAULT_CAPTURE_INDEX))
+            elif _is_target_capture_spec(selection):
+                target_captures.append(selection)
+            else:
+                raise ValueError(
+                    "Target selection must be a target label or "
+                    "`(target, capture_index)` tuple."
+                )
+
+        missing_targets = [
+            target for target, _ in target_captures if target not in self.data
+        ]
+        if missing_targets:
+            joined = ", ".join(missing_targets)
+            raise ValueError(f"Targets not found in data: {joined}.")
+        return target_captures
+
+    def _resolve_targets(
+        self,
+        targets: TargetSelection,
+    ) -> list[str]:
+        """Normalize target selection and ignore capture indices."""
+        target_captures = self._resolve_target_captures(
+            targets,
+        )
+        target_list = [target for target, _ in target_captures]
+        return target_list
+
+    def _get_capture(self, target: str, capture_index: int) -> CaptureData:
+        """Return one capture for a target with a clear error on bad index."""
+        captures = self.data[target]
+        if len(captures) == 0:
+            raise ValueError(f"Target {target} has no capture data.")
+        try:
+            return captures[capture_index]
+        except IndexError as exc:
+            raise IndexError(
+                f"capture_index {capture_index} is out of range for target {target}."
+            ) from exc
+
+    def _get_state_series(
+        self,
+        target: str,
+        capture_index: int,
+    ) -> NDArray[np.int64]:
+        """Return classified state labels stored in a capture."""
+        capture = self._get_capture(target, capture_index)
+        state_series = capture.state_series
+        if state_series is None:
+            raise ValueError(
+                f"Capture for target {target} at index {capture_index} does not "
+                "contain state_series. Run measurement with state_classification=True."
+            )
+        return np.asarray(state_series, dtype=np.int64)
+
+    def get_classified_data(
+        self,
+        targets: TargetSelection = None,
+    ) -> NDArray[np.int64]:
+        """
+        Return classified state labels stacked by target.
+
+        For one target this returns shape ``(n_shots, 1)``. For multiple targets,
+        each row is one simultaneous shot and each column follows the requested
+        target order.
+        """
+        target_captures = self._resolve_target_captures(
+            targets,
+        )
+        state_series = [
+            self._get_state_series(target, selected_capture_index)
+            for target, selected_capture_index in target_captures
+        ]
+        shot_counts = {series.shape[0] for series in state_series}
+        if len(shot_counts) != 1:
+            raise ValueError(
+                "Selected targets have different classified shot counts: "
+                f"{sorted(shot_counts)}."
+            )
+        return np.asarray(np.column_stack(state_series), dtype=np.int64)
+
+    def get_memory(
+        self,
+        targets: TargetSelection = None,
+    ) -> list[str]:
+        """Return per-shot classified memory as bitstring labels."""
+        classified_data = self.get_classified_data(targets)
+        return ["".join(map(str, row)) for row in classified_data]
+
+    def get_counts(
+        self,
+        targets: TargetSelection = None,
+    ) -> Counter[str]:
+        """Return counts of classified bitstrings."""
+        return Counter(self.get_memory(targets))
+
+    def get_probabilities(
+        self,
+        targets: TargetSelection = None,
+    ) -> dict[str, float]:
+        """Return probabilities of classified bitstrings."""
+        counts = self.get_counts(targets)
+        total = sum(counts.values())
+        if total == 0:
+            return {}
+        return {key: count / total for key, count in counts.items()}
+
+    def get_standard_deviations(
+        self,
+        targets: TargetSelection = None,
+    ) -> dict[str, float]:
+        """Return binomial standard deviations for classified probabilities."""
+        counts = self.get_counts(targets)
+        total = sum(counts.values())
+        if total == 0:
+            return {}
+        probabilities = {key: count / total for key, count in counts.items()}
+        return {
+            key: float(np.sqrt(prob * (1.0 - prob) / total))
+            for key, prob in probabilities.items()
+        }
+
+    def _get_classifier_ref(self, target: str) -> ClassifierRef:
+        """Return classifier reference for a target."""
+        if self.classifier_refs is None or target not in self.classifier_refs:
+            raise ValueError(
+                f"Classifier reference for target {target} is not set. "
+                "Run measurement with classifier persistence or attach classifier_refs."
+            )
+        return self.classifier_refs[target]
+
+    def _get_classifier_state_count(self, target: str) -> int:
+        """Return number of classifier states for a target."""
+        return int(self._get_classifier_ref(target).load().n_states)
+
+    def get_basis_indices(
+        self,
+        targets: TargetSelection = None,
+    ) -> list[tuple[int, ...]]:
+        """Return basis index tuples for selected targets."""
+        target_list = self._resolve_targets(targets)
+        dimensions = [
+            self._get_classifier_state_count(target) for target in target_list
+        ]
+        return list(product(*[range(dimension) for dimension in dimensions]))
+
+    def get_basis_labels(
+        self,
+        targets: TargetSelection = None,
+    ) -> list[str]:
+        """Return basis labels for selected targets."""
+        return [
+            "".join(str(index) for index in basis)
+            for basis in self.get_basis_indices(targets)
+        ]
+
+    def get_confusion_matrix(
+        self,
+        targets: TargetSelection = None,
+    ) -> NDArray[np.float64]:
+        """Return row-normalized Kronecker-product confusion matrix."""
+        target_list = self._resolve_targets(targets)
+        confusion_matrices: list[NDArray[np.float64]] = []
+        for target in target_list:
+            matrix = np.asarray(
+                self._get_classifier_ref(target).load().confusion_matrix,
+                dtype=np.float64,
+            )
+            row_sums = matrix.sum(axis=1, keepdims=True)
+            normalized = np.divide(
+                matrix,
+                row_sums,
+                out=np.zeros_like(matrix, dtype=np.float64),
+                where=row_sums != 0,
+            )
+            confusion_matrices.append(normalized)
+        return np.asarray(reduce(np.kron, confusion_matrices), dtype=np.float64)
+
+    def get_inverse_confusion_matrix(
+        self,
+        targets: TargetSelection = None,
+    ) -> NDArray[np.float64]:
+        """Return inverse confusion matrix for selected targets."""
+        return np.asarray(
+            np.linalg.inv(self.get_confusion_matrix(targets)),
+            dtype=np.float64,
+        )
+
+    def get_mitigated_probabilities(
+        self,
+        targets: TargetSelection = None,
+    ) -> dict[str, float]:
+        """Return readout-error-mitigated probabilities for classified bitstrings."""
+        basis_labels = self.get_basis_labels(targets)
+        raw_probabilities = self.get_probabilities(targets)
+        raw = np.array(
+            [raw_probabilities.get(label, 0.0) for label in basis_labels],
+            dtype=float,
+        )
+        mitigated = raw @ self.get_inverse_confusion_matrix(targets)
+        return {
+            basis_label: float(mitigated[index])
+            for index, basis_label in enumerate(basis_labels)
+        }
 
     def plot(
         self,

--- a/src/qubex/measurement/models/sweep_measurement_result.py
+++ b/src/qubex/measurement/models/sweep_measurement_result.py
@@ -2,8 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Mapping
-from typing import Any, TypeAlias
+from collections.abc import Collection, Mapping
+from typing import TypeAlias
 
 import numpy as np
 from numpy.typing import NDArray
@@ -12,19 +12,52 @@ from pydantic import Field
 from qubex.core import DataModel, Value
 
 from .measurement_config import MeasurementConfig
-from .measurement_result import MeasurementResult
+from .measurement_result import MeasurementResult, TargetSelection
 
 SweepKey: TypeAlias = str
 SweepValue: TypeAlias = Value | int | float | str
 SweepPoint: TypeAlias = Mapping[SweepKey, SweepValue]
 SweepAxes: TypeAlias = tuple[SweepKey, ...]
+CaptureDataArray: TypeAlias = NDArray[np.generic]
+StateSeriesMap: TypeAlias = dict[str, NDArray[np.float64]]
+
+
+def _resolve_series_states(
+    values: list[dict[str, float]],
+    states: Collection[str] | None,
+) -> list[str]:
+    """Return state labels for series extraction."""
+    if states is None:
+        return sorted({state for point_values in values for state in point_values})
+    if isinstance(states, str):
+        raise TypeError("`states` must be a collection of state labels, not a string.")
+    state_list = list(states)
+    if len(state_list) == 0:
+        raise ValueError("No states were selected.")
+    return state_list
+
+
+def _build_series_map(
+    values: list[dict[str, float]],
+    *,
+    states: Collection[str] | None,
+) -> StateSeriesMap:
+    """Return selected state-value series from pointwise dictionaries."""
+    state_list = _resolve_series_states(values, states)
+    return {
+        state: np.asarray(
+            [point_values.get(state, 0.0) for point_values in values],
+            dtype=np.float64,
+        )
+        for state in state_list
+    }
 
 
 def _build_sweep_data(
     *,
     results: list[MeasurementResult],
     sweep_shape: tuple[int, ...],
-) -> dict[str, list[NDArray[Any]]]:
+) -> dict[str, list[CaptureDataArray]]:
     """Aggregate capture arrays as `target -> [capture_index arrays]` with sweep axes."""
     expected_points = int(np.prod(sweep_shape, dtype=int))
     if len(results) != expected_points:
@@ -36,7 +69,7 @@ def _build_sweep_data(
         return {}
 
     expected_capture_counts: dict[str, int] = {}
-    per_target_capture_series: dict[str, list[list[NDArray[Any]]]] = {}
+    per_target_capture_series: dict[str, list[list[CaptureDataArray]]] = {}
 
     for point_index, result in enumerate(results):
         result_targets = set(result.data)
@@ -63,7 +96,7 @@ def _build_sweep_data(
                     np.asarray(capture.data)
                 )
 
-    sweep_data: dict[str, list[NDArray[Any]]] = {}
+    sweep_data: dict[str, list[CaptureDataArray]] = {}
     for target, capture_series_list in per_target_capture_series.items():
         sweep_data[target] = []
         for capture_series in capture_series_list:
@@ -81,12 +114,63 @@ class SweepMeasurementResult(DataModel):
     results: list[MeasurementResult] = Field(default_factory=list)
 
     @property
-    def data(self) -> dict[str, list[NDArray[Any]]]:
+    def data(self) -> dict[str, list[CaptureDataArray]]:
         """Return `target -> [capture arrays]` with shape `(n_points, *capture_shape)`."""
         return _build_sweep_data(
             results=self.results,
             sweep_shape=(len(self.sweep_values),),
         )
+
+    def get_probabilities(
+        self,
+        targets: TargetSelection = None,
+    ) -> list[dict[str, float]]:
+        """Return pointwise classified bitstring probabilities."""
+        return [result.get_probabilities(targets) for result in self.results]
+
+    def get_probability_series_map(
+        self,
+        targets: TargetSelection = None,
+        *,
+        states: Collection[str] | None = None,
+    ) -> StateSeriesMap:
+        """Return classified bitstring probability series for selected states."""
+        probabilities = self.get_probabilities(targets)
+        return _build_series_map(probabilities, states=states)
+
+    def get_standard_deviations(
+        self,
+        targets: TargetSelection = None,
+    ) -> list[dict[str, float]]:
+        """Return pointwise binomial standard deviations."""
+        return [result.get_standard_deviations(targets) for result in self.results]
+
+    def get_standard_deviation_series_map(
+        self,
+        targets: TargetSelection = None,
+        *,
+        states: Collection[str] | None = None,
+    ) -> StateSeriesMap:
+        """Return classified bitstring standard-deviation series for selected states."""
+        standard_deviations = self.get_standard_deviations(targets)
+        return _build_series_map(standard_deviations, states=states)
+
+    def get_mitigated_probabilities(
+        self,
+        targets: TargetSelection = None,
+    ) -> list[dict[str, float]]:
+        """Return pointwise readout-error-mitigated bitstring probabilities."""
+        return [result.get_mitigated_probabilities(targets) for result in self.results]
+
+    def get_mitigated_probability_series_map(
+        self,
+        targets: TargetSelection = None,
+        *,
+        states: Collection[str] | None = None,
+    ) -> StateSeriesMap:
+        """Return mitigated bitstring probability series for selected states."""
+        probabilities = self.get_mitigated_probabilities(targets)
+        return _build_series_map(probabilities, states=states)
 
 
 class NDSweepMeasurementResult(DataModel):
@@ -99,7 +183,7 @@ class NDSweepMeasurementResult(DataModel):
     results: list[MeasurementResult] = Field(default_factory=list)
 
     @property
-    def data(self) -> dict[str, list[NDArray[Any]]]:
+    def data(self) -> dict[str, list[CaptureDataArray]]:
         """Return `target -> [capture arrays]` with shape `(*shape, *capture_shape)`."""
         return _build_sweep_data(
             results=self.results,

--- a/tests/measurement/test_measurement_result_model.py
+++ b/tests/measurement/test_measurement_result_model.py
@@ -20,6 +20,7 @@ from qubex.measurement.models import (
     MeasurementConfig,
     MeasurementResult,
     ReturnItem,
+    SweepMeasurementResult,
 )
 from qubex.measurement.models.measure_result import (
     MeasureData,
@@ -102,6 +103,78 @@ def _make_capture(
         sampling_period=sampling_period,
         classifier_ref=classifier_ref,
     )
+
+
+def _make_classified_config(*, shots: int = 4) -> MeasurementConfig:
+    return MeasurementConfig(
+        n_shots=shots,
+        shot_interval=100.0,
+        shot_averaging=False,
+        time_integration=True,
+        state_classification=True,
+        return_items=(ReturnItem.IQ_SERIES, ReturnItem.STATE_SERIES),
+    )
+
+
+def _make_classified_capture(
+    *,
+    target: str,
+    states: np.ndarray,
+    measurement_config: MeasurementConfig,
+    classifier_ref: ClassifierRef | None = None,
+) -> CaptureData:
+    return CaptureData(
+        target=target,
+        config=measurement_config,
+        payload=CapturePayload(
+            iq_series=np.zeros(len(states), dtype=np.complex128),
+            state_series=states,
+        ),
+        sampling_period=0.4,
+        classifier_ref=classifier_ref,
+    )
+
+
+def _make_classified_result(
+    *,
+    q00_states: np.ndarray | None = None,
+    q01_states: np.ndarray | None = None,
+    classifier_refs: dict[str, ClassifierRef] | None = None,
+) -> MeasurementResult:
+    q00 = np.array([0, 0, 1, 1], dtype=np.int64) if q00_states is None else q00_states
+    q01 = np.array([0, 1, 0, 1], dtype=np.int64) if q01_states is None else q01_states
+    config = _make_classified_config(shots=len(q00))
+    return MeasurementResult(
+        data={
+            "Q00": [
+                _make_classified_capture(
+                    target="Q00",
+                    states=q00,
+                    measurement_config=config,
+                    classifier_ref=(classifier_refs or {}).get("Q00"),
+                )
+            ],
+            "Q01": [
+                _make_classified_capture(
+                    target="Q01",
+                    states=q01,
+                    measurement_config=config,
+                    classifier_ref=(classifier_refs or {}).get("Q01"),
+                )
+            ],
+        },
+        measurement_config=config,
+        classifier_refs=classifier_refs,
+    )
+
+
+class _FakeClassifier:
+    def __init__(self, confusion_matrix: np.ndarray) -> None:
+        self.confusion_matrix = confusion_matrix
+
+    @property
+    def n_states(self) -> int:
+        return int(self.confusion_matrix.shape[0])
 
 
 def test_to_multiple_measure_result_returns_wrapped_result() -> None:
@@ -197,6 +270,168 @@ def test_measurement_result_repr_includes_targets_counts_and_config() -> None:
     assert "shot_averaging=False" in text
     assert "time_integration=False" in text
     assert "state_classification=True" in text
+
+
+def test_measurement_result_probabilities_return_joint_bitstrings() -> None:
+    """Canonical result should aggregate classified state_series as bitstrings."""
+    result = _make_classified_result()
+
+    single_target = result.get_probabilities("Q00")
+    joint = result.get_probabilities(["Q00", "Q01"])
+
+    assert single_target == {"0": 0.5, "1": 0.5}
+    assert joint == {"00": 0.25, "01": 0.25, "10": 0.25, "11": 0.25}
+
+
+def test_measurement_result_probabilities_select_per_target_capture_indices() -> None:
+    """Target selection should allow capture-index selection per target."""
+    config = _make_classified_config()
+    result = MeasurementResult(
+        data={
+            "Q00": [
+                _make_classified_capture(
+                    target="Q00",
+                    states=np.array([0, 0, 1, 1], dtype=np.int64),
+                    measurement_config=config,
+                ),
+                _make_classified_capture(
+                    target="Q00",
+                    states=np.array([1, 1, 1, 1], dtype=np.int64),
+                    measurement_config=config,
+                ),
+            ],
+            "Q01": [
+                _make_classified_capture(
+                    target="Q01",
+                    states=np.array([0, 0, 0, 0], dtype=np.int64),
+                    measurement_config=config,
+                ),
+                _make_classified_capture(
+                    target="Q01",
+                    states=np.array([0, 1, 0, 1], dtype=np.int64),
+                    measurement_config=config,
+                ),
+            ],
+        },
+        measurement_config=config,
+    )
+
+    common_capture = result.get_probabilities([("Q00", 0), ("Q01", 0)])
+    mixed_capture = result.get_probabilities([("Q00", 0), ("Q01", 1)])
+
+    assert common_capture == {"00": 0.5, "10": 0.5}
+    assert mixed_capture == {
+        "00": 0.25,
+        "01": 0.25,
+        "10": 0.25,
+        "11": 0.25,
+    }
+
+
+def test_measurement_result_counts_and_standard_deviations_use_total_shots() -> None:
+    """Standard deviations should use the selected shot count, not per-state counts."""
+    result = _make_classified_result()
+
+    counts = result.get_counts(["Q00", "Q01"])
+    standard_deviations = result.get_standard_deviations(["Q00", "Q01"])
+
+    assert counts == {"00": 1, "01": 1, "10": 1, "11": 1}
+    assert standard_deviations["00"] == pytest.approx(np.sqrt(0.25 * 0.75 / 4))
+
+
+def test_measurement_result_probabilities_require_state_series() -> None:
+    """Probability accessors should fail clearly when classified labels are absent."""
+    config = _make_config(mode="single", shots=2, time_integration=True)
+    result = MeasurementResult(
+        data={
+            "Q00": [
+                _make_capture(
+                    target="Q00",
+                    raw=np.array([1.0 + 0.0j, 2.0 + 0.0j]),
+                    measurement_config=config,
+                    sampling_period=0.4,
+                )
+            ]
+        },
+        measurement_config=config,
+    )
+
+    with pytest.raises(ValueError, match="does not contain state_series"):
+        result.get_probabilities("Q00")
+
+
+def test_measurement_result_mitigated_probabilities_use_classifier_refs(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mitigated probabilities should use classifier_refs and preserve basis order."""
+    refs = {
+        "Q00": ClassifierRef(path="unused-q00.pkl"),
+        "Q01": ClassifierRef(path="unused-q01.pkl"),
+    }
+    result = _make_classified_result(classifier_refs=refs)
+
+    def _load(ref: ClassifierRef) -> _FakeClassifier:
+        _ = ref
+        return _FakeClassifier(np.eye(2, dtype=float))
+
+    monkeypatch.setattr(ClassifierRef, "load", _load)
+
+    assert result.get_basis_labels(["Q00", "Q01"]) == ["00", "01", "10", "11"]
+    assert result.get_mitigated_probabilities(["Q00", "Q01"]) == {
+        "00": 0.25,
+        "01": 0.25,
+        "10": 0.25,
+        "11": 0.25,
+    }
+
+
+def test_sweep_measurement_result_probability_series_map_selects_states() -> None:
+    """Sweep result should expose pointwise joint-probability series for plotting."""
+    first = _make_classified_result()
+    second = _make_classified_result(
+        q00_states=np.array([1, 1, 1, 0], dtype=np.int64),
+        q01_states=np.array([1, 1, 0, 0], dtype=np.int64),
+    )
+    sweep = SweepMeasurementResult(
+        sweep_values=[0.1, 0.2],
+        config=first.measurement_config,
+        results=[first, second],
+    )
+
+    all_probabilities = sweep.get_probabilities(["Q00", "Q01"])
+    probabilities = sweep.get_probability_series_map(
+        ["Q00", "Q01"],
+        states=["01", "11"],
+    )
+    standard_deviations = sweep.get_standard_deviation_series_map(
+        ["Q00", "Q01"],
+        states=["01", "11"],
+    )
+
+    assert all_probabilities[0]["11"] == 0.25
+    assert list(probabilities) == ["01", "11"]
+    np.testing.assert_allclose(probabilities["01"], np.array([0.25, 0.0]))
+    np.testing.assert_allclose(probabilities["11"], np.array([0.25, 0.5]))
+    np.testing.assert_allclose(
+        standard_deviations["11"],
+        np.array([np.sqrt(0.25 * 0.75 / 4), np.sqrt(0.5 * 0.5 / 4)]),
+    )
+
+
+def test_sweep_measurement_result_probability_series_map_validates_states() -> None:
+    """Series-map accessors should require a collection of state labels."""
+    result = _make_classified_result()
+    sweep = SweepMeasurementResult(
+        sweep_values=[0.1],
+        config=result.measurement_config,
+        results=[result],
+    )
+
+    with pytest.raises(TypeError, match="not a string"):
+        sweep.get_probability_series_map(["Q00", "Q01"], states="11")
+
+    with pytest.raises(ValueError, match="No states"):
+        sweep.get_probability_series_map(["Q00", "Q01"], states=[])
 
 
 def test_to_measure_result_propagates_sampling_period() -> None:


### PR DESCRIPTION
## Summary

- add classified-state probability/count/standard-deviation accessors to canonical `MeasurementResult`
- add sweep-level pointwise probability accessors plus plot-friendly `*_series_map(..., states=[...])` helpers
- support joint bitstring probabilities for multi-target measurements, including per-target capture selection via `(target, capture_index)`
- cover joint bitstring semantics, readout mitigation via `classifier_refs`, total-shot standard deviations, and sweep series extraction in tests

## Notes

`MeasurementResult.get_probabilities(targets)` follows the intended measurement-result semantics: a single target returns labels such as `"0"` and `"1"`; multiple targets return joint bitstrings such as `"00"`, `"01"`, `"10"`, and `"11"` in the requested target order.

`SweepMeasurementResult.get_probabilities(...)` returns per-point dictionaries. Plot-friendly arrays are exposed through `get_probability_series_map(..., states=["11"])` and `get_mitigated_probability_series_map(..., states=["11"])`, keeping the pointwise API and array API separate.

## Validation

- `UV_PROJECT_ENVIRONMENT=/Users/amachino/projects/paper-bswap-exp/.venv make check`
- `UV_PROJECT_ENVIRONMENT=/Users/amachino/projects/paper-bswap-exp/.venv uv run pytest -q`
- GitHub Actions on PR #326: Python 3.10, 3.11, and 3.12 passed
