### PR TITLE
[codex] fix: preserve nested Pydantic arrays as NetCDF variables

### DIFF
--- a/packages/qxcore/src/qxcore/serialization/netcdf_serializer.py
+++ b/packages/qxcore/src/qxcore/serialization/netcdf_serializer.py
@@ -248,7 +248,7 @@ def _encode_value(
         return {_VARIABLE_REF_KEY: ref}
     if isinstance(value, BaseModel):
         return _encode_value(
-            value.model_dump(mode="python"),
+            _base_model_field_data(value),
             arrays,
             path=path,
         )
@@ -262,6 +262,14 @@ def _encode_value(
             for idx, v in enumerate(value)
         ]
     return serialize_value(value)
+
+
+def _base_model_field_data(value: BaseModel) -> dict[str, Any]:
+    """Return raw Pydantic model field values for recursive NetCDF encoding."""
+    return {
+        field_name: getattr(value, field_name)
+        for field_name in value.__class__.model_fields
+    }
 
 
 def _decode_value(value: Any, ds: Dataset) -> Any:

--- a/tests/measurement/test_measurement_result_model.py
+++ b/tests/measurement/test_measurement_result_model.py
@@ -324,6 +324,72 @@ def test_netcdf_roundtrip_preserves_capture_data(tmp_path) -> None:
     assert restored.data["Q01"][0].sampling_period == pytest.approx(1.0)
 
 
+def test_netcdf_writes_nested_capture_payload_as_variables(tmp_path) -> None:
+    """Given nested capture arrays, NetCDF save should store arrays as variables."""
+    config = _make_config(mode="single", shots=4, time_integration=True)
+    result = MeasurementResult(
+        data={
+            "Q00": [
+                _make_capture(
+                    target="Q00",
+                    raw=np.array([1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 6.0j, 7.0 + 8.0j]),
+                    measurement_config=config,
+                    sampling_period=2.0,
+                )
+            ]
+        },
+        measurement_config=config,
+    )
+
+    path = result.save_netcdf(tmp_path / "measurement_result.nc")
+
+    with Dataset(path, mode="r", auto_complex=True) as ds:
+        assert "data_Q00_i0_payload_iq_series" in ds.variables
+        assert ds.variables["data_Q00_i0_payload_iq_series"].shape == (4,)
+        payload = json.loads(ds.getncattr("payload_json"))
+
+    variable_ref = payload["data"]["Q00"][0]["payload"]["iq_series"]["__variable__"]
+    assert variable_ref["name"] == "data_Q00_i0_payload_iq_series"
+    assert variable_ref["shape"] == [4]
+
+
+def test_load_netcdf_reads_payload_json_only_measurement_result(tmp_path) -> None:
+    """Given legacy payload-only NetCDF, load_netcdf should restore capture arrays."""
+    config = _make_config(mode="single", shots=4, time_integration=True)
+    original = MeasurementResult(
+        data={
+            "Q00": [
+                _make_capture(
+                    target="Q00",
+                    raw=np.array([1.0 + 2.0j, 3.0 + 4.0j, 5.0 + 6.0j, 7.0 + 8.0j]),
+                    measurement_config=config,
+                    sampling_period=2.0,
+                )
+            ]
+        },
+        measurement_config=config,
+    )
+    payload = original.model_dump(mode="python")
+    payload["__meta__"] = {
+        "format": original.format_name,
+        "version": original.format_version,
+    }
+    path = tmp_path / "legacy_payload_only.nc"
+
+    with Dataset(path, mode="w", format="NETCDF4", auto_complex=True) as ds:
+        ds.setncattr("format", original.format_name)
+        ds.setncattr("format_version", original.format_version)
+        ds.setncattr(
+            "model_class",
+            f"{original.__class__.__module__}.{original.__class__.__name__}",
+        )
+        ds.setncattr("payload_json", json.dumps(payload, ensure_ascii=False))
+
+    restored = MeasurementResult.load_netcdf(path)
+
+    assert np.array_equal(restored.data["Q00"][0].data, original.data["Q00"][0].data)
+
+
 def test_save_writes_netcdf_file(tmp_path) -> None:
     """Given save(), when called, then it writes a readable NetCDF file."""
     config = _make_config(mode="avg", shots=2)


### PR DESCRIPTION
## Background

NetCDF encoding for nested Pydantic models used model_dump(mode="python") before recursively encoding fields. For measurement capture payloads, that eagerly converted nested arrays into JSON-ready values before the NetCDF serializer could lift them into variables.

## Summary

- Encode BaseModel instances from their raw Pydantic field values during NetCDF serialization.
- Preserve nested ndarray payloads so capture arrays are stored as NetCDF variables with payload JSON variable references.
- Add regression coverage for nested capture payload variable storage.
- Add compatibility coverage for loading legacy payload-json-only NetCDF measurement results.

## Impact

MeasurementResult NetCDF files now store nested capture payload arrays in NetCDF variables instead of leaving those arrays embedded in payload_json. Public restoration remains through MeasurementResult.load() / load_netcdf().

## Compatibility

Existing payload-json-only NetCDF files remain loadable. No user migration is required. A docs-sync audit found the existing user-guide contract still accurate because it tells users to rely on the DataModel loader rather than internal variable names; only optional wording clarification remains possible.

## Validation

- uv run ruff check --fix: passed
- uv run ruff format: passed, reformatted netcdf_serializer.py
- uv run pyright: passed
- uv run pytest tests/measurement/test_measurement_result_model.py: 47 passed
- uv run pytest: 1070 passed