### PR TITLE
feat: add fidelity objective for readout frequency

### DIFF
--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -4930,18 +4930,22 @@ class Experiment:
         frequency_width: float | None = None,
         readout_amplitude: float | None = None,
         electrical_delay: float | None = None,
+        objective: Literal["fidelity", "distance"] | None = None,
+        fidelity_ratio: float | None = None,
         n_shots: int | None = None,
         shot_interval: float | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
     ) -> Result:
-        """Find the readout frequency maximizing state separation."""
+        """Find the readout frequency maximizing state separation or fidelity."""
         return self.characterization_service.find_optimal_readout_frequency(
             target=target,
             df=df,
             frequency_width=frequency_width,
             readout_amplitude=readout_amplitude,
             electrical_delay=electrical_delay,
+            objective=objective,
+            fidelity_ratio=fidelity_ratio,
             shots=n_shots,
             interval=shot_interval,
             plot=plot,

--- a/src/qubex/experiment/services/characterization_service.py
+++ b/src/qubex/experiment/services/characterization_service.py
@@ -3951,13 +3951,15 @@ class CharacterizationService:
         frequency_width: float | None = None,
         readout_amplitude: float | None = None,
         electrical_delay: float | None = None,
+        objective: Literal["fidelity", "distance"] | None = None,
+        fidelity_ratio: float | None = None,
         shots: int | None = None,
         interval: float | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
     ) -> Result:
         """
-        Find readout frequency maximizing state separation.
+        Find readout frequency maximizing state separation or readout fidelity.
 
         Parameters
         ----------
@@ -3967,7 +3969,17 @@ class CharacterizationService:
             Frequency step in GHz.
         frequency_width
             Span around the center frequency.
+        objective
+            Optimization objective: `"distance"` maximizes IQ state distance
+            (default), `"fidelity"` maximizes GMM-based readout fidelity.
+        fidelity_ratio
+            Fraction of peak fidelity used as the acceptance threshold (0--1).
+            Only used when `objective="fidelity"`.
         """
+        if objective is None:
+            objective = "distance"
+        if fidelity_ratio is None:
+            fidelity_ratio = 0.99
         if shots is None:
             shots = CALIBRATION_SHOTS
         if interval is None:
@@ -3980,6 +3992,45 @@ class CharacterizationService:
             df = 0.0004
         if frequency_width is None:
             frequency_width = 0.02
+
+        if objective == "fidelity":
+            return self._find_optimal_readout_frequency_by_fidelity(
+                target=target,
+                df=df,
+                frequency_width=frequency_width,
+                readout_amplitude=readout_amplitude,
+                fidelity_ratio=fidelity_ratio,
+                shots=shots,
+                interval=interval,
+                plot=plot,
+                save_image=save_image,
+            )
+
+        return self._find_optimal_readout_frequency_by_distance(
+            target=target,
+            df=df,
+            frequency_width=frequency_width,
+            readout_amplitude=readout_amplitude,
+            electrical_delay=electrical_delay,
+            shots=shots,
+            interval=interval,
+            plot=plot,
+            save_image=save_image,
+        )
+
+    def _find_optimal_readout_frequency_by_distance(
+        self,
+        target: str,
+        df: float,
+        frequency_width: float,
+        readout_amplitude: float | None,
+        electrical_delay: float | None,
+        shots: int,
+        interval: float,
+        plot: bool,
+        save_image: bool,
+    ) -> Result:
+        """Find readout frequency maximizing IQ state distance."""
         result_0 = self.measure_reflection_coefficient(
             target,
             df=df,
@@ -4063,6 +4114,171 @@ class CharacterizationService:
                 "fig": fig,
             },
             figure=fig,
+        )
+
+    def _sweep_readout_frequency(
+        self,
+        target: str,
+        frequency_range: NDArray,
+        mode: Literal["avg", "single"],
+        readout_amplitude: float | None,
+        shots: int,
+        interval: float,
+    ) -> tuple[list[NDArray], list[NDArray]]:
+        """Sweep readout frequency and collect IQ data for states 0 and 1."""
+        read_label = self.ctx.resolve_read_label(target)
+        readout_amplitudes = (
+            None if readout_amplitude is None else {target: readout_amplitude}
+        )
+        buffer_0: list[NDArray] = []
+        buffer_1: list[NDArray] = []
+        for frequency in tqdm(frequency_range):
+            with self.ctx.modified_frequencies({read_label: float(frequency)}):
+                result_0 = self._measurement_service.measure_state(
+                    {target: "0"},
+                    mode=mode,
+                    readout_amplitudes=readout_amplitudes,
+                    shots=shots,
+                    interval=interval,
+                )
+                result_1 = self._measurement_service.measure_state(
+                    {target: "1"},
+                    mode=mode,
+                    readout_amplitudes=readout_amplitudes,
+                    shots=shots,
+                    interval=interval,
+                )
+            buffer_0.append(result_0.data[target].kerneled)
+            buffer_1.append(result_1.data[target].kerneled)
+        return buffer_0, buffer_1
+
+    def _find_optimal_readout_frequency_by_fidelity(
+        self,
+        target: str,
+        df: float,
+        frequency_width: float,
+        readout_amplitude: float | None,
+        fidelity_ratio: float,
+        shots: int,
+        interval: float,
+        plot: bool,
+        save_image: bool,
+    ) -> Result:
+        """Find readout frequency maximizing GMM-based readout fidelity."""
+        from qubex.measurement.classifiers.state_classifier_gmm import (
+            StateClassifierGMM,
+        )
+
+        read_label = self.ctx.resolve_read_label(target)
+        center_frequency = self.ctx.targets[read_label].frequency
+        frequency_range = np.arange(
+            center_frequency - frequency_width / 2,
+            center_frequency + frequency_width / 2,
+            df,
+        )
+        phase = self.ctx.reference_phases.get(target, 0.0)
+
+        buffer_0, buffer_1 = self._sweep_readout_frequency(
+            target,
+            frequency_range,
+            mode="single",
+            readout_amplitude=readout_amplitude,
+            shots=shots,
+            interval=interval,
+        )
+
+        fidelities: list[float] = []
+        for iq_0, iq_1 in zip(buffer_0, buffer_1, strict=True):
+            classifier = StateClassifierGMM.fit({0: iq_0, 1: iq_1}, phase=phase)
+            fid_per_state = []
+            for state, iq in enumerate([iq_0, iq_1]):
+                predicted = classifier.predict(iq)
+                correct = int(np.sum(predicted == state))
+                fid_per_state.append(correct / len(iq))
+            fidelities.append(float(np.mean(fid_per_state)))
+
+        fid_arr = np.array(fidelities)
+        fid_peak = float(fid_arr.max())
+        plateau_mask = fid_arr >= fid_peak * fidelity_ratio
+        best_idx = int(np.where(plateau_mask)[0][0])
+        optimal_frequency = float(frequency_range[best_idx])
+
+        fig = viz.make_figure(width=600, height=300)
+        fig.add_scatter(
+            x=list(frequency_range),
+            y=list(fid_arr),
+            name="Readout fidelity",
+            mode="lines+markers",
+        )
+        fig.add_vline(
+            x=optimal_frequency,
+            line_width=2,
+            line_color="red",
+            opacity=0.6,
+        )
+        fig.add_annotation(
+            xref="paper",
+            yref="paper",
+            x=0.95,
+            y=0.95,
+            text=(
+                f"f_opt: {optimal_frequency:.4f} GHz<br>"
+                f"fidelity: {fid_arr[best_idx]:.4f}<br>"
+                f"peak: {fid_peak:.4f}"
+            ),
+            showarrow=False,
+            bgcolor="rgba(255, 255, 255, 0.8)",
+        )
+        fig.update_layout(
+            title=f"Readout fidelity : {target}",
+            xaxis_title="Frequency (GHz)",
+            yaxis_title="Readout fidelity",
+        )
+
+        figures: dict[str, Any] = {"readout_fidelity": fig}
+        readout_amplitudes = (
+            None if readout_amplitude is None else {target: readout_amplitude}
+        )
+        with self.ctx.modified_frequencies({read_label: optimal_frequency}):
+            classifier_result = self._measurement_service.build_classifier(
+                targets=target,
+                readout_amplitudes=readout_amplitudes,
+                n_shots=shots,
+                shot_interval=interval,
+                plot=plot,
+            )
+        if classifier_result.figures is not None:
+            figures.update(classifier_result.figures)
+
+        if plot:
+            fig.show()
+            print(
+                f"f_opt: {optimal_frequency:.4f} GHz  "
+                f"readout_fidelity: {fid_arr[best_idx]:.4f}  "
+                f"peak: {fid_peak:.4f}"
+            )
+
+        if save_image:
+            viz.save_figure(
+                fig,
+                name=f"optimal_readout_frequency_fidelity_{target}",
+                width=600,
+                height=300,
+            )
+
+        return Result(
+            data={
+                "optimal_frequency": optimal_frequency,
+                "frequency_range": frequency_range,
+                "signals_0": np.array(buffer_0),
+                "signals_1": np.array(buffer_1),
+                "readout_fidelity": fid_arr,
+                "classifier_result": classifier_result,
+                # TODO: Remove this legacy payload key after callers migrate to .figure.
+                "fig": fig,
+            },
+            figure=fig,
+            figures=figures,
         )
 
     def find_optimal_readout_amplitude(

--- a/tests/experiment/test_experiment_facade_delegation.py
+++ b/tests/experiment/test_experiment_facade_delegation.py
@@ -42,6 +42,10 @@ class _CharacterizationServiceStub:
         self.calls.append(("characterize_2q", kwargs))
         return "characterize_2q_result"
 
+    def find_optimal_readout_frequency(self, **kwargs: Any) -> str:
+        self.calls.append(("find_optimal_readout_frequency", kwargs))
+        return "find_optimal_readout_frequency_result"
+
 
 class _MeasurementServiceStub:
     def __init__(self) -> None:
@@ -305,6 +309,49 @@ def test_characterize_2q_delegates_in_same_mux_to_characterization_service() -> 
             {
                 "targets": None,
                 "in_same_mux": False,
+                "shots": 512,
+                "interval": 240,
+                "plot": False,
+                "save_image": True,
+            },
+        )
+    ]
+
+
+def test_find_optimal_readout_frequency_delegates_objective_to_characterization_service() -> (
+    None
+):
+    """Given objective args, optimal readout frequency delegates to characterization service."""
+    exp = object.__new__(Experiment)
+    characterization_stub = _CharacterizationServiceStub()
+    exp.__dict__["_characterization_service"] = characterization_stub
+
+    result = exp.find_optimal_readout_frequency(
+        "Q00",
+        df=0.001,
+        frequency_width=0.02,
+        readout_amplitude=0.1,
+        electrical_delay=2.0,
+        objective="fidelity",
+        fidelity_ratio=0.98,
+        n_shots=512,
+        shot_interval=240,
+        plot=False,
+        save_image=True,
+    )
+
+    assert result == "find_optimal_readout_frequency_result"
+    assert characterization_stub.calls == [
+        (
+            "find_optimal_readout_frequency",
+            {
+                "target": "Q00",
+                "df": 0.001,
+                "frequency_width": 0.02,
+                "readout_amplitude": 0.1,
+                "electrical_delay": 2.0,
+                "objective": "fidelity",
+                "fidelity_ratio": 0.98,
                 "shots": 512,
                 "interval": 240,
                 "plot": False,

--- a/tests/experiment/test_optimal_readout_frequency.py
+++ b/tests/experiment/test_optimal_readout_frequency.py
@@ -1,0 +1,178 @@
+"""Tests for optimal readout-frequency selection."""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+from contextlib import contextmanager
+from types import SimpleNamespace
+from typing import Any, cast
+
+import numpy as np
+import pytest
+
+from qubex.experiment.services.characterization_service import CharacterizationService
+
+
+class _FakeFigure:
+    """Plotly-like figure stub for optimal-frequency tests."""
+
+    def add_scatter(self, **_kwargs: Any) -> None:
+        """Accept scatter traces."""
+        return
+
+    def add_vline(self, **_kwargs: Any) -> None:
+        """Accept vertical markers."""
+        return
+
+    def add_annotation(self, **_kwargs: Any) -> None:
+        """Accept annotations."""
+        return
+
+    def update_layout(self, **_kwargs: Any) -> None:
+        """Accept layout updates."""
+        return
+
+
+class _FakeContext:
+    """Experiment-context stub for optimal-frequency tests."""
+
+    def __init__(self) -> None:
+        self.reference_phases = {"Q00": 0.0}
+        self.targets = {"RQ00": SimpleNamespace(frequency=5.105)}
+        self.current_frequency: float | None = None
+        self.frequency_stack: list[float | None] = []
+
+    @staticmethod
+    def resolve_read_label(_target: str) -> str:
+        """Resolve the readout target label."""
+        return "RQ00"
+
+    @contextmanager
+    def modified_frequencies(
+        self,
+        frequencies: dict[str, float] | None,
+    ) -> Iterator[None]:
+        """Record the active readout frequency."""
+        self.frequency_stack.append(self.current_frequency)
+        self.current_frequency = None if frequencies is None else frequencies["RQ00"]
+        try:
+            yield
+        finally:
+            self.current_frequency = self.frequency_stack.pop()
+
+
+class _FakeMeasurementService:
+    """Measurement-service stub for optimal-frequency tests."""
+
+    def __init__(self, ctx: _FakeContext) -> None:
+        self.ctx = ctx
+        self.measure_state_calls: list[dict[str, Any]] = []
+        self.build_classifier_calls: list[dict[str, Any]] = []
+
+    def measure_state(self, states: dict[str, str], **kwargs: Any) -> Any:
+        """Return IQ data tagged by the active frequency and state."""
+        state = next(iter(states.values()))
+        frequency = cast(float, self.ctx.current_frequency)
+        self.measure_state_calls.append(
+            {"states": states, "frequency": frequency, **kwargs}
+        )
+        value = frequency + (0.0 if state == "0" else 0.001)
+        iq = np.full(4, value + 0j, dtype=np.complex128)
+        return SimpleNamespace(data={"Q00": SimpleNamespace(kerneled=iq)})
+
+    def build_classifier(self, **kwargs: Any) -> Any:
+        """Record classifier build calls."""
+        self.build_classifier_calls.append(
+            {"frequency": self.ctx.current_frequency, **kwargs}
+        )
+        return SimpleNamespace(figures={"classifier": object()})
+
+
+def test_find_optimal_readout_frequency_uses_fidelity_plateau_threshold(
+    monkeypatch,
+) -> None:
+    """Given fidelity objective, first frequency within peak ratio is selected."""
+    service = cast(Any, object.__new__(CharacterizationService))
+    ctx = _FakeContext()
+    measurement_service = _FakeMeasurementService(ctx)
+    service.__dict__["_experiment_context"] = ctx
+    service.__dict__["_measurement_service"] = measurement_service
+
+    frequency_range = np.array([5.0, 5.1, 5.2])
+
+    def fake_measure_reflection_coefficient(
+        *_args: Any, **_kwargs: Any
+    ) -> dict[str, Any]:
+        return {"frequency_range": frequency_range}
+
+    class _Classifier:
+        def __init__(self, predictions: dict[int, np.ndarray]) -> None:
+            self._predictions = predictions
+
+        def predict(self, iq: np.ndarray) -> np.ndarray:
+            return self._predictions[id(iq)]
+
+    def fake_fit(data: dict[int, np.ndarray], *, phase: float) -> _Classifier:
+        _ = phase
+        frequency = round(float(np.real(data[0][0])), 1)
+        if frequency == 5.0:
+            pred_0 = np.array([0, 1, 1, 1])
+            pred_1 = np.array([1, 1, 1, 0])
+        elif frequency == 5.1:
+            pred_0 = np.array([0, 0, 0, 0])
+            pred_1 = np.array([1, 1, 1, 1])
+        else:
+            pred_0 = np.array([0, 0, 0, 0])
+            pred_1 = np.array([1, 1, 1, 1])
+        return _Classifier({id(data[0]): pred_0, id(data[1]): pred_1})
+
+    monkeypatch.setattr(
+        service,
+        "measure_reflection_coefficient",
+        fake_measure_reflection_coefficient,
+    )
+    monkeypatch.setattr(
+        "qubex.experiment.services.characterization_service.viz.make_figure",
+        lambda **_kwargs: _FakeFigure(),
+    )
+    monkeypatch.setattr(
+        "qubex.measurement.classifiers.state_classifier_gmm.StateClassifierGMM.fit",
+        fake_fit,
+    )
+
+    result = service.find_optimal_readout_frequency(
+        "Q00",
+        df=0.1,
+        frequency_width=0.21,
+        objective="fidelity",
+        fidelity_ratio=0.99,
+        shots=4,
+        interval=10.0,
+        plot=False,
+        save_image=False,
+    )
+
+    np.testing.assert_allclose(
+        result.data["optimal_frequency"], 5.1, rtol=0, atol=1e-12
+    )
+    np.testing.assert_allclose(result.data["readout_fidelity"], [0.5, 1.0, 1.0])
+    assert result.data["signals_0"].shape == (3, 4)
+    assert result.data["signals_1"].shape == (3, 4)
+    with pytest.warns(DeprecationWarning, match="legacy figure payload key"):
+        assert result.data["fig"] is result.figure
+    np.testing.assert_allclose(
+        [call["frequency"] for call in measurement_service.measure_state_calls],
+        [5.0, 5.0, 5.1, 5.1, 5.2, 5.2],
+        rtol=0,
+        atol=1e-12,
+    )
+    assert measurement_service.build_classifier_calls == [
+        {
+            "frequency": 5.1,
+            "targets": "Q00",
+            "readout_amplitudes": None,
+            "n_shots": 4,
+            "shot_interval": 10.0,
+            "plot": False,
+        }
+    ]


### PR DESCRIPTION
## Summary
- Add opt-in `objective="fidelity"` mode to `find_optimal_readout_frequency` while keeping the default distance objective.
- Reuse the readout-amplitude fidelity selection pattern with a peak-ratio plateau threshold.
- Preserve common result payload keys for the new fidelity path and add tests for service behavior and Experiment facade delegation.

## Compatibility
- Existing calls remain on the distance objective by default.
- Existing distance-mode result payload is unchanged.
- Fidelity mode is additive and keeps `optimal_frequency`, `frequency_range`, `signals_0`, `signals_1`, and legacy `fig` alongside fidelity-specific data.

## Docs
- No direct user-guide page for this API was found. Generated API reference should pick up the updated source docstrings.

## Verification
- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- `uv run pytest`