### PR TITLE
Replace thermal excitation helper with calibrated ef-pulse method

### DIFF
--- a/src/qubex/contrib/__init__.py
+++ b/src/qubex/contrib/__init__.py
@@ -110,7 +110,7 @@ from .experiment.superconducting_gap import (
     get_superconducting_gap,
 )
 from .experiment.thermal_excitation_characterization import (
-    thermal_excitation_via_rabi,
+    measure_thermal_excitation,
 )
 
 __all__ = [
@@ -163,6 +163,7 @@ __all__ = [
     "measure_cr_crosstalk",
     "measure_ghz_state",
     "measure_graph_state",
+    "measure_thermal_excitation",
     "measurement_induced_decay_experiment",
     "measurement_induced_dephasing",
     "measurement_induced_dephasing_experiment",
@@ -187,6 +188,5 @@ __all__ = [
     "stark_ramsey_experiment",
     "stark_t1_experiment",
     "sweep_readout_snr",
-    "thermal_excitation_via_rabi",
     "visualize_graph",
 ]

--- a/src/qubex/contrib/experiment/__init__.py
+++ b/src/qubex/contrib/experiment/__init__.py
@@ -92,7 +92,7 @@ from .simultaneous_qubit_spectroscopy import simultaneous_qubit_spectroscopy
 from .stark_characterization import stark_ramsey_experiment, stark_t1_experiment
 from .superconducting_gap import get_resistance_charge, get_superconducting_gap
 from .thermal_excitation_characterization import (
-    thermal_excitation_via_rabi,
+    measure_thermal_excitation,
 )
 
 __all__ = [
@@ -144,6 +144,7 @@ __all__ = [
     "measure_cr_crosstalk",
     "measure_ghz_state",
     "measure_graph_state",
+    "measure_thermal_excitation",
     "measurement_induced_decay_experiment",
     "measurement_induced_dephasing",
     "measurement_induced_dephasing_experiment",
@@ -168,6 +169,5 @@ __all__ = [
     "stark_ramsey_experiment",
     "stark_t1_experiment",
     "sweep_readout_snr",
-    "thermal_excitation_via_rabi",
     "visualize_graph",
 ]

--- a/src/qubex/contrib/experiment/thermal_excitation_characterization.py
+++ b/src/qubex/contrib/experiment/thermal_excitation_characterization.py
@@ -34,6 +34,7 @@ def measure_thermal_excitation(
     plot : bool, optional
         Whether to plot figures.
     """
+    qubit = exp.ctx.resolve_qubit_label(target)
     ge_label = exp.ctx.resolve_ge_label(target)
     ef_label = exp.ctx.resolve_ef_label(target)
 
@@ -83,10 +84,10 @@ def measure_thermal_excitation(
         plot=plot,
     )
 
-    iq_sig_0 = result_sig_0.data[target].kerneled
-    iq_sig_1 = result_sig_1.data[target].kerneled
-    iq_ref_0 = result_ref_0.data[target].kerneled
-    iq_ref_1 = result_ref_1.data[target].kerneled
+    iq_sig_0 = result_sig_0.data[qubit].kerneled
+    iq_sig_1 = result_sig_1.data[qubit].kerneled
+    iq_ref_0 = result_ref_0.data[qubit].kerneled
+    iq_ref_1 = result_ref_1.data[qubit].kerneled
 
     A_sig = np.abs(iq_sig_1 - iq_sig_0)
     A_ref = np.abs(iq_ref_1 - iq_ref_0)
@@ -95,7 +96,7 @@ def measure_thermal_excitation(
         raise ValueError("Cannot estimate thermal excitation with zero signal.")
     p_ex = A_sig / total_amplitude
     print("")
-    print(f"{target}")
+    print(f"{qubit}")
     print(f"A_sig : {A_sig}")
     print(f"A_ref : {A_ref}")
     print(f"p_ex  : {p_ex}")

--- a/src/qubex/contrib/experiment/thermal_excitation_characterization.py
+++ b/src/qubex/contrib/experiment/thermal_excitation_characterization.py
@@ -2,166 +2,108 @@
 
 from __future__ import annotations
 
-from collections import defaultdict
-
 import numpy as np
-from qxpulse import FlatTop, PulseSchedule, Waveform
+from qxpulse import PulseSchedule
 
 from qubex import Experiment
 from qubex.experiment.experiment_constants import (
     DEFAULT_SHOTS,
-    PI_DURATION,
-    PI_RAMPTIME,
 )
 from qubex.experiment.models.result import Result
-from qubex.measurement.models.measure_result import (
-    MeasureResult,
-)
-from qubex.system.target import Target
 
-EF_PI_DURATION = PI_DURATION
-EF_PI_RAMPTIME = PI_RAMPTIME
-
-THERMAL_EXCITATION_DEFAULT_SHOTS = int(10 * DEFAULT_SHOTS)
+THERMAL_EXCITATION_DEFAULT_SHOTS = int(1024 * DEFAULT_SHOTS)
 
 
-def _build_population_rabi_sequence(
-    target: str,
-    ef_rabi_amplitude: float,
-    pi_pulse: Waveform,
-) -> dict[str, PulseSchedule]:
-    def sequence0(
-        target: str,
-        ef_rabi_amplitude: float,
-        pi_pulse: Waveform,
-    ) -> PulseSchedule:
-        ef_label = Target.ef_label(target)
-
-        with PulseSchedule() as ps:
-            ps.add(
-                ef_label,
-                FlatTop(
-                    duration=EF_PI_DURATION,
-                    amplitude=ef_rabi_amplitude,
-                    tau=EF_PI_RAMPTIME,
-                ),
-            )
-            ps.barrier()
-            ps.add(target, pi_pulse)
-        return ps
-
-    def sequence1(
-        target: str,
-        ef_rabi_amplitude: float,
-        pi_pulse: Waveform,
-    ) -> PulseSchedule:
-        ef_label = Target.ef_label(target)
-
-        with PulseSchedule() as ps:
-            ps.add(target, pi_pulse)
-            ps.barrier()
-            ps.add(
-                ef_label,
-                FlatTop(
-                    duration=EF_PI_DURATION,
-                    amplitude=2 * ef_rabi_amplitude,
-                    tau=EF_PI_RAMPTIME,
-                ),
-            )
-            ps.barrier()
-            ps.add(target, pi_pulse)
-        return ps
-
-    return {
-        "sequence0": sequence0(
-            target=target,
-            ef_rabi_amplitude=ef_rabi_amplitude,
-            pi_pulse=pi_pulse,
-        ),
-        "sequence1": sequence1(
-            target=target,
-            ef_rabi_amplitude=ef_rabi_amplitude,
-            pi_pulse=pi_pulse,
-        ),
-    }
-
-
-def thermal_excitation_via_rabi(
+def measure_thermal_excitation(
     exp: Experiment,
-    *,
     target: str,
+    *,
     n_shots: int = THERMAL_EXCITATION_DEFAULT_SHOTS,
-    readout_amplitude: float | None = None,
     plot: bool = False,
 ) -> Result:
     """
-    Estimate the thermal excitation probability of a qubit via ef Rabi oscillations.
+    Estimate the thermal excitation probability of a qubit.
 
     Parameters
     ----------
     target : str
         Target qubit to measure.
     n_shots : int, optional
-        Number of measurement shots per sequence.  Defaults to 10 times the value of `DEFAULT_SHOTS``.
+        Number of measurement shots per sequence.
+        Defaults to 1024 times the value of ``DEFAULT_SHOTS``.
     plot : bool, optional
-        Whether to plot ef rabi.
+        Whether to plot figures.
     """
-    control_amplitude = exp.calc_control_amplitude(target, rabi_rate=0.0125)
-    if control_amplitude is not None:
-        ef_rabi_amplitude = control_amplitude / np.sqrt(2)
-    if ef_rabi_amplitude is None:
-        raise ValueError("Failed to determine ef_rabi_amplitude.")
+    ge_label = exp.ctx.resolve_ge_label(target)
+    ef_label = exp.ctx.resolve_ef_label(target)
 
-    if readout_amplitude is None:
-        readout_amplitudes = None
-    else:
-        readout_amplitudes = {target: readout_amplitude}
+    def sequence_sig(ef_rabi_amplitude_scale: float) -> PulseSchedule:
+        ef_pulse = exp.pulse.x180(ef_label).scaled(ef_rabi_amplitude_scale)
+        with PulseSchedule() as ps:
+            ps.add(ef_label, ef_pulse)
+            ps.barrier()
+            ps.add(ge_label, exp.pulse.x180(ge_label))
+        return ps
 
-    amplitude_history = defaultdict(list)
+    def sequence_ref(ef_rabi_amplitude_scale: float) -> PulseSchedule:
+        ef_pulse = exp.pulse.x180(ef_label).scaled(ef_rabi_amplitude_scale)
+        with PulseSchedule() as ps:
+            ps.add(ge_label, exp.pulse.x180(ge_label))
+            ps.barrier()
+            ps.add(ef_label, ef_pulse)
+            ps.barrier()
+            ps.add(ge_label, exp.pulse.x180(ge_label))
+        return ps
 
-    for _ef_rabi_amplitude in [0, ef_rabi_amplitude]:
-        sequences = _build_population_rabi_sequence(
-            target=target,
-            ef_rabi_amplitude=_ef_rabi_amplitude,
-            pi_pulse=exp.x180(target),
-        )
+    result_sig_0 = exp.measure(
+        sequence=sequence_sig(0),
+        mode="avg",
+        n_shots=n_shots,
+        plot=plot,
+    )
 
-        result0: MeasureResult = exp.measure(
-            sequence=sequences["sequence0"],
-            readout_amplitudes=readout_amplitudes,
-            mode="avg",
-            n_shots=n_shots,
-            plot=plot,
-        )
-        result1: MeasureResult = exp.measure(
-            sequence=sequences["sequence1"],
-            readout_amplitudes=readout_amplitudes,
-            mode="avg",
-            n_shots=n_shots,
-            plot=plot,
-        )
+    result_sig_1 = exp.measure(
+        sequence=sequence_sig(1),
+        mode="avg",
+        n_shots=n_shots,
+        plot=plot,
+    )
 
-        iq0 = result0.data[target].kerneled
-        iq1 = result1.data[target].kerneled
-        state_center = exp.state_centers[target][1]
-        vec0 = np.abs(iq0 - state_center)
-        vec1 = np.abs(iq1 - state_center)
-        amplitude_history["0"].append(vec0)
-        amplitude_history["1"].append(vec1)
+    result_ref_0 = exp.measure(
+        sequence=sequence_ref(0),
+        mode="avg",
+        n_shots=n_shots,
+        plot=plot,
+    )
 
-    A_min = np.abs(amplitude_history["0"][0] - amplitude_history["0"][-1])
-    A_max = np.abs(amplitude_history["1"][0] - amplitude_history["1"][-1])
-    p_ex = A_min / (A_min + A_max)
+    result_ref_1 = exp.measure(
+        sequence=sequence_ref(1),
+        mode="avg",
+        n_shots=n_shots,
+        plot=plot,
+    )
+
+    iq_sig_0 = result_sig_0.data[target].kerneled
+    iq_sig_1 = result_sig_1.data[target].kerneled
+    iq_ref_0 = result_ref_0.data[target].kerneled
+    iq_ref_1 = result_ref_1.data[target].kerneled
+
+    A_sig = np.abs(iq_sig_1 - iq_sig_0)
+    A_ref = np.abs(iq_ref_1 - iq_ref_0)
+    total_amplitude = A_sig + A_ref
+    if total_amplitude == 0:
+        raise ValueError("Cannot estimate thermal excitation with zero signal.")
+    p_ex = A_sig / total_amplitude
     print("")
     print(f"{target}")
-    print(f"A_min : {A_min}")
-    print(f"A_max : {A_max}")
+    print(f"A_sig : {A_sig}")
+    print(f"A_ref : {A_ref}")
     print(f"p_ex  : {p_ex}")
 
     return Result(
         data={
             "p_ex": p_ex,
-            "rabi_ampl_min": A_min,
-            "rabi_ampl_max": A_max,
+            "signal_amplitude": A_sig,
+            "reference_amplitude": A_ref,
         },
     )

--- a/tests/contrib/thermal_excitation/test_function_api.py
+++ b/tests/contrib/thermal_excitation/test_function_api.py
@@ -2,9 +2,9 @@
 
 from __future__ import annotations
 
-from qubex.contrib import thermal_excitation_via_rabi
+from qubex.contrib import measure_thermal_excitation
 
 
 def test_all_thermal_excitation_functions_are_exported_from_contrib() -> None:
     """Given contrib package, when imported, then thermal excitation helpers are available."""
-    assert callable(thermal_excitation_via_rabi)
+    assert callable(measure_thermal_excitation)


### PR DESCRIPTION
## Summary
- Replaced the previous thermal excitation helper with `measure_thermal_excitation`
- Use calibrated `ef` `x180` pulses directly instead of estimating the `ef` amplitude from `ge`
- Export the new helper from `qubex.contrib` and `qubex.contrib.experiment`
- Updated the thermal excitation contrib API test