### PR TITLE
Fix legacy measurement statistics normalization

### DIFF
--- a/src/qubex/measurement/models/measure_result.py
+++ b/src/qubex/measurement/models/measure_result.py
@@ -32,6 +32,15 @@ from .measurement_record import MeasurementRecord
 logger = logging.getLogger(__name__)
 
 
+def _normalize_confusion_matrix_rows(matrix: NDArray) -> NDArray[np.float64]:
+    """Normalize a confusion matrix as P(measured state | prepared state)."""
+    confusion_matrix = np.asarray(matrix, dtype=float)
+    row_totals = confusion_matrix.sum(axis=1, keepdims=True)
+    if np.any(row_totals == 0):
+        raise ValueError("Confusion matrix contains a prepared state with no shots.")
+    return confusion_matrix / row_totals
+
+
 def _format_raw_preview(raw: NDArray) -> str:
     """Return compact repr text for a raw array."""
     array = np.asarray(raw)
@@ -179,9 +188,9 @@ class MeasureData:
         """Return the normalized confusion matrix."""
         if self.mode == MeasureMode.SINGLE:
             if self.classifier is not None:
-                cm = self.classifier.confusion_matrix
-                n_shots = cm[0].sum()
-                return cm / n_shots
+                return _normalize_confusion_matrix_rows(
+                    self.classifier.confusion_matrix
+                )
             else:
                 raise ValueError("Classifier is not set")
         else:
@@ -619,15 +628,12 @@ class MeasureResult:
         if len(self.data) == 0:
             raise ValueError("No classification data available")
         counts = self.get_counts(targets, threshold=threshold)
-        probs = self.get_probabilities(targets, threshold=threshold)
+        total = sum(counts.values())
+        if total == 0:
+            return {}
         return {
-            key: np.sqrt(prob * (1 - prob) / total)
-            for key, prob, total in zip(
-                counts.keys(),
-                probs.values(),
-                counts.values(),
-                strict=True,
-            )
+            key: np.sqrt((count / total) * (1 - count / total) / total)
+            for key, count in counts.items()
         }
 
     def get_classifier(self, target: str) -> StateClassifier:
@@ -1221,15 +1227,12 @@ class MultipleMeasureResult:
         if len(self.data) == 0:
             raise ValueError("No classification data available")
         counts = self.get_counts(targets, threshold=threshold)
-        probs = self.get_probabilities(targets, threshold=threshold)
+        total = sum(counts.values())
+        if total == 0:
+            return {}
         return {
-            key: np.sqrt(prob * (1 - prob) / total)
-            for key, prob, total in zip(
-                counts.keys(),
-                probs.values(),
-                counts.values(),
-                strict=True,
-            )
+            key: np.sqrt((count / total) * (1 - count / total) / total)
+            for key, count in counts.items()
         }
 
     def get_classifier(self, target: str) -> StateClassifier:

--- a/src/qubex/measurement/services/measurement_classification_service.py
+++ b/src/qubex/measurement/services/measurement_classification_service.py
@@ -6,13 +6,13 @@ from collections.abc import Collection
 from functools import reduce
 
 import numpy as np
-import numpy.typing as npt
+from numpy.typing import NDArray
 
 from qubex.measurement.classifiers.state_classifier import StateClassifier
 from qubex.typing import TargetMap
 
 
-def _normalize_confusion_matrix_rows(matrix: npt.NDArray) -> npt.NDArray:
+def _normalize_confusion_matrix_rows(matrix: NDArray) -> NDArray[np.float64]:
     """Normalize a confusion matrix as P(measured state | prepared state)."""
     confusion_matrix = np.asarray(matrix, dtype=float)
     row_totals = confusion_matrix.sum(axis=1, keepdims=True)
@@ -43,7 +43,7 @@ class MeasurementClassificationService:
     def get_confusion_matrix(
         self,
         targets: Collection[str],
-    ) -> npt.NDArray:
+    ) -> NDArray[np.float64]:
         """
         Return the combined confusion matrix for targets.
 
@@ -67,7 +67,7 @@ class MeasurementClassificationService:
     def get_inverse_confusion_matrix(
         self,
         targets: Collection[str],
-    ) -> npt.NDArray:
+    ) -> NDArray[np.float64]:
         """
         Return the inverse combined confusion matrix.
 

--- a/src/qubex/measurement/services/measurement_classification_service.py
+++ b/src/qubex/measurement/services/measurement_classification_service.py
@@ -12,6 +12,15 @@ from qubex.measurement.classifiers.state_classifier import StateClassifier
 from qubex.typing import TargetMap
 
 
+def _normalize_confusion_matrix_rows(matrix: npt.NDArray) -> npt.NDArray:
+    """Normalize a confusion matrix as P(measured state | prepared state)."""
+    confusion_matrix = np.asarray(matrix, dtype=float)
+    row_totals = confusion_matrix.sum(axis=1, keepdims=True)
+    if np.any(row_totals == 0):
+        raise ValueError("Confusion matrix contains a prepared state with no shots.")
+    return confusion_matrix / row_totals
+
+
 class MeasurementClassificationService:
     """Manage classifiers and confusion-matrix helpers for measurement APIs."""
 
@@ -52,8 +61,7 @@ class MeasurementClassificationService:
         confusion_matrices = []
         for target in target_list:
             cm = self.classifiers[target].confusion_matrix
-            n_shots = cm[0].sum()
-            confusion_matrices.append(cm / n_shots)
+            confusion_matrices.append(_normalize_confusion_matrix_rows(cm))
         return reduce(np.kron, confusion_matrices)
 
     def get_inverse_confusion_matrix(

--- a/tests/measurement/test_measurement_classification_service.py
+++ b/tests/measurement/test_measurement_classification_service.py
@@ -29,8 +29,8 @@ def test_update_classifiers_merges_mapping() -> None:
 
 def test_get_confusion_matrix_returns_kron_product() -> None:
     """Given per-target matrices, when querying confusion matrix, then normalized Kronecker product is returned."""
-    cm_q00 = np.array([[8.0, 2.0], [1.0, 9.0]])
-    cm_q01 = np.array([[6.0, 4.0], [3.0, 7.0]])
+    cm_q00 = np.array([[8.0, 2.0], [1.0, 4.0]])
+    cm_q01 = np.array([[6.0, 4.0], [3.0, 3.0]])
     service = MeasurementClassificationService(
         classifiers={
             "Q00": cast(Any, _classifier_with_matrix(cm_q00)),
@@ -40,18 +40,21 @@ def test_get_confusion_matrix_returns_kron_product() -> None:
 
     result = service.get_confusion_matrix(["Q00", "Q01"])
 
-    expected = np.kron(cm_q00 / cm_q00[0].sum(), cm_q01 / cm_q01[0].sum())
+    expected = np.kron(
+        cm_q00 / cm_q00.sum(axis=1, keepdims=True),
+        cm_q01 / cm_q01.sum(axis=1, keepdims=True),
+    )
     assert np.allclose(result, expected)
 
 
 def test_get_inverse_confusion_matrix_returns_inverse() -> None:
     """Given target list, when querying inverse confusion matrix, then matrix inverse is returned."""
-    cm_q00 = np.array([[9.0, 1.0], [1.0, 9.0]])
+    cm_q00 = np.array([[9.0, 1.0], [1.0, 4.0]])
     service = MeasurementClassificationService(
         classifiers={"Q00": cast(Any, _classifier_with_matrix(cm_q00))},
     )
 
     result = service.get_inverse_confusion_matrix(["Q00"])
 
-    expected = np.linalg.inv(cm_q00 / cm_q00[0].sum())
+    expected = np.linalg.inv(cm_q00 / cm_q00.sum(axis=1, keepdims=True))
     assert np.allclose(result, expected)

--- a/tests/measurement/test_measurement_result.py
+++ b/tests/measurement/test_measurement_result.py
@@ -7,6 +7,7 @@ import warnings
 import numpy as np
 
 from qubex.measurement import MeasureData, MeasureMode, MeasureResult
+from qubex.measurement.models.measure_result import MultipleMeasureResult
 
 
 def test_legacy_measure_models_do_not_warn_on_init(dummy_classifier) -> None:
@@ -42,6 +43,63 @@ def test_measure_data_counts_and_probabilities(dummy_classifier):
     assert set(counts.keys()) <= {"0", "1"}
     assert np.isclose(sum(probs), 1.0)
     assert len(data.standard_deviations) == len(probs)
+
+
+def test_measure_data_confusion_matrix_normalizes_each_prepared_state(
+    dummy_classifier,
+):
+    """MeasureData should normalize confusion matrices row by row."""
+    dummy_classifier.confusion_matrix = np.array([[8, 2], [3, 3]])
+    data = MeasureData(
+        target="Q00",
+        mode=MeasureMode.SINGLE,
+        raw=np.array([[0.0 + 0.0j]]),
+        classifier=dummy_classifier,
+    )
+
+    assert np.allclose(data.confusion_matrix, np.array([[0.8, 0.2], [0.5, 0.5]]))
+
+
+def test_measure_result_standard_deviations_use_total_shots(dummy_classifier):
+    """MeasureResult should compute bitstring standard deviations with total shots."""
+    raw = np.array([0.0 + 0.0j, 1.0 + 0.0j, 1.0 + 0.0j, 1.0 + 0.0j])[:, None]
+    data = MeasureData(
+        target="Q00",
+        mode=MeasureMode.SINGLE,
+        raw=raw,
+        classifier=dummy_classifier,
+    )
+    result = MeasureResult(mode=MeasureMode.SINGLE, data={"Q00": data}, config={})
+
+    standard_deviations = result.get_standard_deviations()
+
+    expected = np.sqrt(0.25 * 0.75 / 4)
+    assert standard_deviations["0"] == expected
+    assert standard_deviations["1"] == expected
+
+
+def test_multiple_measure_result_standard_deviations_use_total_shots(
+    dummy_classifier,
+):
+    """MultipleMeasureResult should compute bitstring standard deviations with total shots."""
+    raw = np.array([0.0 + 0.0j, 1.0 + 0.0j, 1.0 + 0.0j, 1.0 + 0.0j])[:, None]
+    data = MeasureData(
+        target="Q00",
+        mode=MeasureMode.SINGLE,
+        raw=raw,
+        classifier=dummy_classifier,
+    )
+    result = MultipleMeasureResult(
+        mode=MeasureMode.SINGLE,
+        data={"Q00": [data]},
+        config={},
+    )
+
+    standard_deviations = result.get_standard_deviations()
+
+    expected = np.sqrt(0.25 * 0.75 / 4)
+    assert standard_deviations["0"] == expected
+    assert standard_deviations["1"] == expected
 
 
 def test_measure_data_threshold_classification(dummy_classifier):


### PR DESCRIPTION
## Summary

- Fix legacy `MeasureResult` and `MultipleMeasureResult` bitstring standard deviations to use total kept shots instead of per-state counts.
- Normalize legacy confusion matrices row by row as `P(measured state | prepared state)`.
- Apply the same row normalization to `MeasurementClassificationService` so `exp.get_confusion_matrix()` stays consistent with `MeasureResult` helpers.
- Add regression tests with unequal state counts / unequal confusion-matrix row totals so the old behavior is caught.

## Validation

- `UV_PROJECT_ENVIRONMENT=/Users/amachino/projects/paper-bswap-exp/.venv make check`
- `UV_PROJECT_ENVIRONMENT=/Users/amachino/projects/paper-bswap-exp/.venv uv run pytest -q`