### PR TITLE
feat(quel3): add hardware state reader tooling

### DIFF
--- a/src/qubex/backend/quel3/__init__.py
+++ b/src/qubex/backend/quel3/__init__.py
@@ -2,7 +2,11 @@
 
 from .builders import Quel3SequencerBuilder
 from .infra import Quel3ClientMode
-from .managers import Quel3ConfigurationManager, Quel3RuntimeConfig
+from .managers import (
+    Quel3ConfigurationManager,
+    Quel3HardwareStateReader,
+    Quel3RuntimeConfig,
+)
 from .models import (
     InstrumentDeployRequest,
     Quel3BackendExecutionResult,
@@ -10,6 +14,14 @@ from .models import (
     Quel3CaptureWindow,
     Quel3ExecutionPayload,
     Quel3FixedTimeline,
+    Quel3HardwareState,
+    Quel3HardwareStateIssue,
+    Quel3HardwareStateSeverity,
+    Quel3HardwareStateView,
+    Quel3InstrumentState,
+    Quel3PortDiagnostic,
+    Quel3PortState,
+    Quel3UnitState,
     Quel3Waveform,
     Quel3WaveformEvent,
 )
@@ -25,8 +37,17 @@ __all__ = [
     "Quel3ConfigurationManager",
     "Quel3ExecutionPayload",
     "Quel3FixedTimeline",
+    "Quel3HardwareState",
+    "Quel3HardwareStateIssue",
+    "Quel3HardwareStateReader",
+    "Quel3HardwareStateSeverity",
+    "Quel3HardwareStateView",
+    "Quel3InstrumentState",
+    "Quel3PortDiagnostic",
+    "Quel3PortState",
     "Quel3RuntimeConfig",
     "Quel3SequencerBuilder",
+    "Quel3UnitState",
     "Quel3Waveform",
     "Quel3WaveformEvent",
 ]

--- a/src/qubex/backend/quel3/formatting/__init__.py
+++ b/src/qubex/backend/quel3/formatting/__init__.py
@@ -1,0 +1,5 @@
+"""Rich formatting helpers for QuEL-3 backend data."""
+
+from .hardware_state import format_quel3_hardware_state
+
+__all__ = ["format_quel3_hardware_state"]

--- a/src/qubex/backend/quel3/formatting/hardware_state.py
+++ b/src/qubex/backend/quel3/formatting/hardware_state.py
@@ -1,0 +1,271 @@
+"""Rich renderers for QuEL-3 hardware state."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich import box
+from rich.console import Group, RenderableType
+from rich.panel import Panel
+from rich.syntax import Syntax
+from rich.table import Table
+from rich.text import Text
+
+from qubex.backend.quel3.models import (
+    Quel3HardwareState,
+    Quel3HardwareStateIssue,
+    Quel3HardwareStateView,
+    Quel3InstrumentState,
+    Quel3PortState,
+)
+
+_RIGHT_HEADERS = {"Units", "Ports", "Instruments", "Diagnostics", "Min GHz", "Max GHz"}
+_NOWRAP_HEADERS = {"Severity", "Unit", "Role", "Mode"}
+
+
+def format_quel3_hardware_state(
+    state: Quel3HardwareState,
+    *,
+    view: Quel3HardwareStateView = "summary",
+) -> RenderableType:
+    """Return a Rich renderable for one QuEL-3 hardware-state view."""
+    if view == "summary":
+        return Group(_summary_panel(state), _issues_table(state.issues))
+    if view == "units":
+        return _units_table(state)
+    if view == "ports":
+        return _ports_table(state)
+    if view == "instruments":
+        return _instruments_table(state)
+    if view == "diagnostics":
+        return _diagnostics_group(state)
+    if view == "all":
+        return Group(
+            _summary_panel(state),
+            _units_table(state),
+            _ports_table(state),
+            _instruments_table(state),
+            _diagnostics_group(state),
+            _issues_table(state.issues),
+        )
+    raise ValueError(f"Unsupported QuEL-3 hardware-state view: {view!r}")
+
+
+def _summary_panel(state: Quel3HardwareState) -> Panel:
+    """Return a summary panel for one hardware state."""
+    grid = Table.grid(padding=(0, 2))
+    grid.add_column(style="bold cyan", no_wrap=True)
+    grid.add_column()
+    grid.add_row("Endpoint", f"{state.endpoint}:{state.port}")
+    grid.add_row("Generated", state.generated_at)
+    grid.add_row(
+        "Selected units",
+        ", ".join(state.selected_unit_labels) or "all",
+    )
+    grid.add_row("Units", str(len(state.units)))
+    grid.add_row("Ports", str(len(state.ports)))
+    grid.add_row("Instruments", str(len(state.instruments)))
+    grid.add_row("Diagnostics", str(len(state.diagnostics)))
+    return Panel(
+        grid,
+        title="QuEL-3 hardware state",
+        border_style=_summary_border_style(state),
+        box=box.ROUNDED,
+    )
+
+
+def _units_table(state: Quel3HardwareState) -> Table:
+    """Return a table of unit states."""
+    rows = [[unit.label, unit.status or "unknown"] for unit in state.units]
+    return _table("Units", ["Unit", "Status"], rows)
+
+
+def _ports_table(state: Quel3HardwareState) -> Table:
+    """Return a table of port states."""
+    rows = [
+        [
+            _resource_label(port.id, port.unit_label),
+            port.unit_label,
+            port.role or "",
+            ", ".join(_resource_label(dep, port.unit_label) for dep in port.depends_on),
+        ]
+        for port in sorted(state.ports, key=_port_sort_key)
+    ]
+    return _table("Ports", ["Port", "Unit", "Role", "Depends on"], rows)
+
+
+def _instruments_table(state: Quel3HardwareState) -> Table:
+    """Return a table of instrument states."""
+    instruments = sorted(state.instruments, key=_instrument_sort_key)
+    show_unit = len({instrument.unit_label for instrument in instruments}) > 1
+    headers = [
+        "Port",
+        "Alias",
+        "Role",
+        "Mode",
+        "Min GHz",
+        "Max GHz",
+        "Sampling fs",
+    ]
+    if show_unit:
+        headers.insert(0, "Unit")
+    rows = [
+        _instrument_row(instrument, show_unit=show_unit) for instrument in instruments
+    ]
+    return _table("Instruments", headers, rows)
+
+
+def _diagnostics_group(state: Quel3HardwareState) -> RenderableType:
+    """Return diagnostic panels for one hardware state."""
+    if not state.diagnostics:
+        return Text("(no diagnostics)", style="dim")
+    panels: list[RenderableType] = [
+        Panel(
+            Syntax(
+                diagnostic.text.rstrip() or "(empty diagnostic dump)",
+                "yaml",
+                word_wrap=True,
+                background_color="default",
+            ),
+            title=f"Port {diagnostic.port_id}",
+            border_style="cyan",
+            box=box.ROUNDED,
+        )
+        for diagnostic in state.diagnostics
+    ]
+    return Group(*panels)
+
+
+def _issues_table(issues: tuple[Quel3HardwareStateIssue, ...]) -> Table:
+    """Return a table of hardware-state issues."""
+    rows = [
+        [
+            issue.severity,
+            issue.code,
+            issue.message,
+            issue.detail or "",
+            issue.resource_id or "",
+        ]
+        for issue in issues
+    ]
+    return _table(
+        "Issues",
+        ["Severity", "Code", "Message", "Detail", "Resource"],
+        rows,
+    )
+
+
+def _table(title: str, headers: list[str], rows: list[list[Any]]) -> Table:
+    """Return a styled Rich table."""
+    result = Table(
+        title=title,
+        box=box.ROUNDED,
+        header_style="bold cyan",
+        border_style="bright_black",
+        row_styles=("", "dim"),
+    )
+    for header in headers:
+        result.add_column(
+            header,
+            justify="right" if header in _RIGHT_HEADERS else "left",
+            no_wrap=header in _NOWRAP_HEADERS,
+            overflow="fold",
+        )
+    if not rows:
+        result.add_row(
+            Text(f"No {title.lower()}", style="dim"),
+            *[""] * (len(headers) - 1),
+        )
+        return result
+    for row in rows:
+        result.add_row(
+            *(_cell(value, header) for value, header in zip(row, headers, strict=True))
+        )
+    return result
+
+
+def _cell(value: Any, header: str) -> Text:
+    """Return a styled table cell."""
+    text = str(value)
+    if not text:
+        return Text("-", style="dim")
+    if header == "Severity":
+        return _severity_text(text)
+    if header in _RIGHT_HEADERS:
+        return Text(text, style="cyan")
+    return Text(text)
+
+
+def _severity_text(severity: str) -> Text:
+    """Return styled severity text."""
+    style = {
+        "info": "cyan",
+        "warning": "bold yellow",
+        "error": "bold red",
+    }.get(severity, "bold")
+    return Text(severity.upper(), style=style)
+
+
+def _summary_border_style(state: Quel3HardwareState) -> str:
+    """Return summary panel border style from issues."""
+    severities = {issue.severity for issue in state.issues}
+    if "error" in severities:
+        return "red"
+    if "warning" in severities:
+        return "yellow"
+    return "green"
+
+
+def _instrument_row(
+    instrument: Quel3InstrumentState,
+    *,
+    show_unit: bool,
+) -> list[Any]:
+    """Return a display row for one instrument."""
+    row: list[Any] = [
+        _resource_label(instrument.port_id, instrument.unit_label),
+        instrument.normalized_alias or instrument.alias or "",
+        instrument.role or "",
+        instrument.mode or "",
+        _frequency_ghz(instrument.frequency_range_min_hz),
+        _frequency_ghz(instrument.frequency_range_max_hz),
+        instrument.sampling_period_fs or "",
+    ]
+    if show_unit:
+        row.insert(0, instrument.unit_label)
+    return row
+
+
+def _frequency_ghz(value: float | None) -> str:
+    """Format one frequency in GHz."""
+    if value is None:
+        return ""
+    return f"{value / 1.0e9:.4f}"
+
+
+def _resource_label(resource_id: str, unit_label: str) -> str:
+    """Return a compact resource label when the unit prefix matches."""
+    prefix = f"{unit_label}:"
+    if resource_id.startswith(prefix):
+        return resource_id.removeprefix(prefix)
+    return resource_id
+
+
+def _resource_suffix(resource_id: str) -> str:
+    """Return resource ID suffix after the first unit separator."""
+    return resource_id.split(":", maxsplit=1)[-1]
+
+
+def _port_sort_key(port: Quel3PortState) -> tuple[str, str]:
+    """Return stable sort key for one port."""
+    return port.unit_label, _resource_suffix(port.id)
+
+
+def _instrument_sort_key(instrument: Quel3InstrumentState) -> tuple[str, str, str, str]:
+    """Return stable sort key for one instrument."""
+    return (
+        instrument.unit_label,
+        _resource_suffix(instrument.port_id),
+        instrument.normalized_alias or instrument.alias or "",
+        instrument.id,
+    )

--- a/src/qubex/backend/quel3/interfaces/client.py
+++ b/src/qubex/backend/quel3/interfaces/client.py
@@ -233,6 +233,10 @@ class QuelwareClientProtocol(Protocol):
         """Get port info for one resource ID."""
         ...
 
+    async def dump_port_state(self, resource_id: ResourceIdProtocol) -> str:
+        """Dump diagnostic state for one port resource ID."""
+        ...
+
     def create_session(
         self,
         resource_ids: Iterable[ResourceIdProtocol],

--- a/src/qubex/backend/quel3/managers/__init__.py
+++ b/src/qubex/backend/quel3/managers/__init__.py
@@ -3,6 +3,7 @@
 from .configuration_manager import Quel3ConfigurationManager
 from .connection_manager import Quel3ConnectionManager
 from .execution_manager import Quel3ExecutionManager
+from .hardware_state_reader import Quel3HardwareStateReader
 from .runtime_config import Quel3RuntimeConfig
 from .session_manager import Quel3SessionManager
 
@@ -10,6 +11,7 @@ __all__ = [
     "Quel3ConfigurationManager",
     "Quel3ConnectionManager",
     "Quel3ExecutionManager",
+    "Quel3HardwareStateReader",
     "Quel3RuntimeConfig",
     "Quel3SessionManager",
 ]

--- a/src/qubex/backend/quel3/managers/configuration_manager.py
+++ b/src/qubex/backend/quel3/managers/configuration_manager.py
@@ -24,6 +24,9 @@ from qubex.backend.quel3.interfaces.client import (
     ResourceInfoProtocol,
     SessionProtocol,
 )
+from qubex.backend.quel3.managers.hardware_state_reader import (
+    Quel3HardwareStateReader,
+)
 from qubex.backend.quel3.managers.runtime_config import Quel3RuntimeConfig
 from qubex.backend.quel3.managers.session_workarounds import (
     QUELWARE_SESSION_REQUEST_MAX_ATTEMPTS,
@@ -183,12 +186,12 @@ class Quel3ConfigurationManager:
         unit_labels_by_box_id: Mapping[str, str],
         parallel: bool | None = None,
     ) -> dict[str, dict]:
-        """Fetch normalized QuEL-3 instrument snapshots keyed by box ID."""
-        return _run_async(
-            lambda: self._fetch_backend_settings_from_hardware(
-                unit_labels_by_box_id=dict(unit_labels_by_box_id),
-                parallel=True if parallel is None else parallel,
-            )
+        """Fetch backend settings from hardware through the state reader."""
+        return Quel3HardwareStateReader(
+            runtime_config=self._runtime_config,
+        ).fetch_backend_settings_from_hardware(
+            unit_labels_by_box_id=unit_labels_by_box_id,
+            parallel=parallel,
         )
 
     def sync_backend_settings_to_cache(
@@ -452,55 +455,6 @@ class Quel3ConfigurationManager:
         self._target_alias_map = {}
         return dict(deployed)
 
-    async def _fetch_backend_settings_from_hardware(
-        self,
-        *,
-        unit_labels_by_box_id: dict[str, str],
-        parallel: bool,
-    ) -> dict[str, dict]:
-        """Fetch normalized instrument snapshots for selected QuEL-3 boxes."""
-        box_id_by_unit_label = {
-            unit_label: box_id for box_id, unit_label in unit_labels_by_box_id.items()
-        }
-        fetched: dict[str, dict] = {
-            box_id: {"instruments": {}} for box_id in unit_labels_by_box_id
-        }
-        if len(unit_labels_by_box_id) == 0:
-            return fetched
-
-        client_factory = self._load_quelware_client_factory()
-        async with client_factory(
-            self._runtime_config.endpoint,
-            self._runtime_config.port,
-        ) as client:
-            instrument_infos = await self._list_instrument_infos(
-                client=client,
-                parallel=parallel,
-                unit_labels=set(unit_labels_by_box_id.values()),
-            )
-
-        for instrument_info in instrument_infos:
-            unit_label = self._extract_unit_label(str(instrument_info.port_id))
-            box_id = box_id_by_unit_label.get(unit_label)
-            if box_id is None:
-                continue
-            alias, _runtime_alias = self._split_alias_for_port(
-                alias=instrument_info.definition.alias,
-                port_id=instrument_info.port_id,
-            )
-            if len(alias) == 0:
-                continue
-            definition = self._serialize_instrument_definition(
-                instrument_info.definition,
-            )
-            fetched[box_id]["instruments"][alias] = {
-                "resource_id": str(instrument_info.id),
-                "port_id": str(instrument_info.port_id),
-                "role": self._normalize_role_name(instrument_info.definition.role),
-                "definition": definition,
-            }
-        return fetched
-
     def _load_quelware_client_factory(self) -> QuelwareClientFactory:
         """Import quelware client factory lazily."""
         return self._runtime_config.load_client_factory()
@@ -630,33 +584,6 @@ class Quel3ConfigurationManager:
     def _normalize_enum_name(cls, value: object) -> str:
         """Normalize one enum-like runtime value to a comparable string."""
         return cls._normalize_role_name(value)
-
-    @classmethod
-    def _serialize_instrument_definition(cls, definition: object) -> dict[str, object]:
-        """Serialize stable instrument-definition fields into plain data."""
-        serialized = {
-            "alias": getattr(definition, "alias", ""),
-            "role": cls._normalize_enum_name(getattr(definition, "role", None)),
-        }
-        mode = getattr(definition, "mode", None)
-        if mode is not None:
-            serialized["mode"] = cls._normalize_enum_name(mode)
-        profile = cls._serialize_profile(getattr(definition, "profile", None))
-        if profile:
-            serialized["profile"] = profile
-        return serialized
-
-    @staticmethod
-    def _serialize_profile(profile: object) -> dict[str, object]:
-        """Serialize stable fixed-timeline profile fields into plain data."""
-        if profile is None:
-            return {}
-        serialized: dict[str, object] = {}
-        for attr in ("frequency_range_min", "frequency_range_max"):
-            value = getattr(profile, attr, None)
-            if isinstance(value, int | float):
-                serialized[attr] = float(value)
-        return serialized
 
     @classmethod
     def _build_cached_definition(

--- a/src/qubex/backend/quel3/managers/hardware_state_reader.py
+++ b/src/qubex/backend/quel3/managers/hardware_state_reader.py
@@ -1,0 +1,748 @@
+"""Hardware-state reader for QuEL-3 runtime inspection."""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+from collections import Counter, defaultdict
+from collections.abc import Awaitable, Callable, Mapping, Sequence
+from datetime import datetime, timezone
+from typing import Any, TypeVar, cast
+
+from qubex.backend.quel3.infra.quelware_imports import Quel3ClientMode
+from qubex.backend.quel3.interfaces import (
+    QuelwareClientFactory,
+    QuelwareClientProtocol,
+)
+from qubex.backend.quel3.managers.runtime_config import Quel3RuntimeConfig
+from qubex.backend.quel3.models import (
+    Quel3HardwareState,
+    Quel3HardwareStateIssue,
+    Quel3InstrumentState,
+    Quel3PortDiagnostic,
+    Quel3PortState,
+    Quel3UnitState,
+)
+from qubex.core.async_bridge import DEFAULT_TIMEOUT_SECONDS, get_shared_async_bridge
+
+T = TypeVar("T")
+
+
+def _run_async(
+    factory: Callable[[], Awaitable[T]],
+    *,
+    timeout: float = DEFAULT_TIMEOUT_SECONDS,
+) -> T:
+    """Run one awaitable factory from synchronous APIs."""
+    bridge = get_shared_async_bridge(key="quel3-hardware-state")
+    return bridge.run(factory, timeout=timeout)
+
+
+async def _resolve(value: T | Awaitable[T]) -> T:
+    """Resolve a value that may be awaitable."""
+    if inspect.isawaitable(value):
+        return await value
+    return value
+
+
+class Quel3HardwareStateReader:
+    """Collect read-only QuEL-3 hardware state through quelware APIs."""
+
+    def __init__(
+        self,
+        *,
+        runtime_config: Quel3RuntimeConfig | None = None,
+    ) -> None:
+        self._runtime_config = runtime_config or Quel3RuntimeConfig()
+
+    @property
+    def runtime_config(self) -> Quel3RuntimeConfig:
+        """Return the shared quelware runtime config."""
+        return self._runtime_config
+
+    @property
+    def quelware_endpoint(self) -> str:
+        """Return quelware endpoint used for hardware state reads."""
+        return self._runtime_config.endpoint
+
+    @property
+    def quelware_port(self) -> int:
+        """Return quelware port used for hardware state reads."""
+        return self._runtime_config.port
+
+    @property
+    def client_mode(self) -> Quel3ClientMode:
+        """Return configured quelware client mode."""
+        return self._runtime_config.client_mode_value
+
+    @property
+    def quelware_pat_path(self) -> str | None:
+        """Return configured quelware personal access token path."""
+        return self._runtime_config.pat_path
+
+    def collect_state(
+        self,
+        *,
+        unit_labels: Sequence[str] = (),
+        instrument_port_ids: Sequence[str] = (),
+        diagnostic_port_ids: Sequence[str] = (),
+        include_diagnostics: bool = False,
+        parallel: bool = True,
+        timeout_seconds: float | None = None,
+    ) -> Quel3HardwareState:
+        """Collect one structured QuEL-3 hardware-state snapshot."""
+        timeout = (
+            DEFAULT_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
+        )
+        return _run_async(
+            lambda: self._collect_state(
+                unit_labels=tuple(unit_labels),
+                instrument_port_ids=tuple(instrument_port_ids),
+                diagnostic_port_ids=tuple(diagnostic_port_ids),
+                include_diagnostics=include_diagnostics,
+                parallel=parallel,
+            ),
+            timeout=timeout,
+        )
+
+    def fetch_backend_settings_from_hardware(
+        self,
+        *,
+        unit_labels_by_box_id: Mapping[str, str],
+        parallel: bool | None = None,
+    ) -> dict[str, dict]:
+        """Fetch QuEL-3 backend settings by projecting hardware state."""
+        if len(unit_labels_by_box_id) == 0:
+            return {}
+        state = self.collect_state(
+            unit_labels=tuple(unit_labels_by_box_id.values()),
+            include_diagnostics=False,
+            parallel=True if parallel is None else parallel,
+        )
+        return self.project_backend_settings(
+            state=state,
+            unit_labels_by_box_id=unit_labels_by_box_id,
+        )
+
+    async def _collect_state(
+        self,
+        *,
+        unit_labels: tuple[str, ...],
+        instrument_port_ids: tuple[str, ...],
+        diagnostic_port_ids: tuple[str, ...],
+        include_diagnostics: bool,
+        parallel: bool,
+    ) -> Quel3HardwareState:
+        """Collect hardware state from one quelware client context."""
+        generated_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+        client_factory = self._load_quelware_client_factory()
+        async with client_factory(
+            self._runtime_config.endpoint,
+            self._runtime_config.port,
+        ) as client:
+            discovered_unit_labels = tuple(
+                str(label) for label in await _resolve(client.list_unit_labels())
+            )
+            selected_unit_labels = tuple(unit_labels)
+            visible_unit_labels = self._visible_unit_labels(
+                discovered_unit_labels=discovered_unit_labels,
+                selected_unit_labels=selected_unit_labels,
+            )
+            units = tuple(Quel3UnitState(label=label) for label in visible_unit_labels)
+            resource_infos = [
+                resource_info
+                for resource_info in await _resolve(client.list_resource_infos())
+                if self._is_visible_resource(
+                    resource_info=resource_info,
+                    selected_unit_labels=selected_unit_labels,
+                )
+            ]
+            ports, port_issues = await self._collect_ports(
+                client=client,
+                resource_infos=resource_infos,
+                selected_unit_labels=selected_unit_labels,
+                parallel=parallel,
+            )
+            instruments, instrument_issues = await self._collect_instruments(
+                client=client,
+                resource_infos=resource_infos,
+                selected_unit_labels=selected_unit_labels,
+                instrument_port_ids=instrument_port_ids,
+                parallel=parallel,
+            )
+            diagnostics, diagnostic_issues = await self._collect_diagnostics(
+                client=client,
+                ports=ports,
+                diagnostic_port_ids=diagnostic_port_ids,
+                include_diagnostics=include_diagnostics,
+                parallel=parallel,
+            )
+
+        issues = (
+            *port_issues,
+            *instrument_issues,
+            *diagnostic_issues,
+            *self._evaluate_state(
+                selected_unit_labels=selected_unit_labels,
+                discovered_unit_labels=discovered_unit_labels,
+                units=units,
+                ports=ports,
+                instruments=instruments,
+            ),
+        )
+        return Quel3HardwareState(
+            generated_at=generated_at,
+            endpoint=self._runtime_config.endpoint,
+            port=self._runtime_config.port,
+            selected_unit_labels=selected_unit_labels,
+            units=units,
+            ports=tuple(sorted(ports, key=lambda port: port.id)),
+            instruments=tuple(
+                sorted(
+                    instruments,
+                    key=lambda instrument: (
+                        instrument.port_id,
+                        instrument.normalized_alias or instrument.alias or "",
+                        instrument.id,
+                    ),
+                )
+            ),
+            diagnostics=tuple(sorted(diagnostics, key=lambda item: item.port_id)),
+            issues=issues,
+        )
+
+    async def _collect_ports(
+        self,
+        *,
+        client: QuelwareClientProtocol,
+        resource_infos: Sequence[object],
+        selected_unit_labels: tuple[str, ...],
+        parallel: bool,
+    ) -> tuple[tuple[Quel3PortState, ...], tuple[Quel3HardwareStateIssue, ...]]:
+        """Collect port states and preserve per-resource failures as issues."""
+        port_resource_ids = tuple(
+            self._resource_id(resource_info)
+            for resource_info in resource_infos
+            if self._category_name(getattr(resource_info, "category", None)) == "PORT"
+        )
+
+        async def _fetch(resource_id: str) -> Quel3PortState:
+            return self._port_state(await _resolve(client.get_port_info(resource_id)))
+
+        results = await self._collect_resource_results(
+            resource_ids=port_resource_ids,
+            fetch=_fetch,
+            parallel=parallel,
+        )
+        ports: list[Quel3PortState] = []
+        issues: list[Quel3HardwareStateIssue] = []
+        for resource_id, result in zip(port_resource_ids, results, strict=True):
+            if isinstance(result, BaseException):
+                issues.append(
+                    self._resource_issue(
+                        operation="get_port_info",
+                        resource_id=resource_id,
+                        exc=result,
+                    )
+                )
+                fallback = Quel3PortState(
+                    id=resource_id,
+                    unit_label=self._unit_label(resource_id),
+                    role=None,
+                )
+                if self._is_selected_unit_label(
+                    unit_label=fallback.unit_label,
+                    selected_unit_labels=selected_unit_labels,
+                ):
+                    ports.append(fallback)
+                continue
+            if not self._is_selected_unit_label(
+                unit_label=result.unit_label,
+                selected_unit_labels=selected_unit_labels,
+            ):
+                continue
+            ports.append(result)
+        return tuple(ports), tuple(issues)
+
+    async def _collect_instruments(
+        self,
+        *,
+        client: QuelwareClientProtocol,
+        resource_infos: Sequence[object],
+        selected_unit_labels: tuple[str, ...],
+        instrument_port_ids: tuple[str, ...],
+        parallel: bool,
+    ) -> tuple[tuple[Quel3InstrumentState, ...], tuple[Quel3HardwareStateIssue, ...]]:
+        """Collect instrument states and preserve per-resource failures as issues."""
+        instrument_resource_ids = tuple(
+            self._resource_id(resource_info)
+            for resource_info in resource_infos
+            if self._category_name(getattr(resource_info, "category", None))
+            == "INSTRUMENT"
+        )
+
+        async def _fetch(resource_id: str) -> Quel3InstrumentState:
+            return self._instrument_state(
+                await _resolve(client.get_instrument_info(resource_id))
+            )
+
+        results = await self._collect_resource_results(
+            resource_ids=instrument_resource_ids,
+            fetch=_fetch,
+            parallel=parallel,
+        )
+        selected_port_ids = set(instrument_port_ids)
+        instruments: list[Quel3InstrumentState] = []
+        issues: list[Quel3HardwareStateIssue] = []
+        for resource_id, result in zip(instrument_resource_ids, results, strict=True):
+            if isinstance(result, BaseException):
+                issues.append(
+                    self._resource_issue(
+                        operation="get_instrument_info",
+                        resource_id=resource_id,
+                        exc=result,
+                    )
+                )
+                continue
+            if not self._is_selected_unit_label(
+                unit_label=result.unit_label,
+                selected_unit_labels=selected_unit_labels,
+            ):
+                continue
+            if selected_port_ids and result.port_id not in selected_port_ids:
+                continue
+            instruments.append(result)
+        return tuple(instruments), tuple(issues)
+
+    async def _collect_diagnostics(
+        self,
+        *,
+        client: QuelwareClientProtocol,
+        ports: Sequence[Quel3PortState],
+        diagnostic_port_ids: tuple[str, ...],
+        include_diagnostics: bool,
+        parallel: bool,
+    ) -> tuple[tuple[Quel3PortDiagnostic, ...], tuple[Quel3HardwareStateIssue, ...]]:
+        """Collect optional port diagnostic dumps."""
+        if not include_diagnostics:
+            return (), ()
+        port_ids = diagnostic_port_ids or tuple(port.id for port in ports)
+
+        async def _fetch(port_id: str) -> Quel3PortDiagnostic:
+            dump_port_state = client.dump_port_state
+            text = await _resolve(dump_port_state(port_id))
+            return Quel3PortDiagnostic(
+                port_id=port_id,
+                unit_label=self._unit_label(port_id),
+                text=str(text),
+            )
+
+        results = await self._collect_resource_results(
+            resource_ids=tuple(port_ids),
+            fetch=_fetch,
+            parallel=parallel,
+        )
+        diagnostics: list[Quel3PortDiagnostic] = []
+        issues: list[Quel3HardwareStateIssue] = []
+        for port_id, result in zip(port_ids, results, strict=True):
+            if isinstance(result, BaseException):
+                issues.append(
+                    self._resource_issue(
+                        operation="dump_port_state",
+                        resource_id=port_id,
+                        exc=result,
+                    )
+                )
+                continue
+            diagnostics.append(result)
+        return tuple(diagnostics), tuple(issues)
+
+    @staticmethod
+    async def _collect_resource_results(
+        *,
+        resource_ids: tuple[str, ...],
+        fetch: Callable[[str], Awaitable[T]],
+        parallel: bool,
+    ) -> tuple[T | BaseException, ...]:
+        """Collect resource results in parallel or serial order."""
+
+        async def _fetch_result(resource_id: str) -> T | BaseException:
+            try:
+                return await fetch(resource_id)
+            except Exception as exc:
+                return exc
+
+        if parallel:
+            return tuple(
+                await asyncio.gather(
+                    *(_fetch_result(resource_id) for resource_id in resource_ids),
+                    return_exceptions=True,
+                )
+            )
+
+        return tuple([await _fetch_result(resource_id) for resource_id in resource_ids])
+
+    @classmethod
+    def project_backend_settings(
+        cls,
+        *,
+        state: Quel3HardwareState,
+        unit_labels_by_box_id: Mapping[str, str],
+    ) -> dict[str, dict]:
+        """Project hardware state into QuEL-3 backend-settings cache data."""
+        settings: dict[str, dict] = {
+            box_id: {"instruments": {}} for box_id in unit_labels_by_box_id
+        }
+        box_ids_by_unit_label: dict[str, list[str]] = defaultdict(list)
+        for box_id, unit_label in unit_labels_by_box_id.items():
+            box_ids_by_unit_label[unit_label].append(box_id)
+
+        for instrument in state.instruments:
+            alias = instrument.normalized_alias or instrument.alias
+            if alias is None:
+                continue
+            for box_id in box_ids_by_unit_label.get(instrument.unit_label, ()):
+                settings[box_id]["instruments"][alias] = (
+                    cls._backend_settings_instrument(instrument)
+                )
+        return settings
+
+    @staticmethod
+    def _backend_settings_instrument(instrument: Quel3InstrumentState) -> dict:
+        """Return backend-settings data for one instrument state."""
+        definition: dict[str, object] = {
+            "alias": instrument.alias or instrument.normalized_alias or "",
+            "role": instrument.role,
+        }
+        if instrument.mode is not None:
+            definition["mode"] = instrument.mode
+        profile: dict[str, float] = {}
+        if instrument.frequency_range_min_hz is not None:
+            profile["frequency_range_min"] = instrument.frequency_range_min_hz
+        if instrument.frequency_range_max_hz is not None:
+            profile["frequency_range_max"] = instrument.frequency_range_max_hz
+        if profile:
+            definition["profile"] = profile
+        return {
+            "resource_id": instrument.id,
+            "port_id": instrument.port_id,
+            "role": instrument.role,
+            "definition": definition,
+        }
+
+    @classmethod
+    def _evaluate_state(
+        cls,
+        *,
+        selected_unit_labels: tuple[str, ...],
+        discovered_unit_labels: tuple[str, ...],
+        units: Sequence[Quel3UnitState],
+        ports: Sequence[Quel3PortState],
+        instruments: Sequence[Quel3InstrumentState],
+    ) -> tuple[Quel3HardwareStateIssue, ...]:
+        """Evaluate derived health issues for a hardware-state snapshot."""
+        issues: list[Quel3HardwareStateIssue] = []
+        discovered = set(discovered_unit_labels)
+        missing_units = sorted(set(selected_unit_labels) - discovered)
+        if missing_units:
+            issues.append(
+                Quel3HardwareStateIssue(
+                    severity="error",
+                    code="UNIT_NOT_FOUND",
+                    message="Selected QuEL-3 units were not discovered.",
+                    detail=", ".join(missing_units),
+                )
+            )
+        if len(units) == 0:
+            issues.append(
+                Quel3HardwareStateIssue(
+                    severity="error",
+                    code="NO_UNITS",
+                    message="No QuEL-3 units were discovered.",
+                )
+            )
+        if len(ports) == 0:
+            issues.append(
+                Quel3HardwareStateIssue(
+                    severity="warning",
+                    code="NO_PORTS",
+                    message="No QuEL-3 port resources were found.",
+                )
+            )
+        if len(instruments) == 0:
+            issues.append(
+                Quel3HardwareStateIssue(
+                    severity="warning",
+                    code="NO_INSTRUMENTS",
+                    message="No QuEL-3 instrument resources were found.",
+                )
+            )
+        issues.extend(cls._port_dependency_issues(ports))
+        issues.extend(cls._instrument_issues(instruments=instruments, ports=ports))
+        return tuple(issues)
+
+    @staticmethod
+    def _port_dependency_issues(
+        ports: Sequence[Quel3PortState],
+    ) -> list[Quel3HardwareStateIssue]:
+        """Return issues for missing port dependency references."""
+        issues: list[Quel3HardwareStateIssue] = []
+        port_ids = {port.id for port in ports}
+        for port in ports:
+            missing = [
+                resource_id
+                for resource_id in port.depends_on
+                if resource_id not in port_ids
+            ]
+            if missing:
+                issues.append(
+                    Quel3HardwareStateIssue(
+                        severity="warning",
+                        code="UNKNOWN_PORT_DEPENDENCY",
+                        message="Port references resources not listed as ports.",
+                        detail=", ".join(missing),
+                        resource_id=port.id,
+                    )
+                )
+        return issues
+
+    @classmethod
+    def _instrument_issues(
+        cls,
+        *,
+        instruments: Sequence[Quel3InstrumentState],
+        ports: Sequence[Quel3PortState],
+    ) -> list[Quel3HardwareStateIssue]:
+        """Return issues for instrument-port and definition consistency."""
+        issues: list[Quel3HardwareStateIssue] = []
+        port_ids = {port.id for port in ports}
+        aliases = Counter(
+            (instrument.unit_label, instrument.normalized_alias or instrument.alias)
+            for instrument in instruments
+            if instrument.normalized_alias or instrument.alias
+        )
+        for (unit_label, alias), count in sorted(aliases.items()):
+            if count > 1:
+                issues.append(
+                    Quel3HardwareStateIssue(
+                        severity="warning",
+                        code="DUPLICATE_INSTRUMENT_ALIAS",
+                        message=(
+                            f"Instrument alias {alias} appears {count} times "
+                            f"in unit {unit_label}."
+                        ),
+                    )
+                )
+
+        for instrument in instruments:
+            if instrument.port_id not in port_ids:
+                issues.append(
+                    Quel3HardwareStateIssue(
+                        severity="error",
+                        code="ORPHAN_INSTRUMENT",
+                        message="Instrument points to an unknown port.",
+                        detail=instrument.port_id,
+                        resource_id=instrument.id,
+                    )
+                )
+            if not instrument.alias:
+                issues.append(
+                    Quel3HardwareStateIssue(
+                        severity="warning",
+                        code="EMPTY_INSTRUMENT_ALIAS",
+                        message="Instrument has no alias.",
+                        resource_id=instrument.id,
+                    )
+                )
+            issues.extend(cls._frequency_issues(instrument))
+        return issues
+
+    @staticmethod
+    def _frequency_issues(
+        instrument: Quel3InstrumentState,
+    ) -> list[Quel3HardwareStateIssue]:
+        """Return frequency-range issues for one instrument."""
+        lower = instrument.frequency_range_min_hz
+        upper = instrument.frequency_range_max_hz
+        if lower is None or upper is None:
+            return [
+                Quel3HardwareStateIssue(
+                    severity="warning",
+                    code="MISSING_FREQUENCY_RANGE",
+                    message="Instrument has no complete frequency range.",
+                    resource_id=instrument.id,
+                )
+            ]
+        if lower >= upper:
+            return [
+                Quel3HardwareStateIssue(
+                    severity="error",
+                    code="INVALID_FREQUENCY_RANGE",
+                    message="Instrument has an invalid frequency range.",
+                    detail=f"{lower} >= {upper}",
+                    resource_id=instrument.id,
+                )
+            ]
+        return []
+
+    @classmethod
+    def _port_state(cls, port_info: object) -> Quel3PortState:
+        """Build one port state from a quelware port-info object."""
+        port_info_obj = cast(Any, port_info)
+        port_id = str(port_info_obj.id)
+        depends_on = tuple(str(item) for item in getattr(port_info, "depends_on", ()))
+        return Quel3PortState(
+            id=port_id,
+            unit_label=cls._unit_label(port_id),
+            role=cls._enum_name(getattr(port_info, "role", None)),
+            depends_on=depends_on,
+        )
+
+    @classmethod
+    def _instrument_state(cls, instrument_info: object) -> Quel3InstrumentState:
+        """Build one instrument state from a quelware instrument-info object."""
+        instrument_info_obj = cast(Any, instrument_info)
+        instrument_id = str(instrument_info_obj.id)
+        port_id = str(instrument_info_obj.port_id)
+        definition = instrument_info_obj.definition
+        config = getattr(instrument_info, "config", None)
+        profile = getattr(definition, "profile", None)
+        alias = cls._string_or_none(getattr(definition, "alias", None))
+        return Quel3InstrumentState(
+            id=instrument_id,
+            unit_label=cls._unit_label(port_id),
+            port_id=port_id,
+            alias=alias,
+            normalized_alias=cls._normalize_alias(alias=alias, port_id=port_id),
+            role=cls._enum_name(getattr(definition, "role", None)),
+            mode=cls._enum_name(getattr(definition, "mode", None)),
+            frequency_range_min_hz=cls._float_or_none(
+                getattr(profile, "frequency_range_min", None)
+            ),
+            frequency_range_max_hz=cls._float_or_none(
+                getattr(profile, "frequency_range_max", None)
+            ),
+            sampling_period_fs=cls._int_or_none(
+                getattr(config, "sampling_period_fs", None)
+            ),
+            bitdepth=cls._int_or_none(getattr(config, "bitdepth", None)),
+            timeline_step_samples=cls._int_or_none(
+                getattr(config, "timeline_step_samples", None)
+            ),
+            samples_per_tick=cls._int_or_none(
+                getattr(config, "samples_per_tick", None)
+            ),
+        )
+
+    @staticmethod
+    def _resource_issue(
+        *,
+        operation: str,
+        resource_id: str,
+        exc: BaseException,
+    ) -> Quel3HardwareStateIssue:
+        """Return an issue describing one failed resource fetch."""
+        return Quel3HardwareStateIssue(
+            severity="error",
+            code="RESOURCE_FETCH_ERROR",
+            message=f"{operation} failed.",
+            detail=str(exc),
+            resource_id=resource_id,
+        )
+
+    @classmethod
+    def _is_visible_resource(
+        cls,
+        *,
+        resource_info: object,
+        selected_unit_labels: tuple[str, ...],
+    ) -> bool:
+        """Return whether a resource belongs to selected units."""
+        if not selected_unit_labels:
+            return True
+        resource_id = cls._resource_id(resource_info)
+        if ":" not in resource_id:
+            return True
+        return cls._unit_label(resource_id) in set(selected_unit_labels)
+
+    @staticmethod
+    def _is_selected_unit_label(
+        *,
+        unit_label: str,
+        selected_unit_labels: tuple[str, ...],
+    ) -> bool:
+        """Return whether a resolved state belongs to selected units."""
+        return not selected_unit_labels or unit_label in set(selected_unit_labels)
+
+    @staticmethod
+    def _resource_id(resource_info: object) -> str:
+        """Return string resource ID from a resource-info object."""
+        return str(cast(Any, resource_info).id)
+
+    @staticmethod
+    def _visible_unit_labels(
+        *,
+        discovered_unit_labels: tuple[str, ...],
+        selected_unit_labels: tuple[str, ...],
+    ) -> tuple[str, ...]:
+        """Return discovered units visible under one selection."""
+        if not selected_unit_labels:
+            return discovered_unit_labels
+        selected = set(selected_unit_labels)
+        return tuple(label for label in discovered_unit_labels if label in selected)
+
+    @staticmethod
+    def _unit_label(resource_id: str) -> str:
+        """Return the unit-label prefix from one resource ID."""
+        return resource_id.split(":", maxsplit=1)[0]
+
+    @staticmethod
+    def _category_name(category: object) -> str:
+        """Normalize one category enum-like value to its name."""
+        category_name = getattr(category, "name", None)
+        text = category_name if isinstance(category_name, str) else str(category)
+        return text.rsplit(".", maxsplit=1)[-1]
+
+    @staticmethod
+    def _enum_name(value: object) -> str | None:
+        """Normalize one enum-like value to its name."""
+        if value is None:
+            return None
+        enum_name = getattr(value, "name", None)
+        if isinstance(enum_name, str):
+            return enum_name
+        return str(value)
+
+    @classmethod
+    def _normalize_alias(cls, *, alias: str | None, port_id: str) -> str | None:
+        """Strip the unit-label prefix from an instrument alias when present."""
+        if alias is None:
+            return None
+        stripped = alias.strip()
+        prefix = f"{cls._unit_label(port_id)}:"
+        if stripped.startswith(prefix):
+            stripped = stripped.removeprefix(prefix).strip()
+        return stripped or None
+
+    @staticmethod
+    def _string_or_none(value: object) -> str | None:
+        """Return stripped text or `None`."""
+        return value.strip() if isinstance(value, str) and value.strip() else None
+
+    @staticmethod
+    def _float_or_none(value: object) -> float | None:
+        """Return float for numeric values except booleans."""
+        if isinstance(value, bool):
+            return None
+        return float(value) if isinstance(value, int | float) else None
+
+    @staticmethod
+    def _int_or_none(value: object) -> int | None:
+        """Return int for integer values except booleans."""
+        if isinstance(value, bool):
+            return None
+        return value if isinstance(value, int) else None
+
+    def _load_quelware_client_factory(self) -> QuelwareClientFactory:
+        """Import quelware client factory lazily."""
+        return self._runtime_config.load_client_factory()

--- a/src/qubex/backend/quel3/models/__init__.py
+++ b/src/qubex/backend/quel3/models/__init__.py
@@ -1,6 +1,16 @@
-"""Data models for QuEL-3 backend payloads, deployment, and results."""
+"""Data models for QuEL-3 backend payloads, deployment, state, and results."""
 
 from .deploy import InstrumentDeployRequest, RoleName
+from .hardware_state import (
+    Quel3HardwareState,
+    Quel3HardwareStateIssue,
+    Quel3HardwareStateSeverity,
+    Quel3HardwareStateView,
+    Quel3InstrumentState,
+    Quel3PortDiagnostic,
+    Quel3PortState,
+    Quel3UnitState,
+)
 from .payload import (
     Quel3CaptureMode,
     Quel3CaptureWindow,
@@ -18,6 +28,14 @@ __all__ = [
     "Quel3CaptureWindow",
     "Quel3ExecutionPayload",
     "Quel3FixedTimeline",
+    "Quel3HardwareState",
+    "Quel3HardwareStateIssue",
+    "Quel3HardwareStateSeverity",
+    "Quel3HardwareStateView",
+    "Quel3InstrumentState",
+    "Quel3PortDiagnostic",
+    "Quel3PortState",
+    "Quel3UnitState",
     "Quel3Waveform",
     "Quel3WaveformEvent",
     "RoleName",

--- a/src/qubex/backend/quel3/models/hardware_state.py
+++ b/src/qubex/backend/quel3/models/hardware_state.py
@@ -1,0 +1,92 @@
+"""Hardware-state models for QuEL-3 runtime inspection."""
+
+from __future__ import annotations
+
+from dataclasses import asdict, dataclass
+from typing import Any, Literal, TypeAlias
+
+Quel3HardwareStateSeverity: TypeAlias = Literal["info", "warning", "error"]
+Quel3HardwareStateView: TypeAlias = Literal[
+    "summary",
+    "units",
+    "ports",
+    "instruments",
+    "diagnostics",
+    "all",
+]
+
+
+@dataclass(frozen=True)
+class Quel3UnitState:
+    """One discovered QuEL-3 unit."""
+
+    label: str
+    status: str | None = None
+
+
+@dataclass(frozen=True)
+class Quel3PortState:
+    """One QuEL-3 port resource."""
+
+    id: str
+    unit_label: str
+    role: str | None
+    depends_on: tuple[str, ...] = ()
+
+
+@dataclass(frozen=True)
+class Quel3InstrumentState:
+    """One QuEL-3 instrument resource."""
+
+    id: str
+    unit_label: str
+    port_id: str
+    alias: str | None
+    normalized_alias: str | None
+    role: str | None
+    mode: str | None
+    frequency_range_min_hz: float | None = None
+    frequency_range_max_hz: float | None = None
+    sampling_period_fs: int | None = None
+    bitdepth: int | None = None
+    timeline_step_samples: int | None = None
+    samples_per_tick: int | None = None
+
+
+@dataclass(frozen=True)
+class Quel3PortDiagnostic:
+    """Diagnostic dump for one QuEL-3 port."""
+
+    port_id: str
+    unit_label: str
+    text: str
+
+
+@dataclass(frozen=True)
+class Quel3HardwareStateIssue:
+    """One issue found while collecting or evaluating QuEL-3 hardware state."""
+
+    severity: Quel3HardwareStateSeverity
+    code: str
+    message: str
+    detail: str | None = None
+    resource_id: str | None = None
+
+
+@dataclass(frozen=True)
+class Quel3HardwareState:
+    """Structured QuEL-3 hardware state snapshot."""
+
+    generated_at: str
+    endpoint: str
+    port: int
+    selected_unit_labels: tuple[str, ...]
+    units: tuple[Quel3UnitState, ...]
+    ports: tuple[Quel3PortState, ...]
+    instruments: tuple[Quel3InstrumentState, ...]
+    diagnostics: tuple[Quel3PortDiagnostic, ...] = ()
+    issues: tuple[Quel3HardwareStateIssue, ...] = ()
+
+    def to_dict(self) -> dict[str, Any]:
+        """Return a JSON-serializable dictionary representation."""
+        return asdict(self)

--- a/src/qubex/backend/quel3/quel3_backend_controller.py
+++ b/src/qubex/backend/quel3/quel3_backend_controller.py
@@ -9,11 +9,14 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
+from rich.console import Console
+
 from qubex.backend.backend_controller import (
     BackendController,
     BackendExecutionRequest,
     BackendExecutionResult,
 )
+from qubex.backend.quel3.formatting import format_quel3_hardware_state
 from qubex.backend.quel3.infra import Quel3ClientMode
 from qubex.backend.quel3.interfaces.client import InstrumentInfoProtocol
 
@@ -21,10 +24,11 @@ from .managers import (
     Quel3ConfigurationManager,
     Quel3ConnectionManager,
     Quel3ExecutionManager,
+    Quel3HardwareStateReader,
     Quel3RuntimeConfig,
     Quel3SessionManager,
 )
-from .models import InstrumentDeployRequest
+from .models import InstrumentDeployRequest, Quel3HardwareState, Quel3HardwareStateView
 from .quel3_backend_constants import CAPTURE_DECIMATION_FACTOR, SAMPLING_PERIOD_NS
 
 
@@ -52,6 +56,7 @@ class Quel3BackendController(BackendController):
         session_manager: Quel3SessionManager | None = None,
         configuration_manager: Quel3ConfigurationManager | None = None,
         execution_manager: Quel3ExecutionManager | None = None,
+        hardware_state_reader: Quel3HardwareStateReader | None = None,
     ) -> None:
         """
         Initialize a QuEL-3 backend controller.
@@ -70,6 +75,8 @@ class Quel3BackendController(BackendController):
             Injected configuration manager for testing or customization.
         execution_manager : Quel3ExecutionManager | None, optional
             Injected execution manager for testing or customization.
+        hardware_state_reader : Quel3HardwareStateReader | None, optional
+            Injected hardware-state reader for testing or customization.
         """
         runtime_config = Quel3RuntimeConfig(
             endpoint=quelware_endpoint or "localhost",
@@ -113,6 +120,13 @@ class Quel3BackendController(BackendController):
                 sampling_period_ns=self._sampling_period_ns,
                 capture_decimation_factor=self.CAPTURE_DECIMATION_FACTOR,
                 session_manager=self._session_manager,
+            )
+        )
+        self._hardware_state_reader = (
+            hardware_state_reader
+            if hardware_state_reader is not None
+            else Quel3HardwareStateReader(
+                runtime_config=runtime_config,
             )
         )
 
@@ -182,6 +196,11 @@ class Quel3BackendController(BackendController):
         return self._execution_manager
 
     @property
+    def hardware_state_reader(self) -> Quel3HardwareStateReader:
+        """Return backend-side QuEL-3 hardware-state reader."""
+        return self._hardware_state_reader
+
+    @property
     def target_alias_map(self) -> dict[tuple[str, str], str]:
         """Return deployed box-and-target to runtime-alias mapping."""
         return self._configuration_manager.target_alias_map
@@ -221,6 +240,52 @@ class Quel3BackendController(BackendController):
             requests=requests,
             parallel=parallel,
         )
+
+    def get_hardware_state(
+        self,
+        *,
+        unit_labels: Sequence[str] = (),
+        instrument_port_ids: Sequence[str] = (),
+        diagnostic_port_ids: Sequence[str] = (),
+        include_diagnostics: bool = False,
+        parallel: bool = True,
+        timeout_seconds: float | None = None,
+    ) -> Quel3HardwareState:
+        """Collect one structured QuEL-3 hardware-state snapshot."""
+        return self._hardware_state_reader.collect_state(
+            unit_labels=tuple(unit_labels),
+            instrument_port_ids=tuple(instrument_port_ids),
+            diagnostic_port_ids=tuple(diagnostic_port_ids),
+            include_diagnostics=include_diagnostics,
+            parallel=parallel,
+            timeout_seconds=timeout_seconds,
+        )
+
+    def print_hardware_state(
+        self,
+        *,
+        view: Quel3HardwareStateView = "summary",
+        unit_labels: Sequence[str] = (),
+        instrument_port_ids: Sequence[str] = (),
+        diagnostic_port_ids: Sequence[str] = (),
+        include_diagnostics: bool | None = None,
+        parallel: bool = True,
+        timeout_seconds: float | None = None,
+        console: Console | None = None,
+    ) -> None:
+        """Print one QuEL-3 hardware-state view with Rich."""
+        if include_diagnostics is None:
+            include_diagnostics = view in ("diagnostics", "all")
+        state = self.get_hardware_state(
+            unit_labels=unit_labels,
+            instrument_port_ids=instrument_port_ids,
+            diagnostic_port_ids=diagnostic_port_ids,
+            include_diagnostics=include_diagnostics,
+            parallel=parallel,
+            timeout_seconds=timeout_seconds,
+        )
+        output_console = console or Console(highlight=False)
+        output_console.print(format_quel3_hardware_state(state, view=view))
 
     @property
     def sampling_period_ns(self) -> float:

--- a/src/qubex/system/quel3/quel3_system_synchronizer.py
+++ b/src/qubex/system/quel3/quel3_system_synchronizer.py
@@ -90,7 +90,7 @@ class Quel3SystemSynchronizer:
         unit_labels_by_box_id = {
             box_id: experiment_system.get_box(box_id).name for box_id in box_ids
         }
-        return self._backend_controller.configuration_manager.fetch_backend_settings_from_hardware(
+        return self._backend_controller.hardware_state_reader.fetch_backend_settings_from_hardware(
             unit_labels_by_box_id=unit_labels_by_box_id,
             parallel=parallel,
         )

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -8,11 +8,13 @@ import asyncio
 import logging
 from dataclasses import dataclass, replace
 from enum import Enum
+from io import StringIO
 from types import SimpleNamespace
 from typing import Any, cast
 
 import numpy as np
 import pytest
+from rich.console import Console
 
 from qubex.backend import BackendExecutionRequest
 from qubex.backend.backend_controller import BackendController
@@ -24,6 +26,7 @@ from qubex.backend.quel3 import (
     Quel3CaptureWindow,
     Quel3ExecutionPayload,
     Quel3FixedTimeline,
+    Quel3HardwareState,
     Quel3RuntimeConfig,
     Quel3Waveform,
     Quel3WaveformEvent,
@@ -108,6 +111,16 @@ class _CountingInstrumentResolver(_FakeInstrumentResolver):
         self.refresh_calls += 1
 
 
+class _FakeHardwareStateReader:
+    def __init__(self, state: Quel3HardwareState) -> None:
+        self.state = state
+        self.last_collect_kwargs: dict[str, object] = {}
+
+    def collect_state(self, **kwargs: object) -> Quel3HardwareState:
+        self.last_collect_kwargs = dict(kwargs)
+        return self.state
+
+
 def _make_payload(
     *,
     mode: str = "avg",
@@ -173,6 +186,60 @@ def test_quel3_constructor_rejects_alias_map_argument() -> None:
     """Given legacy alias-map kwarg, constructor raises TypeError."""
     with pytest.raises(TypeError, match="alias_map"):
         cast(Any, Quel3BackendController)(alias_map={"RQ00": "inst-00"})
+
+
+def test_get_hardware_state_delegates_to_hardware_state_reader() -> None:
+    """Given hardware state reader, controller should delegate state collection."""
+    state = Quel3HardwareState(
+        generated_at="2026-07-07T00:00:00+00:00",
+        endpoint="localhost",
+        port=50051,
+        selected_unit_labels=("unit-a",),
+        units=(),
+        ports=(),
+        instruments=(),
+        diagnostics=(),
+        issues=(),
+    )
+    hardware_state_reader = _FakeHardwareStateReader(state)
+    controller = Quel3BackendController(
+        hardware_state_reader=cast(Any, hardware_state_reader)
+    )
+
+    result = controller.get_hardware_state(
+        unit_labels=("unit-a",),
+        include_diagnostics=True,
+        parallel=False,
+    )
+
+    assert result is state
+    assert hardware_state_reader.last_collect_kwargs["unit_labels"] == ("unit-a",)
+    assert hardware_state_reader.last_collect_kwargs["include_diagnostics"] is True
+    assert hardware_state_reader.last_collect_kwargs["parallel"] is False
+
+
+def test_print_hardware_state_renders_with_rich_console() -> None:
+    """Given hardware state, controller should print a Rich hardware-state view."""
+    state = Quel3HardwareState(
+        generated_at="2026-07-07T00:00:00+00:00",
+        endpoint="localhost",
+        port=50051,
+        selected_unit_labels=(),
+        units=(),
+        ports=(),
+        instruments=(),
+        diagnostics=(),
+        issues=(),
+    )
+    controller = Quel3BackendController(
+        hardware_state_reader=cast(Any, _FakeHardwareStateReader(state))
+    )
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, width=120)
+
+    controller.print_hardware_state(view="summary", console=console)
+
+    assert "QuEL-3 hardware state" in output.getvalue()
 
 
 def test_execute_rejects_non_quel3_payload() -> None:

--- a/tests/backend/test_quel3_configuration_manager.py
+++ b/tests/backend/test_quel3_configuration_manager.py
@@ -1542,251 +1542,47 @@ def test_refresh_instrument_cache_maps_unit_prefixed_aliases(
     )
 
 
-def test_fetch_backend_settings_from_hardware_groups_instruments_by_box(
+def test_fetch_backend_settings_from_hardware_delegates_to_state_reader(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Given quelware instruments, hardware fetch should normalize them per box."""
-    manager = Quel3ConfigurationManager()
+    """Given legacy hardware fetch API, manager should delegate to state reader."""
+    runtime_config = Quel3RuntimeConfig(endpoint="quelware.local", port=50052)
+    manager = Quel3ConfigurationManager(runtime_config=runtime_config)
+    calls: list[dict[str, object]] = []
 
-    class _InstrumentCategory:
-        name = "INSTRUMENT"
+    class _FakeHardwareStateReader:
+        def __init__(self, *, runtime_config: Quel3RuntimeConfig) -> None:
+            calls.append({"runtime_config": runtime_config})
 
-    class _PortCategory:
-        name = "PORT"
-
-    class _ResourceInfo:
-        def __init__(self, resource_id: str, category: object) -> None:
-            self.id = resource_id
-            self.category = category
-
-    class _Role:
-        def __init__(self, name: str) -> None:
-            self.name = name
-
-    class _Mode:
-        def __init__(self, name: str) -> None:
-            self.name = name
-
-    class _Profile:
-        def __init__(
+        def fetch_backend_settings_from_hardware(
             self,
             *,
-            frequency_range_min: float,
-            frequency_range_max: float,
-        ) -> None:
-            self.frequency_range_min = frequency_range_min
-            self.frequency_range_max = frequency_range_max
-
-    class _Definition:
-        def __init__(
-            self,
-            alias: str,
-            role: object,
-            *,
-            mode: object,
-            profile: object,
-        ) -> None:
-            self.alias = alias
-            self.role = role
-            self.mode = mode
-            self.profile = profile
-
-    class _InstrumentInfo:
-        def __init__(
-            self,
-            resource_id: str,
-            alias: str,
-            port_id: str,
-            role: str,
-            *,
-            frequency_range_min: float,
-            frequency_range_max: float,
-        ) -> None:
-            self.id = resource_id
-            self.port_id = port_id
-            self.definition = _Definition(
-                alias,
-                _Role(role),
-                mode=_Mode("FIXED_TIMELINE"),
-                profile=_Profile(
-                    frequency_range_min=frequency_range_min,
-                    frequency_range_max=frequency_range_max,
-                ),
-            )
-
-    class _FakeClient:
-        async def __aenter__(self) -> _FakeClient:
-            return self
-
-        async def __aexit__(
-            self,
-            exc_type: type[BaseException] | None,
-            exc: BaseException | None,
-            tb: object | None,
-        ) -> None:
-            _ = (exc_type, exc, tb)
-
-        async def list_resource_infos(self) -> list[object]:
-            return [
-                _ResourceInfo("inst-q00", _InstrumentCategory()),
-                _ResourceInfo("inst-rq00", _InstrumentCategory()),
-                _ResourceInfo("inst-other", _InstrumentCategory()),
-                _ResourceInfo("port-q00", _PortCategory()),
-            ]
-
-        async def get_instrument_info(self, resource_id: str) -> object:
-            infos = {
-                "inst-q00": _InstrumentInfo(
-                    "inst-q00",
-                    "Q00",
-                    "quel3-02-a01:tx_p04",
-                    "TRANSMITTER",
-                    frequency_range_min=4.1e9,
-                    frequency_range_max=4.3e9,
-                ),
-                "inst-rq00": _InstrumentInfo(
-                    "inst-rq00",
-                    "RQ00",
-                    "quel3-02-a02:trx_p00p04",
-                    "TRANSCEIVER",
-                    frequency_range_min=5.9e9,
-                    frequency_range_max=6.1e9,
-                ),
-                "inst-other": _InstrumentInfo(
-                    "inst-other",
-                    "Q99",
-                    "quel3-02-a99:tx_p01",
-                    "TRANSMITTER",
-                    frequency_range_min=4.0e9,
-                    frequency_range_max=4.5e9,
-                ),
-            }
-            return infos[resource_id]
+            unit_labels_by_box_id: dict[str, str],
+            parallel: bool | None = None,
+        ) -> dict[str, dict]:
+            calls[-1]["unit_labels_by_box_id"] = unit_labels_by_box_id
+            calls[-1]["parallel"] = parallel
+            return {"BOX1": {"instruments": {}}}
 
     monkeypatch.setattr(
-        manager,
-        "_load_quelware_client_factory",
-        lambda: lambda endpoint, port: _FakeClient(),
+        configuration_manager_module,
+        "Quel3HardwareStateReader",
+        _FakeHardwareStateReader,
     )
 
     fetched = manager.fetch_backend_settings_from_hardware(
-        unit_labels_by_box_id={
-            "BOX1": "quel3-02-a01",
-            "BOX2": "quel3-02-a02",
-            "BOX3": "quel3-02-a03",
-        },
+        unit_labels_by_box_id={"BOX1": "unit-a"},
         parallel=False,
     )
 
-    assert fetched == {
-        "BOX1": {
-            "instruments": {
-                "Q00": {
-                    "resource_id": "inst-q00",
-                    "port_id": "quel3-02-a01:tx_p04",
-                    "role": "TRANSMITTER",
-                    "definition": {
-                        "alias": "Q00",
-                        "role": "TRANSMITTER",
-                        "mode": "FIXED_TIMELINE",
-                        "profile": {
-                            "frequency_range_min": 4.1e9,
-                            "frequency_range_max": 4.3e9,
-                        },
-                    },
-                }
-            }
-        },
-        "BOX2": {
-            "instruments": {
-                "RQ00": {
-                    "resource_id": "inst-rq00",
-                    "port_id": "quel3-02-a02:trx_p00p04",
-                    "role": "TRANSCEIVER",
-                    "definition": {
-                        "alias": "RQ00",
-                        "role": "TRANSCEIVER",
-                        "mode": "FIXED_TIMELINE",
-                        "profile": {
-                            "frequency_range_min": 5.9e9,
-                            "frequency_range_max": 6.1e9,
-                        },
-                    },
-                }
-            }
-        },
-        "BOX3": {"instruments": {}},
-    }
-
-
-def test_fetch_backend_settings_skips_unselected_unit_instrument_details(
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Given selected unit labels, hardware fetch should not inspect instruments on other units."""
-    manager = Quel3ConfigurationManager()
-
-    class _InstrumentCategory:
-        name = "INSTRUMENT"
-
-    class _ResourceInfo:
-        def __init__(self, resource_id: str) -> None:
-            self.id = resource_id
-            self.category = _InstrumentCategory()
-
-    class _Role:
-        name = "TRANSMITTER"
-
-    class _Definition:
-        alias = "Q00"
-        role = _Role()
-        mode = None
-        profile = None
-
-    class _InstrumentInfo:
-        id = "quel3-02-a01:inst-q00"
-        port_id = "quel3-02-a01:tx_p04"
-        definition = _Definition()
-
-    get_calls: list[str] = []
-
-    class _FakeClient:
-        async def __aenter__(self) -> _FakeClient:
-            return self
-
-        async def __aexit__(
-            self,
-            exc_type: type[BaseException] | None,
-            exc: BaseException | None,
-            tb: object | None,
-        ) -> None:
-            _ = (exc_type, exc, tb)
-
-        async def list_resource_infos(self) -> list[object]:
-            return [
-                _ResourceInfo("quel3-02-a01:inst-q00"),
-                _ResourceInfo("quel3-02-a22:inst-q22"),
-            ]
-
-        async def get_instrument_info(self, resource_id: str) -> object:
-            get_calls.append(resource_id)
-            if resource_id != "quel3-02-a01:inst-q00":
-                raise AssertionError(f"Unexpected instrument fetch: {resource_id}")
-            return _InstrumentInfo()
-
-    monkeypatch.setattr(
-        manager,
-        "_load_quelware_client_factory",
-        lambda: lambda endpoint, port: _FakeClient(),
-    )
-
-    fetched = manager.fetch_backend_settings_from_hardware(
-        unit_labels_by_box_id={"BOX1": "quel3-02-a01"},
-    )
-
-    assert get_calls == ["quel3-02-a01:inst-q00"]
-    assert fetched["BOX1"]["instruments"]["Q00"]["resource_id"] == (
-        "quel3-02-a01:inst-q00"
-    )
+    assert fetched == {"BOX1": {"instruments": {}}}
+    assert calls == [
+        {
+            "runtime_config": runtime_config,
+            "unit_labels_by_box_id": {"BOX1": "unit-a"},
+            "parallel": False,
+        }
+    ]
 
 
 def test_sync_backend_settings_to_cache_restores_alias_mapping_from_snapshot() -> None:

--- a/tests/backend/test_quel3_hardware_state_formatting.py
+++ b/tests/backend/test_quel3_hardware_state_formatting.py
@@ -1,0 +1,91 @@
+"""Tests for QuEL-3 hardware state Rich formatting."""
+
+from __future__ import annotations
+
+from io import StringIO
+
+from rich.console import Console
+
+from qubex.backend.quel3.formatting import format_quel3_hardware_state
+from qubex.backend.quel3.models import (
+    Quel3HardwareState,
+    Quel3HardwareStateIssue,
+    Quel3InstrumentState,
+    Quel3PortDiagnostic,
+    Quel3PortState,
+    Quel3UnitState,
+)
+
+
+def _render_text(renderable: object) -> str:
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, width=140)
+    console.print(renderable)
+    return output.getvalue()
+
+
+def test_summary_view_returns_rich_renderable() -> None:
+    """Given hardware state, summary view should render key counts."""
+    state = Quel3HardwareState(
+        generated_at="2026-07-07T00:00:00+00:00",
+        endpoint="localhost",
+        port=50051,
+        selected_unit_labels=("unit-a",),
+        units=(Quel3UnitState(label="unit-a"),),
+        ports=(Quel3PortState(id="unit-a:tx_p01", unit_label="unit-a", role="TX"),),
+        instruments=(
+            Quel3InstrumentState(
+                id="unit-a:inst-q00",
+                unit_label="unit-a",
+                port_id="unit-a:tx_p01",
+                alias="unit-a:Q00",
+                normalized_alias="Q00",
+                role="TRANSMITTER",
+                mode="FIXED_TIMELINE",
+                frequency_range_min_hz=4.1e9,
+                frequency_range_max_hz=4.3e9,
+            ),
+        ),
+        diagnostics=(),
+        issues=(
+            Quel3HardwareStateIssue(
+                severity="warning",
+                code="UNKNOWN_PORT_DEPENDENCY",
+                message="Port references an unknown dependency.",
+                resource_id="unit-a:tx_p01",
+            ),
+        ),
+    )
+
+    text = _render_text(format_quel3_hardware_state(state, view="summary"))
+
+    assert "QuEL-3 hardware state" in text
+    assert "Units" in text
+    assert "Instruments" in text
+    assert "UNKNOWN_PORT_DEPENDENCY" in text
+
+
+def test_diagnostics_view_renders_port_dumps() -> None:
+    """Given diagnostic data, diagnostics view should render port dump text."""
+    state = Quel3HardwareState(
+        generated_at="2026-07-07T00:00:00+00:00",
+        endpoint="localhost",
+        port=50051,
+        selected_unit_labels=(),
+        units=(),
+        ports=(),
+        instruments=(),
+        diagnostics=(
+            Quel3PortDiagnostic(
+                port_id="unit-a:tx_p01",
+                unit_label="unit-a",
+                text="line: value",
+            ),
+        ),
+        issues=(),
+    )
+
+    text = _render_text(format_quel3_hardware_state(state, view="diagnostics"))
+
+    assert "unit-a:tx_p01" in text
+    assert "line: value" in text

--- a/tests/backend/test_quel3_hardware_state_reader.py
+++ b/tests/backend/test_quel3_hardware_state_reader.py
@@ -1,0 +1,391 @@
+"""Tests for QuEL-3 hardware state collection."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import cast
+
+import pytest
+
+from qubex.backend.quel3.interfaces import QuelwareClientFactory
+from qubex.backend.quel3.managers import Quel3HardwareStateReader
+
+
+@dataclass(frozen=True)
+class _Category:
+    name: str
+
+
+@dataclass(frozen=True)
+class _Role:
+    name: str
+
+
+@dataclass(frozen=True)
+class _Mode:
+    name: str
+
+
+@dataclass(frozen=True)
+class _Profile:
+    frequency_range_min: float | None = None
+    frequency_range_max: float | None = None
+
+
+@dataclass(frozen=True)
+class _Config:
+    sampling_period_fs: int | None = None
+    bitdepth: int | None = None
+    timeline_step_samples: int | None = None
+    samples_per_tick: int | None = None
+
+
+@dataclass(frozen=True)
+class _Definition:
+    alias: str
+    role: object
+    mode: object | None = None
+    profile: object | None = None
+
+
+@dataclass(frozen=True)
+class _ResourceInfo:
+    id: str
+    category: object
+
+
+@dataclass(frozen=True)
+class _PortInfo:
+    id: str
+    role: object
+    depends_on: list[str]
+
+
+@dataclass(frozen=True)
+class _InstrumentInfo:
+    id: str
+    port_id: str
+    definition: _Definition
+    config: _Config
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.instrument_info_calls: list[str] = []
+        self.port_state_calls: list[str] = []
+
+    async def __aenter__(self) -> _FakeClient:
+        return self
+
+    async def __aexit__(
+        self,
+        exc_type: type[BaseException] | None,
+        exc: BaseException | None,
+        tb: object | None,
+    ) -> None:
+        _ = (exc_type, exc, tb)
+
+    def list_unit_labels(self) -> list[str]:
+        return ["unit-a", "unit-b"]
+
+    async def list_resource_infos(self) -> list[_ResourceInfo]:
+        return [
+            _ResourceInfo("unit-a:tx_p01", _Category("PORT")),
+            _ResourceInfo("unit-a:inst-q00", _Category("INSTRUMENT")),
+            _ResourceInfo("unit-b:inst-q01", _Category("INSTRUMENT")),
+        ]
+
+    async def get_port_info(self, resource_id: str) -> _PortInfo:
+        if resource_id != "unit-a:tx_p01":
+            raise KeyError(resource_id)
+        return _PortInfo(
+            id="unit-a:tx_p01",
+            role=_Role("TX"),
+            depends_on=["unit-a:clock"],
+        )
+
+    async def get_instrument_info(self, resource_id: str) -> _InstrumentInfo:
+        self.instrument_info_calls.append(resource_id)
+        if resource_id == "unit-a:inst-q00":
+            return _InstrumentInfo(
+                id="unit-a:inst-q00",
+                port_id="unit-a:tx_p01",
+                definition=_Definition(
+                    alias="unit-a:Q00",
+                    role=_Role("TRANSMITTER"),
+                    mode=_Mode("FIXED_TIMELINE"),
+                    profile=_Profile(
+                        frequency_range_min=4.1e9,
+                        frequency_range_max=4.3e9,
+                    ),
+                ),
+                config=_Config(
+                    sampling_period_fs=400_000,
+                    bitdepth=16,
+                    timeline_step_samples=4,
+                    samples_per_tick=2,
+                ),
+            )
+        return _InstrumentInfo(
+            id="unit-b:inst-q01",
+            port_id="unit-b:tx_p02",
+            definition=_Definition(
+                alias="Q01",
+                role=_Role("TRANSMITTER"),
+                mode=_Mode("FIXED_TIMELINE"),
+                profile=_Profile(
+                    frequency_range_min=5.0e9,
+                    frequency_range_max=5.2e9,
+                ),
+            ),
+            config=_Config(),
+        )
+
+    async def dump_port_state(self, port_id: str) -> str:
+        self.port_state_calls.append(port_id)
+        return f"state: {port_id}"
+
+
+class _UnqualifiedInstrumentResourceClient(_FakeClient):
+    async def list_resource_infos(self) -> list[_ResourceInfo]:
+        return [
+            _ResourceInfo("unit-a:tx_p01", _Category("PORT")),
+            _ResourceInfo("inst-q00", _Category("INSTRUMENT")),
+        ]
+
+    async def get_instrument_info(self, resource_id: str) -> _InstrumentInfo:
+        self.instrument_info_calls.append(resource_id)
+        return _InstrumentInfo(
+            id="inst-q00",
+            port_id="unit-a:tx_p01",
+            definition=_Definition(
+                alias="Q00",
+                role=_Role("TRANSMITTER"),
+                mode=_Mode("FIXED_TIMELINE"),
+                profile=_Profile(
+                    frequency_range_min=4.1e9,
+                    frequency_range_max=4.3e9,
+                ),
+            ),
+            config=_Config(),
+        )
+
+
+class _UnqualifiedOtherUnitResourceClient(_FakeClient):
+    async def list_resource_infos(self) -> list[_ResourceInfo]:
+        return [
+            _ResourceInfo("unit-a:tx_p01", _Category("PORT")),
+            _ResourceInfo("port-other", _Category("PORT")),
+            _ResourceInfo("inst-other", _Category("INSTRUMENT")),
+        ]
+
+    async def get_port_info(self, resource_id: str) -> _PortInfo:
+        if resource_id == "unit-a:tx_p01":
+            return await super().get_port_info(resource_id)
+        return _PortInfo(
+            id="unit-b:tx_p02",
+            role=_Role("TX"),
+            depends_on=[],
+        )
+
+    async def get_instrument_info(self, resource_id: str) -> _InstrumentInfo:
+        self.instrument_info_calls.append(resource_id)
+        return _InstrumentInfo(
+            id=resource_id,
+            port_id="unit-b:tx_p02",
+            definition=_Definition(
+                alias="Q00",
+                role=_Role("TRANSMITTER"),
+                mode=_Mode("FIXED_TIMELINE"),
+                profile=_Profile(
+                    frequency_range_min=5.0e9,
+                    frequency_range_max=5.2e9,
+                ),
+            ),
+            config=_Config(),
+        )
+
+
+class _BoxLocalAliasClient(_FakeClient):
+    async def list_resource_infos(self) -> list[_ResourceInfo]:
+        return [
+            _ResourceInfo("unit-a:tx_p01", _Category("PORT")),
+            _ResourceInfo("unit-b:tx_p01", _Category("PORT")),
+            _ResourceInfo("unit-a:inst-q00", _Category("INSTRUMENT")),
+            _ResourceInfo("unit-b:inst-q00", _Category("INSTRUMENT")),
+        ]
+
+    async def get_port_info(self, resource_id: str) -> _PortInfo:
+        return _PortInfo(
+            id=resource_id,
+            role=_Role("TX"),
+            depends_on=[],
+        )
+
+    async def get_instrument_info(self, resource_id: str) -> _InstrumentInfo:
+        self.instrument_info_calls.append(resource_id)
+        unit_label = resource_id.split(":", maxsplit=1)[0]
+        return _InstrumentInfo(
+            id=resource_id,
+            port_id=f"{unit_label}:tx_p01",
+            definition=_Definition(
+                alias="Q00",
+                role=_Role("TRANSMITTER"),
+                mode=_Mode("FIXED_TIMELINE"),
+                profile=_Profile(
+                    frequency_range_min=4.1e9,
+                    frequency_range_max=4.3e9,
+                ),
+            ),
+            config=_Config(),
+        )
+
+
+class _FakeHardwareStateReader(Quel3HardwareStateReader):
+    def __init__(self, client: _FakeClient) -> None:
+        super().__init__()
+        self._client = client
+
+    def _load_quelware_client_factory(self) -> QuelwareClientFactory:
+        """Return a fake quelware client factory for tests."""
+        return cast(QuelwareClientFactory, lambda endpoint, port: self._client)
+
+
+def _make_reader(client: _FakeClient) -> Quel3HardwareStateReader:
+    return _FakeHardwareStateReader(client)
+
+
+def test_collect_state_normalizes_units_ports_and_instruments() -> None:
+    """Given quelware resources, hardware state should expose normalized Qubex data."""
+    client = _FakeClient()
+    reader = _make_reader(client)
+
+    state = reader.collect_state(unit_labels=("unit-a",), parallel=False)
+
+    assert [unit.label for unit in state.units] == ["unit-a"]
+    assert [port.id for port in state.ports] == ["unit-a:tx_p01"]
+    assert state.ports[0].role == "TX"
+    assert state.ports[0].depends_on == ("unit-a:clock",)
+    assert [instrument.id for instrument in state.instruments] == ["unit-a:inst-q00"]
+    instrument = state.instruments[0]
+    assert instrument.alias == "unit-a:Q00"
+    assert instrument.normalized_alias == "Q00"
+    assert instrument.role == "TRANSMITTER"
+    assert instrument.mode == "FIXED_TIMELINE"
+    assert instrument.frequency_range_min_hz == pytest.approx(4.1e9)
+    assert instrument.frequency_range_max_hz == pytest.approx(4.3e9)
+    assert instrument.sampling_period_fs == 400_000
+    assert client.instrument_info_calls == ["unit-a:inst-q00"]
+
+
+def test_collect_state_records_fetch_errors_without_raising() -> None:
+    """Given a failed resource fetch, hardware state should keep an issue."""
+    client = _FakeClient()
+
+    async def _fail_instrument(resource_id: str) -> _InstrumentInfo:
+        raise RuntimeError(f"failed {resource_id}")
+
+    client.get_instrument_info = _fail_instrument  # type: ignore[method-assign]
+    reader = _make_reader(client)
+
+    state = reader.collect_state(unit_labels=("unit-a",), parallel=True)
+
+    assert state.instruments == ()
+    assert any(issue.code == "RESOURCE_FETCH_ERROR" for issue in state.issues)
+    assert any(issue.resource_id == "unit-a:inst-q00" for issue in state.issues)
+
+
+def test_collect_state_diagnosis_is_opt_in() -> None:
+    """Given diagnostics disabled, hardware state should not dump port state."""
+    client = _FakeClient()
+    reader = _make_reader(client)
+
+    state = reader.collect_state(unit_labels=("unit-a",), include_diagnostics=False)
+
+    assert state.diagnostics == ()
+    assert client.port_state_calls == []
+
+    state_with_diagnostics = reader.collect_state(
+        unit_labels=("unit-a",),
+        include_diagnostics=True,
+    )
+
+    assert state_with_diagnostics.diagnostics[0].text == "state: unit-a:tx_p01"
+    assert client.port_state_calls == ["unit-a:tx_p01"]
+
+
+def test_backend_settings_projection_uses_hardware_state_instruments() -> None:
+    """Given hardware state, backend settings projection should keep deploy cache fields."""
+    client = _FakeClient()
+    reader = _make_reader(client)
+
+    settings = reader.fetch_backend_settings_from_hardware(
+        unit_labels_by_box_id={
+            "BOX1": "unit-a",
+            "BOX2": "unit-c",
+        },
+        parallel=False,
+    )
+
+    assert settings == {
+        "BOX1": {
+            "instruments": {
+                "Q00": {
+                    "resource_id": "unit-a:inst-q00",
+                    "port_id": "unit-a:tx_p01",
+                    "role": "TRANSMITTER",
+                    "definition": {
+                        "alias": "unit-a:Q00",
+                        "role": "TRANSMITTER",
+                        "mode": "FIXED_TIMELINE",
+                        "profile": {
+                            "frequency_range_min": 4.1e9,
+                            "frequency_range_max": 4.3e9,
+                        },
+                    },
+                }
+            }
+        },
+        "BOX2": {"instruments": {}},
+    }
+
+
+def test_backend_settings_fetch_keeps_unqualified_instrument_resources() -> None:
+    """Backend settings fetch should keep unqualified instrument resources."""
+    client = _UnqualifiedInstrumentResourceClient()
+    reader = _make_reader(client)
+
+    settings = reader.fetch_backend_settings_from_hardware(
+        unit_labels_by_box_id={"BOX1": "unit-a"},
+        parallel=False,
+    )
+
+    assert settings["BOX1"]["instruments"]["Q00"]["resource_id"] == "inst-q00"
+    assert settings["BOX1"]["instruments"]["Q00"]["port_id"] == "unit-a:tx_p01"
+    assert client.instrument_info_calls == ["inst-q00"]
+
+
+def test_collect_state_filters_unqualified_resources_by_resolved_unit() -> None:
+    """Selected-unit collection should filter unqualified resources after fetch."""
+    client = _UnqualifiedOtherUnitResourceClient()
+    reader = _make_reader(client)
+
+    state = reader.collect_state(unit_labels=("unit-a",), parallel=False)
+
+    assert [port.id for port in state.ports] == ["unit-a:tx_p01"]
+    assert state.instruments == ()
+    assert client.instrument_info_calls == ["inst-other"]
+
+
+def test_collect_state_scopes_duplicate_aliases_by_unit() -> None:
+    """Multi-unit collection should allow box-local normalized aliases."""
+    client = _BoxLocalAliasClient()
+    reader = _make_reader(client)
+
+    state = reader.collect_state(parallel=False)
+
+    assert [instrument.normalized_alias for instrument in state.instruments] == [
+        "Q00",
+        "Q00",
+    ]
+    assert not any(issue.code == "DUPLICATE_INSTRUMENT_ALIAS" for issue in state.issues)

--- a/tests/system/test_quel3_target_deploy_planner.py
+++ b/tests/system/test_quel3_target_deploy_planner.py
@@ -360,3 +360,67 @@ def test_quel3_synchronizer_does_not_cache_experiment_system_for_push() -> None:
     )
 
     assert planner_calls == [pushed_experiment_system]
+
+
+def test_quel3_synchronizer_projects_hardware_state_to_backend_settings() -> None:
+    """Given selected boxes, synchronizer should fetch backend settings from hardware state."""
+    calls: list[dict[str, object]] = []
+
+    class _FakeHardwareStateReader:
+        def fetch_backend_settings_from_hardware(
+            self,
+            *,
+            unit_labels_by_box_id: dict[str, str],
+            parallel: bool | None = None,
+        ) -> dict[str, dict]:
+            calls.append(
+                {
+                    "unit_labels_by_box_id": unit_labels_by_box_id,
+                    "parallel": parallel,
+                }
+            )
+            return {
+                "BOX1": {
+                    "instruments": {
+                        "Q00": {
+                            "resource_id": "unit-a:inst-q00",
+                            "port_id": "unit-a:tx_p01",
+                            "role": "TRANSMITTER",
+                        }
+                    }
+                }
+            }
+
+    class _FakeBackendController:
+        hardware_state_reader = _FakeHardwareStateReader()
+
+    experiment_system = SimpleNamespace(
+        get_box=lambda box_id: SimpleNamespace(id=box_id, name="unit-a"),
+    )
+    synchronizer = Quel3SystemSynchronizer(
+        backend_controller=cast(Any, _FakeBackendController()),
+    )
+
+    fetched = synchronizer.fetch_backend_settings_from_hardware(
+        experiment_system=cast(Any, experiment_system),
+        box_ids=("BOX1",),
+        parallel=False,
+    )
+
+    assert fetched == {
+        "BOX1": {
+            "instruments": {
+                "Q00": {
+                    "resource_id": "unit-a:inst-q00",
+                    "port_id": "unit-a:tx_p01",
+                    "role": "TRANSMITTER",
+                }
+            }
+        }
+    }
+    assert calls == [
+        {
+            "unit_labels_by_box_id": {"BOX1": "unit-a"},
+            "parallel": False,
+        }
+    ]


### PR DESCRIPTION
## Summary
- Add a read-only QuEL-3 hardware state reader and structured hardware state models.
- Expose hardware-state collection and Rich views through the QuEL-3 backend controller.
- Preserve backend-settings fetch compatibility by projecting current hardware state into the existing cache shape.

## API impact
- Introduces `Quel3HardwareStateReader` as the public read-only hardware state component.
- Uses `hardware_state_reader` on `Quel3BackendController`; no `HardwareStateManager` alias is kept because this branch has not shipped in a tagged release.

## Validation
- `uv run pytest tests/backend/test_quel3_hardware_state_reader.py tests/backend/test_quel3_backend_controller.py tests/backend/test_quel3_configuration_manager.py tests/system/test_quel3_target_deploy_planner.py` - 77 passed
- `uv run ruff check --fix` - passed
- `uv run ruff format` - 502 files left unchanged
- `uv run pyright` - 0 errors
- `uv run pytest` - 1157 passed