### PR TITLE
Improve warning message in quel1 sync

### DIFF
--- a/docs/user-guide/getting-started/system-configuration.md
+++ b/docs/user-guide/getting-started/system-configuration.md
@@ -98,9 +98,11 @@ entries, they are required.
 `options` is optional and accepts a list of backend option labels for that box.
 Use it when a box needs a non-default hardware profile.
 
-For example, `quel1se-riken8` accepts an AWG profile label such as
-`se8_mxfe1_awg1331`, `se8_mxfe1_awg2222`, or `se8_mxfe1_awg3113`. When no AWG
-profile is specified, Qubex uses `se8_mxfe1_awg2222`.
+For example, `quel1se-riken8` accepts an AWG options label such as
+`se8_mxfe1_awg1331`, `se8_mxfe1_awg2222`, or `se8_mxfe1_awg3113`. Here, the last
+four digits refer to the number of FNCOs for each control port defined during
+the link-up procedure. When no AWG options label is specified, Qubex uses
+`se8_mxfe1_awg2222`.
 
 ### Control Layout Resolution
 

--- a/src/qubex/system/quel1/quel1_system_synchronizer.py
+++ b/src/qubex/system/quel1/quel1_system_synchronizer.py
@@ -276,7 +276,9 @@ class Quel1SystemSynchronizer:
                 ):
                     logger.warning(
                         "Skipping backend port sync for %s:%s due to fnco count mismatch "
-                        "(expected=%s, actual=%s).",
+                        "(expected=%s, actual=%s). Verify that the AWG profile in the "
+                        "box.yaml is correct (try se8_mxfe1_awg1331, se8_mxfe1_awg2222, "
+                        "or se8_mxfe1_awg3113) - see https://amachino.github.io/qubex/user-guide/getting-started/system-configuration/#boxyaml",
                         box_id,
                         port_number,
                         expected_fnco_count,

--- a/src/qubex/system/quel1/quel1_system_synchronizer.py
+++ b/src/qubex/system/quel1/quel1_system_synchronizer.py
@@ -276,13 +276,15 @@ class Quel1SystemSynchronizer:
                 ):
                     logger.warning(
                         "Skipping backend port sync for %s:%s due to fnco count mismatch "
-                        "(expected=%s, actual=%s). Verify that the AWG profile in the "
-                        "box.yaml is correct (try se8_mxfe1_awg1331, se8_mxfe1_awg2222, "
-                        "or se8_mxfe1_awg3113) - see https://amachino.github.io/qubex/user-guide/getting-started/system-configuration/#boxyaml",
+                        "(expected=%s, actual=%s). Verify that the 'type' and 'options' "
+                        "entries of %s in box.yaml match its active hardware "
+                        "configuration. For further details, see "
+                        "https://amachino.github.io/qubex/user-guide/getting-started/system-configuration/#boxyaml",
                         box_id,
                         port_number,
                         expected_fnco_count,
                         len(fnco_freqs_hz),
+                        box_id,
                     )
                     continue
                 updates.append(


### PR DESCRIPTION
Hi, I encountered the "Skipping backend port sync for box_xy:z due to fnco count mismatch" issue but it was difficult to find out how to fix it. In the end I found the solution on the Slack, but I think it's better if the error message directly shows what to do. Please let me know if the message needs clarification or if it's incorrect.