### PR TITLE
feat(quel3)!: unify hardware-state filters

### DIFF
--- a/src/qubex/backend/quel3/managers/hardware_state_reader.py
+++ b/src/qubex/backend/quel3/managers/hardware_state_reader.py
@@ -84,21 +84,45 @@ class Quel3HardwareStateReader:
         self,
         *,
         unit_labels: Sequence[str] = (),
-        instrument_port_ids: Sequence[str] = (),
-        diagnostic_port_ids: Sequence[str] = (),
+        port_ids: Sequence[str] = (),
+        instrument_aliases: Sequence[str] = (),
         include_diagnostics: bool = False,
         parallel: bool = True,
         timeout_seconds: float | None = None,
     ) -> Quel3HardwareState:
-        """Collect one structured QuEL-3 hardware-state snapshot."""
+        """
+        Collect one structured QuEL-3 hardware-state snapshot.
+
+        Filters are applied in order: `unit_labels`, then `port_ids`, then
+        `instrument_aliases`. Local port IDs and aliases match every currently
+        selected unit. Unit-qualified aliases narrow instruments, their related
+        ports, and diagnostics to the qualified unit.
+
+        Parameters
+        ----------
+        unit_labels : Sequence[str], optional
+            Unit labels to inspect. Empty means all discovered units.
+        port_ids : Sequence[str], optional
+            Full port IDs such as `unit-a:tx_p01` or local IDs such as
+            `tx_p01`.
+        instrument_aliases : Sequence[str], optional
+            Unit-qualified aliases such as `unit-a:Q00` or local aliases such
+            as `Q00`.
+        include_diagnostics : bool, optional
+            Whether to collect diagnostic dumps for the final visible ports.
+        parallel : bool, optional
+            Whether resource reads should run concurrently.
+        timeout_seconds : float | None, optional
+            Timeout for the synchronous collection call.
+        """
         timeout = (
             DEFAULT_TIMEOUT_SECONDS if timeout_seconds is None else timeout_seconds
         )
         return _run_async(
             lambda: self._collect_state(
                 unit_labels=tuple(unit_labels),
-                instrument_port_ids=tuple(instrument_port_ids),
-                diagnostic_port_ids=tuple(diagnostic_port_ids),
+                port_ids=tuple(port_ids),
+                instrument_aliases=tuple(instrument_aliases),
                 include_diagnostics=include_diagnostics,
                 parallel=parallel,
             ),
@@ -128,8 +152,8 @@ class Quel3HardwareStateReader:
         self,
         *,
         unit_labels: tuple[str, ...],
-        instrument_port_ids: tuple[str, ...],
-        diagnostic_port_ids: tuple[str, ...],
+        port_ids: tuple[str, ...],
+        instrument_aliases: tuple[str, ...],
         include_diagnostics: bool,
         parallel: bool,
     ) -> Quel3HardwareState:
@@ -167,13 +191,17 @@ class Quel3HardwareStateReader:
                 client=client,
                 resource_infos=resource_infos,
                 selected_unit_labels=selected_unit_labels,
-                instrument_port_ids=instrument_port_ids,
                 parallel=parallel,
+            )
+            ports, instruments = self._filter_visible_state(
+                ports=ports,
+                instruments=instruments,
+                port_ids=port_ids,
+                instrument_aliases=instrument_aliases,
             )
             diagnostics, diagnostic_issues = await self._collect_diagnostics(
                 client=client,
                 ports=ports,
-                diagnostic_port_ids=diagnostic_port_ids,
                 include_diagnostics=include_diagnostics,
                 parallel=parallel,
             )
@@ -270,7 +298,6 @@ class Quel3HardwareStateReader:
         client: QuelwareClientProtocol,
         resource_infos: Sequence[object],
         selected_unit_labels: tuple[str, ...],
-        instrument_port_ids: tuple[str, ...],
         parallel: bool,
     ) -> tuple[tuple[Quel3InstrumentState, ...], tuple[Quel3HardwareStateIssue, ...]]:
         """Collect instrument states and preserve per-resource failures as issues."""
@@ -291,7 +318,6 @@ class Quel3HardwareStateReader:
             fetch=_fetch,
             parallel=parallel,
         )
-        selected_port_ids = set(instrument_port_ids)
         instruments: list[Quel3InstrumentState] = []
         issues: list[Quel3HardwareStateIssue] = []
         for resource_id, result in zip(instrument_resource_ids, results, strict=True):
@@ -309,8 +335,6 @@ class Quel3HardwareStateReader:
                 selected_unit_labels=selected_unit_labels,
             ):
                 continue
-            if selected_port_ids and result.port_id not in selected_port_ids:
-                continue
             instruments.append(result)
         return tuple(instruments), tuple(issues)
 
@@ -319,14 +343,13 @@ class Quel3HardwareStateReader:
         *,
         client: QuelwareClientProtocol,
         ports: Sequence[Quel3PortState],
-        diagnostic_port_ids: tuple[str, ...],
         include_diagnostics: bool,
         parallel: bool,
     ) -> tuple[tuple[Quel3PortDiagnostic, ...], tuple[Quel3HardwareStateIssue, ...]]:
         """Collect optional port diagnostic dumps."""
         if not include_diagnostics:
             return (), ()
-        port_ids = diagnostic_port_ids or tuple(port.id for port in ports)
+        port_ids = tuple(port.id for port in ports)
 
         async def _fetch(port_id: str) -> Quel3PortDiagnostic:
             dump_port_state = client.dump_port_state
@@ -356,6 +379,123 @@ class Quel3HardwareStateReader:
                 continue
             diagnostics.append(result)
         return tuple(diagnostics), tuple(issues)
+
+    @classmethod
+    def _filter_visible_state(
+        cls,
+        *,
+        ports: Sequence[Quel3PortState],
+        instruments: Sequence[Quel3InstrumentState],
+        port_ids: tuple[str, ...],
+        instrument_aliases: tuple[str, ...],
+    ) -> tuple[tuple[Quel3PortState, ...], tuple[Quel3InstrumentState, ...]]:
+        """Filter ports and instruments after selected-unit collection."""
+        visible_ports = tuple(
+            port
+            for port in ports
+            if cls._matches_port_filters(port_id=port.id, port_ids=port_ids)
+        )
+        visible_instruments = tuple(
+            instrument
+            for instrument in instruments
+            if cls._matches_port_filters(
+                port_id=instrument.port_id,
+                port_ids=port_ids,
+            )
+        )
+        visible_instruments = tuple(
+            instrument
+            for instrument in visible_instruments
+            if cls._matches_alias_filters(
+                instrument=instrument,
+                instrument_aliases=instrument_aliases,
+            )
+        )
+        if instrument_aliases:
+            visible_instrument_port_ids = {
+                instrument.port_id for instrument in visible_instruments
+            }
+            visible_ports = tuple(
+                port for port in visible_ports if port.id in visible_instrument_port_ids
+            )
+        return visible_ports, visible_instruments
+
+    @classmethod
+    def _matches_port_filters(
+        cls,
+        *,
+        port_id: str,
+        port_ids: tuple[str, ...],
+    ) -> bool:
+        """Return whether one port ID matches local or full selected IDs."""
+        if not port_ids:
+            return True
+        return any(
+            cls._matches_port_id(port_id=port_id, selected_port_id=selected_port_id)
+            for selected_port_id in port_ids
+        )
+
+    @classmethod
+    def _matches_port_id(
+        cls,
+        *,
+        port_id: str,
+        selected_port_id: str,
+    ) -> bool:
+        """Return whether one port ID matches a local or full ID filter."""
+        if ":" in selected_port_id:
+            return port_id == selected_port_id
+        return cls._local_resource_id(port_id) == selected_port_id
+
+    @classmethod
+    def _matches_alias_filters(
+        cls,
+        *,
+        instrument: Quel3InstrumentState,
+        instrument_aliases: tuple[str, ...],
+    ) -> bool:
+        """Return whether one instrument matches selected aliases."""
+        if not instrument_aliases:
+            return True
+        return any(
+            cls._matches_instrument_alias(
+                instrument=instrument,
+                selected_alias=selected_alias,
+            )
+            for selected_alias in instrument_aliases
+        )
+
+    @classmethod
+    def _matches_instrument_alias(
+        cls,
+        *,
+        instrument: Quel3InstrumentState,
+        selected_alias: str,
+    ) -> bool:
+        """Return whether one instrument matches a local or unit-qualified alias."""
+        if ":" in selected_alias:
+            unit_label, local_alias = selected_alias.split(":", maxsplit=1)
+            return (
+                instrument.unit_label == unit_label
+                and local_alias in cls._local_instrument_aliases(instrument)
+            )
+        return selected_alias in cls._local_instrument_aliases(instrument)
+
+    @classmethod
+    def _local_instrument_aliases(
+        cls,
+        instrument: Quel3InstrumentState,
+    ) -> tuple[str, ...]:
+        """Return local aliases that can match one instrument."""
+        aliases: list[str] = []
+        if instrument.normalized_alias is not None:
+            aliases.append(instrument.normalized_alias)
+        if instrument.alias is not None:
+            aliases.append(instrument.alias)
+            prefix = f"{instrument.unit_label}:"
+            if instrument.alias.startswith(prefix):
+                aliases.append(instrument.alias.removeprefix(prefix))
+        return tuple(dict.fromkeys(aliases))
 
     @staticmethod
     async def _collect_resource_results(
@@ -695,6 +835,13 @@ class Quel3HardwareStateReader:
     def _unit_label(resource_id: str) -> str:
         """Return the unit-label prefix from one resource ID."""
         return resource_id.split(":", maxsplit=1)[0]
+
+    @staticmethod
+    def _local_resource_id(resource_id: str) -> str:
+        """Return the local suffix from a unit-qualified resource ID."""
+        if ":" not in resource_id:
+            return resource_id
+        return resource_id.split(":", maxsplit=1)[1]
 
     @staticmethod
     def _category_name(category: object) -> str:

--- a/src/qubex/backend/quel3/quel3_backend_controller.py
+++ b/src/qubex/backend/quel3/quel3_backend_controller.py
@@ -245,17 +245,36 @@ class Quel3BackendController(BackendController):
         self,
         *,
         unit_labels: Sequence[str] = (),
-        instrument_port_ids: Sequence[str] = (),
-        diagnostic_port_ids: Sequence[str] = (),
+        port_ids: Sequence[str] = (),
+        instrument_aliases: Sequence[str] = (),
         include_diagnostics: bool = False,
         parallel: bool = True,
         timeout_seconds: float | None = None,
     ) -> Quel3HardwareState:
-        """Collect one structured QuEL-3 hardware-state snapshot."""
+        """
+        Collect one structured QuEL-3 hardware-state snapshot.
+
+        Parameters
+        ----------
+        unit_labels : Sequence[str], optional
+            Unit labels to inspect. Empty means all discovered units.
+        port_ids : Sequence[str], optional
+            Full port IDs or local port IDs used to filter ports and
+            instruments.
+        instrument_aliases : Sequence[str], optional
+            Unit-qualified aliases or local aliases used to filter instruments
+            and their related ports.
+        include_diagnostics : bool, optional
+            Whether to collect diagnostic dumps for the final visible ports.
+        parallel : bool, optional
+            Whether resource reads should run concurrently.
+        timeout_seconds : float | None, optional
+            Timeout for the synchronous hardware-state collection call.
+        """
         return self._hardware_state_reader.collect_state(
             unit_labels=tuple(unit_labels),
-            instrument_port_ids=tuple(instrument_port_ids),
-            diagnostic_port_ids=tuple(diagnostic_port_ids),
+            port_ids=tuple(port_ids),
+            instrument_aliases=tuple(instrument_aliases),
             include_diagnostics=include_diagnostics,
             parallel=parallel,
             timeout_seconds=timeout_seconds,
@@ -266,25 +285,46 @@ class Quel3BackendController(BackendController):
         *,
         view: Quel3HardwareStateView = "summary",
         unit_labels: Sequence[str] = (),
-        instrument_port_ids: Sequence[str] = (),
-        diagnostic_port_ids: Sequence[str] = (),
+        port_ids: Sequence[str] = (),
+        instrument_aliases: Sequence[str] = (),
         include_diagnostics: bool | None = None,
         parallel: bool = True,
         timeout_seconds: float | None = None,
-        console: Console | None = None,
     ) -> None:
-        """Print one QuEL-3 hardware-state view with Rich."""
+        """
+        Print one QuEL-3 hardware-state view with Rich.
+
+        Parameters
+        ----------
+        view : Quel3HardwareStateView, optional
+            Rendered view name.
+        unit_labels : Sequence[str], optional
+            Unit labels to inspect. Empty means all discovered units.
+        port_ids : Sequence[str], optional
+            Full port IDs or local port IDs used to filter ports and
+            instruments.
+        instrument_aliases : Sequence[str], optional
+            Unit-qualified aliases or local aliases used to filter instruments
+            and their related ports.
+        include_diagnostics : bool | None, optional
+            Whether to collect diagnostic dumps. `None` includes diagnostics
+            for the `diagnostics` and `all` views.
+        parallel : bool, optional
+            Whether resource reads should run concurrently.
+        timeout_seconds : float | None, optional
+            Timeout for the synchronous hardware-state collection call.
+        """
         if include_diagnostics is None:
             include_diagnostics = view in ("diagnostics", "all")
         state = self.get_hardware_state(
             unit_labels=unit_labels,
-            instrument_port_ids=instrument_port_ids,
-            diagnostic_port_ids=diagnostic_port_ids,
+            port_ids=port_ids,
+            instrument_aliases=instrument_aliases,
             include_diagnostics=include_diagnostics,
             parallel=parallel,
             timeout_seconds=timeout_seconds,
         )
-        output_console = console or Console(highlight=False)
+        output_console = Console(highlight=False)
         output_console.print(format_quel3_hardware_state(state, view=view))
 
     @property

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -16,6 +16,7 @@ import numpy as np
 import pytest
 from rich.console import Console
 
+import qubex.backend.quel3.quel3_backend_controller as quel3_backend_controller_module
 from qubex.backend import BackendExecutionRequest
 from qubex.backend.backend_controller import BackendController
 from qubex.backend.quel1 import Quel1BackendController
@@ -208,17 +209,52 @@ def test_get_hardware_state_delegates_to_hardware_state_reader() -> None:
 
     result = controller.get_hardware_state(
         unit_labels=("unit-a",),
+        port_ids=("tx_p01",),
+        instrument_aliases=("Q00",),
         include_diagnostics=True,
         parallel=False,
+        timeout_seconds=1.5,
     )
 
     assert result is state
     assert hardware_state_reader.last_collect_kwargs["unit_labels"] == ("unit-a",)
+    assert hardware_state_reader.last_collect_kwargs["port_ids"] == ("tx_p01",)
+    assert hardware_state_reader.last_collect_kwargs["instrument_aliases"] == ("Q00",)
     assert hardware_state_reader.last_collect_kwargs["include_diagnostics"] is True
     assert hardware_state_reader.last_collect_kwargs["parallel"] is False
+    assert hardware_state_reader.last_collect_kwargs["timeout_seconds"] == 1.5
 
 
-def test_print_hardware_state_renders_with_rich_console() -> None:
+def test_get_hardware_state_rejects_old_filter_kwargs() -> None:
+    """Given removed hardware-state filter kwargs, controller raises TypeError."""
+    controller = Quel3BackendController(
+        hardware_state_reader=cast(
+            Any,
+            _FakeHardwareStateReader(
+                Quel3HardwareState(
+                    generated_at="2026-07-07T00:00:00+00:00",
+                    endpoint="localhost",
+                    port=50051,
+                    selected_unit_labels=(),
+                    units=(),
+                    ports=(),
+                    instruments=(),
+                    diagnostics=(),
+                    issues=(),
+                )
+            ),
+        )
+    )
+
+    with pytest.raises(TypeError, match="instrument_port_ids"):
+        cast(Any, controller).get_hardware_state(instrument_port_ids=("unit-a:tx_p01",))
+    with pytest.raises(TypeError, match="diagnostic_port_ids"):
+        cast(Any, controller).get_hardware_state(diagnostic_port_ids=("unit-a:tx_p01",))
+
+
+def test_print_hardware_state_renders_with_rich_console(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     """Given hardware state, controller should print a Rich hardware-state view."""
     state = Quel3HardwareState(
         generated_at="2026-07-07T00:00:00+00:00",
@@ -235,11 +271,47 @@ def test_print_hardware_state_renders_with_rich_console() -> None:
         hardware_state_reader=cast(Any, _FakeHardwareStateReader(state))
     )
     output = StringIO()
-    console = Console(file=output, force_terminal=False, width=120)
 
-    controller.print_hardware_state(view="summary", console=console)
+    def _console_factory(*, highlight: bool) -> Console:
+        assert highlight is False
+        return Console(file=output, force_terminal=False, width=120)
+
+    monkeypatch.setattr(
+        quel3_backend_controller_module,
+        "Console",
+        _console_factory,
+    )
+
+    controller.print_hardware_state(view="summary")
 
     assert "QuEL-3 hardware state" in output.getvalue()
+
+
+def test_print_hardware_state_rejects_console_kwarg() -> None:
+    """Given removed console kwarg, controller raises TypeError."""
+    controller = Quel3BackendController(
+        hardware_state_reader=cast(
+            Any,
+            _FakeHardwareStateReader(
+                Quel3HardwareState(
+                    generated_at="2026-07-07T00:00:00+00:00",
+                    endpoint="localhost",
+                    port=50051,
+                    selected_unit_labels=(),
+                    units=(),
+                    ports=(),
+                    instruments=(),
+                    diagnostics=(),
+                    issues=(),
+                )
+            ),
+        )
+    )
+    output = StringIO()
+    console = Console(file=output, force_terminal=False, width=120)
+
+    with pytest.raises(TypeError, match="console"):
+        cast(Any, controller).print_hardware_state(console=console)
 
 
 def test_execute_rejects_non_quel3_payload() -> None:

--- a/tests/backend/test_quel3_hardware_state_reader.py
+++ b/tests/backend/test_quel3_hardware_state_reader.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import cast
+from typing import Any, cast
 
 import pytest
 
@@ -241,6 +241,48 @@ class _BoxLocalAliasClient(_FakeClient):
         )
 
 
+class _MultiInstrumentClient(_FakeClient):
+    async def list_resource_infos(self) -> list[_ResourceInfo]:
+        return [
+            _ResourceInfo("unit-a:tx_p01", _Category("PORT")),
+            _ResourceInfo("unit-a:rx_p02", _Category("PORT")),
+            _ResourceInfo("unit-b:tx_p01", _Category("PORT")),
+            _ResourceInfo("unit-a:inst-q00", _Category("INSTRUMENT")),
+            _ResourceInfo("unit-a:inst-q01", _Category("INSTRUMENT")),
+            _ResourceInfo("unit-b:inst-q00", _Category("INSTRUMENT")),
+        ]
+
+    async def get_port_info(self, resource_id: str) -> _PortInfo:
+        return _PortInfo(
+            id=resource_id,
+            role=_Role("TX") if "tx_" in resource_id else _Role("RX"),
+            depends_on=[],
+        )
+
+    async def get_instrument_info(self, resource_id: str) -> _InstrumentInfo:
+        self.instrument_info_calls.append(resource_id)
+        definitions = {
+            "unit-a:inst-q00": ("unit-a:tx_p01", "unit-a:Q00"),
+            "unit-a:inst-q01": ("unit-a:rx_p02", "Q01"),
+            "unit-b:inst-q00": ("unit-b:tx_p01", "Q00"),
+        }
+        port_id, alias = definitions[resource_id]
+        return _InstrumentInfo(
+            id=resource_id,
+            port_id=port_id,
+            definition=_Definition(
+                alias=alias,
+                role=_Role("TRANSMITTER"),
+                mode=_Mode("FIXED_TIMELINE"),
+                profile=_Profile(
+                    frequency_range_min=4.1e9,
+                    frequency_range_max=4.3e9,
+                ),
+            ),
+            config=_Config(),
+        )
+
+
 class _FakeHardwareStateReader(Quel3HardwareStateReader):
     def __init__(self, client: _FakeClient) -> None:
         super().__init__()
@@ -312,6 +354,95 @@ def test_collect_state_diagnosis_is_opt_in() -> None:
 
     assert state_with_diagnostics.diagnostics[0].text == "state: unit-a:tx_p01"
     assert client.port_state_calls == ["unit-a:tx_p01"]
+
+
+def test_collect_state_filters_local_port_after_unit_scoping() -> None:
+    """Given selected unit and local port ID, state should keep that unit port."""
+    client = _BoxLocalAliasClient()
+    reader = _make_reader(client)
+
+    state = reader.collect_state(
+        unit_labels=("unit-a",),
+        port_ids=("tx_p01",),
+        parallel=False,
+    )
+
+    assert [port.id for port in state.ports] == ["unit-a:tx_p01"]
+    assert [instrument.id for instrument in state.instruments] == ["unit-a:inst-q00"]
+
+
+def test_collect_state_matches_local_port_across_selected_units() -> None:
+    """Given local port ID without unit selection, state should keep all matches."""
+    client = _BoxLocalAliasClient()
+    reader = _make_reader(client)
+
+    state = reader.collect_state(port_ids=("tx_p01",), parallel=False)
+
+    assert [port.id for port in state.ports] == ["unit-a:tx_p01", "unit-b:tx_p01"]
+    assert [instrument.id for instrument in state.instruments] == [
+        "unit-a:inst-q00",
+        "unit-b:inst-q00",
+    ]
+
+
+def test_collect_state_filters_alias_related_ports_and_diagnostics() -> None:
+    """Given local alias filter, state should keep matched instruments and ports."""
+    client = _MultiInstrumentClient()
+    reader = _make_reader(client)
+
+    state = reader.collect_state(
+        unit_labels=("unit-a",),
+        instrument_aliases=("Q00",),
+        include_diagnostics=True,
+        parallel=False,
+    )
+
+    assert [port.id for port in state.ports] == ["unit-a:tx_p01"]
+    assert [instrument.id for instrument in state.instruments] == ["unit-a:inst-q00"]
+    assert [diagnostic.port_id for diagnostic in state.diagnostics] == ["unit-a:tx_p01"]
+    assert client.port_state_calls == ["unit-a:tx_p01"]
+
+
+def test_collect_state_matches_unit_qualified_alias() -> None:
+    """Given unit-qualified alias, state should keep only that unit match."""
+    client = _MultiInstrumentClient()
+    reader = _make_reader(client)
+
+    state = reader.collect_state(
+        instrument_aliases=("unit-b:Q00",),
+        parallel=False,
+    )
+
+    assert [port.id for port in state.ports] == ["unit-b:tx_p01"]
+    assert [instrument.id for instrument in state.instruments] == ["unit-b:inst-q00"]
+
+
+def test_collect_state_intersects_port_and_alias_filters() -> None:
+    """Given port and alias filters, state should keep only their intersection."""
+    client = _MultiInstrumentClient()
+    reader = _make_reader(client)
+
+    state = reader.collect_state(
+        port_ids=("unit-a:rx_p02",),
+        instrument_aliases=("Q00",),
+        include_diagnostics=True,
+        parallel=False,
+    )
+
+    assert state.ports == ()
+    assert state.instruments == ()
+    assert state.diagnostics == ()
+    assert client.port_state_calls == []
+
+
+def test_collect_state_rejects_old_filter_kwargs() -> None:
+    """Given removed hardware-state filter kwargs, reader raises TypeError."""
+    reader = _make_reader(_FakeClient())
+
+    with pytest.raises(TypeError, match="instrument_port_ids"):
+        cast(Any, reader).collect_state(instrument_port_ids=("unit-a:tx_p01",))
+    with pytest.raises(TypeError, match="diagnostic_port_ids"):
+        cast(Any, reader).collect_state(diagnostic_port_ids=("unit-a:tx_p01",))
 
 
 def test_backend_settings_projection_uses_hardware_state_instruments() -> None:


### PR DESCRIPTION
## Summary
- Replace QuEL-3 hardware-state filter kwargs with `unit_labels`, `port_ids`, and `instrument_aliases`.
- Apply the final visible port set consistently to instruments, diagnostics, and issue evaluation.
- Remove the `console` kwarg from `print_hardware_state()` and instantiate `Console(highlight=False)` internally.

## Compatibility
- Breaking change: `get_hardware_state()`, `print_hardware_state()`, and `Quel3HardwareStateReader.collect_state()` no longer accept `instrument_port_ids`, `diagnostic_port_ids`, or `console`.
- Documentation changes were intentionally left out per request.

## Validation
- `uv run pytest tests/backend/test_quel3_backend_controller.py tests/backend/test_quel3_hardware_state_reader.py` passed, 58 tests.
- Earlier full local gate on the same code change passed before docs were removed: `uv run ruff check --fix`, `uv run ruff format`, `uv run pyright`, and `uv run pytest`.
