### PR TITLE
fix: defer QuEL-1 backend loading until selection

### DIFF
--- a/src/qubex/backend/quel1/compat/driver_loader.py
+++ b/src/qubex/backend/quel1/compat/driver_loader.py
@@ -9,8 +9,6 @@ from functools import lru_cache
 from importlib.metadata import PackageNotFoundError, version
 from typing import TYPE_CHECKING, Any, Literal, TypeAlias
 
-from qubex.patches.quel_ic_config import apply_quelware_runtime_patches
-
 if TYPE_CHECKING:
     from .qubecalib_protocols import (
         ActionProtocol,
@@ -179,6 +177,8 @@ def _resolve_symbol(*, package_name: DriverPackageName, symbol_name: str) -> Any
 
 def _import_driver_symbols(package_name: DriverPackageName) -> Que1lDriver:
     """Import one driver package and map required backend symbols by class-level paths."""
+    from qubex.patches.quel_ic_config import apply_quelware_runtime_patches
+
     importlib.import_module(package_name)
     apply_quelware_runtime_patches()
 

--- a/src/qubex/backend/quel1/managers/execution_manager.py
+++ b/src/qubex/backend/quel1/managers/execution_manager.py
@@ -14,7 +14,6 @@ from qubex.backend.quel1.compat.parallel_action_builder import (
     ClockHealthCheckOptions,
 )
 from qubex.backend.quel1.compat.qubecalib_protocols import SequencerProtocol
-from qubex.backend.quel1.compat.sequencer import Quel1Sequencer
 from qubex.backend.quel1.compat.sequencer_execution_engine import (
     SequencerExecutionEngine,
 )
@@ -150,6 +149,8 @@ class Quel1ExecutionManager:
         interval_ns: int,
     ) -> Sequencer:
         """Create QuEL-1 sequencer instance from prepared execution payload."""
+        from qubex.backend.quel1.compat.sequencer import Quel1Sequencer
+
         return Quel1Sequencer(
             gen_sampled_sequence=gen_sampled_sequence,
             cap_sampled_sequence=cap_sampled_sequence,

--- a/src/qubex/experiment/experiment_util.py
+++ b/src/qubex/experiment/experiment_util.py
@@ -50,7 +50,10 @@ class ExperimentUtil:
         """
         if isinstance(sampling_period, (int, float)):
             return float(sampling_period)
-        backend_controller = getattr(SystemManager.shared(), "backend_controller", None)
+        try:
+            backend_controller = SystemManager.shared().backend_controller
+        except RuntimeError:
+            backend_controller = None
         backend_sampling_period_ns = getattr(
             backend_controller,
             "sampling_period_ns",

--- a/src/qubex/system/system_manager.py
+++ b/src/qubex/system/system_manager.py
@@ -9,7 +9,7 @@ from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, cast
+from typing import Any
 
 from rich.prompt import Confirm
 from typing_extensions import Self, deprecated
@@ -147,12 +147,8 @@ class SystemManager:
         if self._initialized:
             return
         self._experiment_system = None
-        self._backend_kind: BackendKind = BACKEND_KIND_QUEL1
-        self._backend_controller = self._create_backend_controller(self._backend_kind)
-        self._system_synchronizer = self._create_system_synchronizer(
-            self._backend_controller,
-            self._backend_kind,
-        )
+        self._backend_controller: SystemBackendController | None = None
+        self._system_synchronizer: SystemSynchronizer | None = None
         self._backend_settings: BackendSettings = BackendSettings()
         self._cached_state = SystemState(0, 0, 0)
         self._rawdata_dir = None
@@ -169,9 +165,14 @@ class SystemManager:
         return Quel1BackendController()
 
     @property
-    def backend_kind(self) -> BackendKind:
+    def backend_kind(self) -> BackendKind | None:
         """Return backend family selected for the current experiment session."""
-        return self._backend_kind
+        backend_controller = self._backend_controller
+        if isinstance(backend_controller, Quel1BackendController):
+            return BACKEND_KIND_QUEL1
+        if isinstance(backend_controller, Quel3BackendController):
+            return BACKEND_KIND_QUEL3
+        return None
 
     def set_backend_kind(self, backend_kind: BackendKind) -> None:
         """
@@ -182,31 +183,26 @@ class SystemManager:
         backend_kind : BackendKind
             Backend family. One session uses either QuEL-1 or QuEL-3.
         """
-        if backend_kind == self._backend_kind:
+        backend_controller = self._backend_controller
+        if (
+            backend_kind == BACKEND_KIND_QUEL1
+            and isinstance(backend_controller, Quel1BackendController)
+        ) or (
+            backend_kind == BACKEND_KIND_QUEL3
+            and isinstance(backend_controller, Quel3BackendController)
+        ):
             return
-        self._backend_kind = backend_kind
         self._backend_controller = self._create_backend_controller(backend_kind)
         self._system_synchronizer = self._create_system_synchronizer(
             self._backend_controller,
-            self._backend_kind,
         )
         self._backend_settings = BackendSettings()
 
     def _create_system_synchronizer(
         self,
         backend_controller: SystemBackendController,
-        backend_kind: BackendKind | None = None,
     ) -> SystemSynchronizer | None:
         """Create backend-specific system synchronizer when supported."""
-        resolved_backend_kind = backend_kind or self._backend_kind
-        if resolved_backend_kind == BACKEND_KIND_QUEL1:
-            return Quel1SystemSynchronizer(
-                backend_controller=cast(Quel1BackendController, backend_controller),
-            )
-        if resolved_backend_kind == BACKEND_KIND_QUEL3:
-            return Quel3SystemSynchronizer(
-                backend_controller=cast(Quel3BackendController, backend_controller),
-            )
         if isinstance(backend_controller, Quel1BackendController):
             return Quel1SystemSynchronizer(backend_controller=backend_controller)
         if isinstance(backend_controller, Quel3BackendController):
@@ -216,35 +212,12 @@ class SystemManager:
     def _resolve_system_synchronizer(
         self,
     ) -> SystemSynchronizer | None:
-        """Return active system synchronizer, refreshing built-in synchronizers when needed."""
-        system_synchronizer = self._system_synchronizer
-        if system_synchronizer is None:
+        """Return the active system synchronizer."""
+        if self._backend_controller is None:
             return None
-        if isinstance(system_synchronizer, Quel1SystemSynchronizer):
-            if (
-                not isinstance(self._backend_controller, Quel1BackendController)
-                or system_synchronizer.backend_controller
-                is not self._backend_controller
-            ):
-                system_synchronizer = self._create_system_synchronizer(
-                    self._backend_controller,
-                    self._backend_kind,
-                )
-                self._system_synchronizer = system_synchronizer
-            return system_synchronizer
-        if isinstance(system_synchronizer, Quel3SystemSynchronizer):
-            if (
-                not isinstance(self._backend_controller, Quel3BackendController)
-                or system_synchronizer.backend_controller
-                is not self._backend_controller
-            ):
-                system_synchronizer = self._create_system_synchronizer(
-                    self._backend_controller,
-                    self._backend_kind,
-                )
-                self._system_synchronizer = system_synchronizer
-            return system_synchronizer
-        return system_synchronizer
+        if self._system_synchronizer is None:
+            raise RuntimeError("System synchronizer is not initialized.")
+        return self._system_synchronizer
 
     @property
     def rawdata_dir(self) -> Path | None:
@@ -271,7 +244,10 @@ class SystemManager:
     @property
     def backend_controller(self) -> SystemBackendController:
         """Return the backend controller."""
-        return self._backend_controller
+        backend_controller = self._backend_controller
+        if backend_controller is None:
+            raise RuntimeError("Backend controller is not initialized.")
+        return backend_controller
 
     @property
     @deprecated("Use `backend_controller` property instead.")
@@ -376,7 +352,6 @@ class SystemManager:
             self._backend_controller = backend_controller
             self._system_synchronizer = self._create_system_synchronizer(
                 backend_controller,
-                resolved_backend_kind,
             )
             self._backend_settings = BackendSettings()
         self._config_loader = next_config_loader

--- a/tests/backend/test_backend_public_api.py
+++ b/tests/backend/test_backend_public_api.py
@@ -66,6 +66,126 @@ def test_backend_quel3_module_hides_migrated_system_defaults() -> None:
     assert not hasattr(quel3, "DEFAULT_PUMP_FREQUENCY_GHZ")
 
 
+def test_experiment_import_does_not_load_backend_driver_dependencies() -> None:
+    """Given Experiment import, when loading the facade, then backend drivers stay unloaded."""
+    code = """
+import sys
+
+from qubex import Experiment
+
+assert Experiment.__name__ == "Experiment"
+loaded_backend_drivers = [
+    name
+    for name in sys.modules
+    if name.startswith(("qxdriver_quel1", "quel_ic_config", "quelware_client"))
+]
+assert loaded_backend_drivers == [], loaded_backend_drivers
+"""
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_quel1_package_import_defers_driver_loading_until_controller_init() -> None:
+    """Given QuEL-1 package import, when creating its controller, then drivers load lazily."""
+    code = """
+import sys
+
+import qubex.backend.quel1 as quel1
+
+loaded_quel1_drivers = [
+    name
+    for name in sys.modules
+    if name.startswith(("qxdriver_quel1", "quel_ic_config", "qubecalib"))
+]
+assert loaded_quel1_drivers == [], loaded_quel1_drivers
+
+controller = quel1.Quel1BackendController()
+assert controller.driver.package_name in sys.modules
+"""
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_quel3_selection_does_not_initialize_quel1_driver() -> None:
+    """Given QuEL-3 selection, when initializing its controller, then QuEL-1 drivers stay unloaded."""
+    code = """
+import sys
+
+from qubex.system import SystemManager
+
+manager = SystemManager.shared()
+manager.set_backend_kind("quel3")
+
+assert manager.backend_kind == "quel3"
+loaded_quel1_drivers = [
+    name
+    for name in sys.modules
+    if name.startswith(("qxdriver_quel1", "quel_ic_config", "qubecalib"))
+]
+assert loaded_quel1_drivers == [], loaded_quel1_drivers
+"""
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
+def test_system_manager_has_no_backend_before_selection() -> None:
+    """Given no backend selection, when reading backend state, then only the controller is unavailable."""
+    code = """
+import sys
+
+from qubex.system import SystemManager
+
+manager = SystemManager.shared()
+loaded_quel1_drivers = [
+    name
+    for name in sys.modules
+    if name.startswith(("qxdriver_quel1", "quel_ic_config", "qubecalib"))
+]
+assert loaded_quel1_drivers == [], loaded_quel1_drivers
+
+assert manager.backend_kind is None
+try:
+    manager.backend_controller
+except RuntimeError as exc:
+    assert "not initialized" in str(exc)
+else:
+    raise AssertionError("backend_controller unexpectedly available")
+
+loaded_quel1_drivers = [
+    name
+    for name in sys.modules
+    if name.startswith(("qxdriver_quel1", "quel_ic_config", "qubecalib"))
+]
+assert loaded_quel1_drivers == [], loaded_quel1_drivers
+"""
+    result = subprocess.run(  # noqa: S603
+        [sys.executable, "-c", code],
+        check=False,
+        capture_output=True,
+        text=True,
+    )
+
+    assert result.returncode == 0, result.stderr
+
+
 def test_quel3_import_and_controller_init_do_not_require_qxdriver_dependency() -> None:
     """Given missing qxdriver dependency, QuEL-3 import and init should still succeed."""
     code = """

--- a/tests/backend/test_driver_loader.py
+++ b/tests/backend/test_driver_loader.py
@@ -325,6 +325,8 @@ def test_load_quel1_driver_resolves_quel1box_symbol(
 
 def test_load_quel1_driver_applies_qubex_runtime_patches(monkeypatch) -> None:
     """Given driver load, when importing package, then qubex runtime patches are applied."""
+    import qubex.patches.quel_ic_config as quel_ic_config_patches
+
     mapping = _build_fake_driver_modules("qxdriver_quel1", include_compat=True)
     patch_calls: list[str] = []
 
@@ -339,7 +341,7 @@ def test_load_quel1_driver_applies_qubex_runtime_patches(monkeypatch) -> None:
     driver_loader.clear_quel1_driver_cache()
     monkeypatch.setattr(driver_loader, "version", lambda _: "0.10.0")
     monkeypatch.setattr(
-        driver_loader,
+        quel_ic_config_patches,
         "apply_quelware_runtime_patches",
         _apply_qubex_runtime_patches,
     )

--- a/tests/backend/test_quel1_backend_executor_mode.py
+++ b/tests/backend/test_quel1_backend_executor_mode.py
@@ -7,7 +7,6 @@ from typing import Any, cast
 
 import pytest
 
-import qubex.backend.quel1.managers.execution_manager as execution_manager_module
 from qubex.backend import BackendExecutionRequest
 from qubex.backend.quel1 import Quel1ExecutionPayload
 from qubex.backend.quel1.managers.execution_manager import Quel1ExecutionManager
@@ -126,6 +125,8 @@ def test_create_quel1_sequencer_passes_driver_for_constructor_compatibility(
     monkeypatch: Any,
 ) -> None:
     """Given manager sequencer creation, constructor receives driver and sysdb."""
+    import qubex.backend.quel1.compat.sequencer as sequencer_module
+
     created_kwargs: dict[str, Any] = {}
     fake_system = object()
     fake_sysdb = object()
@@ -143,7 +144,7 @@ def test_create_quel1_sequencer_passes_driver_for_constructor_compatibility(
         def quel1system(self) -> Any:
             return fake_system
 
-    monkeypatch.setattr(execution_manager_module, "Quel1Sequencer", _FakeSequencer)
+    monkeypatch.setattr(sequencer_module, "Quel1Sequencer", _FakeSequencer)
 
     class _ExecutionManager(Quel1ExecutionManager):
         def _execute_sequencer(self, **kwargs: Any) -> str:

--- a/tests/backend/test_system_manager.py
+++ b/tests/backend/test_system_manager.py
@@ -11,6 +11,7 @@ from types import SimpleNamespace
 import pytest
 
 from qubex.backend.backend_controller import BACKEND_KIND_QUEL1, BACKEND_KIND_QUEL3
+from qubex.backend.quel1 import Quel1BackendController
 from qubex.backend.quel3 import Quel3BackendController
 from qubex.system.control_system import PortType
 from qubex.system.system_manager import BackendSettings, SystemManager
@@ -33,16 +34,16 @@ class FakeBox:
     ports: tuple[FakePort, ...]
 
 
-class FakeBackendController:
+class FakeBackendController(Quel1BackendController):
     """Backend controller stub for backend settings tests."""
 
     def __init__(self, configs: dict[str, dict]) -> None:
         self._configs = configs
         self._box_config_cache: dict[str, dict] = {}
 
-    def dump_box(self, box_id: str) -> dict:
+    def dump_box(self, box_name: str) -> dict:
         """Return a predefined box configuration."""
-        return self._configs.get(box_id, {})
+        return self._configs.get(box_name, {})
 
     def get_box_config_cache(self) -> dict[str, dict]:
         """Return a copy of the current box-cache snapshot."""
@@ -61,6 +62,19 @@ class FakeBackendController:
     def hash(self) -> int:
         """Return a stable hash for controller state."""
         return 0
+
+
+def _set_backend_controller(
+    manager: SystemManager,
+    monkeypatch: pytest.MonkeyPatch,
+    backend_controller: Quel1BackendController | Quel3BackendController,
+) -> None:
+    monkeypatch.setattr(manager, "_backend_controller", backend_controller)
+    system_synchronizer = manager._create_system_synchronizer(  # noqa: SLF001
+        backend_controller
+    )
+    assert system_synchronizer is not None
+    monkeypatch.setattr(manager, "_system_synchronizer", system_synchronizer)
 
 
 class FakeExperimentSystem:
@@ -200,7 +214,7 @@ def test_fetch_backend_settings_from_hardware_collects_ports(
     }
     manager = SystemManager.shared()
     backend_controller = FakeBackendController(configs)
-    monkeypatch.setattr(manager, "_backend_controller", backend_controller)
+    _set_backend_controller(manager, monkeypatch, backend_controller)
     monkeypatch.setattr(
         manager, "_experiment_system", FakeExperimentSystem([box_a, box_b])
     )
@@ -237,7 +251,11 @@ def test_sync_backend_settings_to_experiment_system_updates_in_place(
     )
     experiment_system = FakeExperimentSystemForBackendSettings([box])
     monkeypatch.setattr(manager, "_experiment_system", experiment_system)
-    monkeypatch.setattr(manager, "_backend_controller", SimpleNamespace(hash=1))
+    _set_backend_controller(
+        manager,
+        monkeypatch,
+        object.__new__(Quel1BackendController),
+    )
     backend_settings = {
         "A": {
             "ports": {
@@ -302,7 +320,11 @@ def test_sync_backend_settings_to_experiment_system_skips_fnco_count_mismatch(
     )
     experiment_system = FakeExperimentSystemForBackendSettings([box])
     monkeypatch.setattr(manager, "_experiment_system", experiment_system)
-    monkeypatch.setattr(manager, "_backend_controller", SimpleNamespace(hash=1))
+    _set_backend_controller(
+        manager,
+        monkeypatch,
+        object.__new__(Quel1BackendController),
+    )
     backend_settings = {
         "A": {
             "ports": {
@@ -334,9 +356,9 @@ def test_fetch_backend_settings_from_hardware_has_no_side_effect(
     """Given current cache, when fetching, then manager backend settings stay unchanged."""
     manager = SystemManager.shared()
     box = FakeBox(id="A", ports=(FakePort(number=1, type=PortType.CTRL),))
-    monkeypatch.setattr(
+    _set_backend_controller(
         manager,
-        "_backend_controller",
+        monkeypatch,
         FakeBackendController({"A": {"ports": {1: {"mode": "ctrl"}}}}),
     )
     monkeypatch.setattr(manager, "_experiment_system", FakeExperimentSystem([box]))
@@ -354,9 +376,9 @@ def test_is_synced_has_no_side_effect_on_backend_settings(
     """Given mismatch, when checking sync, then backend settings stay unchanged."""
     manager = SystemManager.shared()
     box = FakeBox(id="A", ports=(FakePort(number=1, type=PortType.CTRL),))
-    monkeypatch.setattr(
+    _set_backend_controller(
         manager,
-        "_backend_controller",
+        monkeypatch,
         FakeBackendController({"A": {"ports": {1: {"mode": "ctrl"}}}}),
     )
     monkeypatch.setattr(manager, "_experiment_system", FakeExperimentSystem([box]))
@@ -386,7 +408,7 @@ def test_pull_merges_partial_backend_settings(
     )
     backend_controller = FakeBackendController({"A": {"ports": {1: {"mode": "ctrl"}}}})
     backend_controller.replace_box_config_cache({"B": {"ports": {2: {"mode": "read"}}}})
-    monkeypatch.setattr(manager, "_backend_controller", backend_controller)
+    _set_backend_controller(manager, monkeypatch, backend_controller)
     monkeypatch.setattr(
         manager,
         "_backend_settings",
@@ -420,7 +442,7 @@ def test_pull_restores_full_cache_after_partial_fetch_when_cache_is_empty(
     )
     backend_controller = FakeBackendController({"A": {"ports": {1: {"mode": "ctrl"}}}})
     backend_controller.replace_box_config_cache({})
-    monkeypatch.setattr(manager, "_backend_controller", backend_controller)
+    _set_backend_controller(manager, monkeypatch, backend_controller)
     monkeypatch.setattr(
         manager,
         "_backend_settings",
@@ -444,9 +466,9 @@ def test_is_synced_compares_requested_box_subset(
     manager = SystemManager.shared()
     box_a = FakeBox(id="A", ports=())
     monkeypatch.setattr(manager, "_experiment_system", FakeExperimentSystem([box_a]))
-    monkeypatch.setattr(
+    _set_backend_controller(
         manager,
-        "_backend_controller",
+        monkeypatch,
         FakeBackendController({"A": {"ports": {1: {"mode": "ctrl"}}}}),
     )
     monkeypatch.setattr(
@@ -495,6 +517,7 @@ def test_sync_experiment_system_to_hardware_parallel_submits_per_box(
             )
 
     monkeypatch.setattr(manager, "_system_synchronizer", _SystemSyncManager())
+    monkeypatch.setattr(manager, "_backend_controller", SimpleNamespace(hash=1))
     monkeypatch.setattr(manager, "_experiment_system", experiment_system)
 
     manager._sync_experiment_system_to_hardware(  # noqa: SLF001
@@ -537,6 +560,7 @@ def test_sync_experiment_system_to_hardware_sequential_calls_in_order(
             )
 
     monkeypatch.setattr(manager, "_system_synchronizer", _SystemSyncManager())
+    monkeypatch.setattr(manager, "_backend_controller", SimpleNamespace(hash=1))
     monkeypatch.setattr(manager, "_experiment_system", experiment_system)
 
     manager._sync_experiment_system_to_hardware(  # noqa: SLF001
@@ -577,6 +601,7 @@ def test_sync_experiment_system_to_backend_controller_delegates_to_system_synchr
             delegated.append(resolved_experiment_system)
 
     monkeypatch.setattr(manager, "_system_synchronizer", _SystemSyncManager())
+    monkeypatch.setattr(manager, "_backend_controller", SimpleNamespace(hash=1))
     monkeypatch.setattr(manager, "_experiment_system", experiment_system)
     monkeypatch.setattr(manager, "_backend_settings", BackendSettings())
 
@@ -605,7 +630,7 @@ def test_modified_backend_settings_initializes_shared_read_box_once(
         number: int
         fnco_freq: int
 
-    class _FakeBackendController:
+    class _FakeBackendController(Quel1BackendController):
         def __init__(self) -> None:
             self._cache = {
                 "BOX0": {
@@ -619,42 +644,53 @@ def test_modified_backend_settings_initializes_shared_read_box_once(
                     }
                 }
             }
-            self.initialize_calls: list[str | list[str]] = []
+            self.initialize_calls: list[str | Sequence[str]] = []
 
         def get_box_config_cache(self) -> dict[str, dict]:
             return deepcopy(self._cache)
 
         def config_port(
             self,
-            *,
             box_name: str,
-            port: int,
-            lo_freq_hz: int | None,
-            cnco_freq_hz: int,
+            *,
+            port: int | tuple[int, int],
+            lo_freq_hz: int | None = None,
+            cnco_freq_hz: int | None = None,
+            vatt: int | None = None,
+            sideband: str | None = None,
+            fullscale_current: int | None = None,
+            rfswitch: str | None = None,
         ) -> None:
+            del vatt, sideband, fullscale_current, rfswitch
+            assert isinstance(port, int)
+            assert cnco_freq_hz is not None
             self._cache[box_name]["ports"][port]["lo_freq"] = lo_freq_hz
             self._cache[box_name]["ports"][port]["cnco_freq"] = cnco_freq_hz
 
         def config_channel(
             self,
-            *,
             box_name: str,
-            port: int,
+            *,
+            port: int | tuple[int, int],
             channel: int,
-            fnco_freq_hz: int,
+            fnco_freq_hz: int | None = None,
         ) -> None:
+            assert isinstance(port, int)
+            assert fnco_freq_hz is not None
             self._cache[box_name]["ports"][port]["channels"][channel]["fnco_freq"] = (
                 fnco_freq_hz
             )
 
         def config_runit(
             self,
-            *,
             box_name: str,
-            port: int,
+            *,
+            port: int | tuple[int, int],
             runit: int,
-            fnco_freq_hz: int,
+            fnco_freq_hz: int | None = None,
         ) -> None:
+            assert isinstance(port, int)
+            assert fnco_freq_hz is not None
             self._cache[box_name]["ports"][port]["runits"][runit]["fnco_freq"] = (
                 fnco_freq_hz
             )
@@ -663,7 +699,13 @@ def test_modified_backend_settings_initializes_shared_read_box_once(
             for box_id, config in box_configs.items():
                 self._cache[box_id] = deepcopy(config)
 
-        def initialize_awg_and_capunits(self, box_names: str | list[str]) -> None:
+        def initialize_awg_and_capunits(
+            self,
+            box_names: str | Sequence[str],
+            *,
+            parallel: bool | None = None,
+        ) -> None:
+            del parallel
             self.initialize_calls.append(box_names)
 
         def replace_box_config_cache(self, box_configs: dict[str, dict]) -> None:
@@ -690,7 +732,7 @@ def test_modified_backend_settings_initializes_shared_read_box_once(
             return
 
     backend_controller = _FakeBackendController()
-    monkeypatch.setattr(manager, "_backend_controller", backend_controller)
+    _set_backend_controller(manager, monkeypatch, backend_controller)
     monkeypatch.setattr(manager, "_experiment_system", _FakeExperimentSystem())
 
     with manager.modified_backend_settings(
@@ -715,7 +757,7 @@ def test_push_cancel_restores_backend_controller_cache_from_backend_settings(
     backend_settings = {"A": {"ports": {1: {"mode": "ctrl"}}}}
     backend_controller = FakeBackendController({})
     backend_controller.replace_box_config_cache({})
-    monkeypatch.setattr(manager, "_backend_controller", backend_controller)
+    _set_backend_controller(manager, monkeypatch, backend_controller)
     monkeypatch.setattr(manager, "_backend_settings", backend_settings)
 
     box = SimpleNamespace(id="A", name="Alpha")
@@ -749,7 +791,7 @@ def test_push_does_not_reconfigure_ports(
     """Given user-modified system model, when pushing, then push does not reconfigure ports."""
     manager = SystemManager.shared()
     backend_controller = FakeBackendController({})
-    monkeypatch.setattr(manager, "_backend_controller", backend_controller)
+    _set_backend_controller(manager, monkeypatch, backend_controller)
     monkeypatch.setattr(manager, "_backend_settings", {})
 
     box = SimpleNamespace(id="A", name="Alpha")
@@ -794,7 +836,7 @@ def test_push_restores_full_cache_after_partial_fetch_when_cache_is_empty(
     manager = SystemManager.shared()
     backend_controller = FakeBackendController({})
     backend_controller.replace_box_config_cache({})
-    monkeypatch.setattr(manager, "_backend_controller", backend_controller)
+    _set_backend_controller(manager, monkeypatch, backend_controller)
     monkeypatch.setattr(
         manager,
         "_backend_settings",
@@ -843,6 +885,7 @@ def test_push_without_cache_sync_still_applies_hardware_sync(
             hash=0,
         ),
     )
+    monkeypatch.setattr(manager, "_backend_controller", SimpleNamespace(hash=0))
     monkeypatch.setattr(manager, "_supports_box_settings_cache_sync", lambda: False)
 
     called_sync_hardware = False
@@ -872,6 +915,7 @@ def test_push_forwards_target_labels_to_hardware_sync(
             hash=0,
         ),
     )
+    monkeypatch.setattr(manager, "_backend_controller", SimpleNamespace(hash=0))
     monkeypatch.setattr(manager, "_supports_box_settings_cache_sync", lambda: False)
     captured: dict[str, object] = {}
 
@@ -1000,9 +1044,12 @@ def test_modified_backend_settings_is_noop_for_quel3_without_cache_support(
 ) -> None:
     """Given QuEL-3 without cache support, modified_backend_settings should no-op."""
     manager = SystemManager.shared()
-    monkeypatch.setattr(manager, "_backend_kind", BACKEND_KIND_QUEL3)
     monkeypatch.setattr(manager, "_system_synchronizer", SimpleNamespace())
-    monkeypatch.setattr(manager, "_backend_controller", SimpleNamespace())
+    monkeypatch.setattr(
+        manager,
+        "_backend_controller",
+        object.__new__(Quel3BackendController),
+    )
     monkeypatch.setattr(manager, "_experiment_system", SimpleNamespace(hash=0))
 
     entered = False
@@ -1049,7 +1096,6 @@ def test_load_passes_backend_kind_to_selector(
 
     def _fake_set_backend_kind(kind: str) -> None:
         called.append(f"kind:{kind}")
-        manager.__dict__["_backend_kind"] = kind
 
     def _fake_sync() -> None:
         called.append("sync")
@@ -1094,7 +1140,6 @@ def test_load_uses_config_loader_backend_kind_when_backend_kind_is_omitted(
 
     def _fake_set_backend_kind(kind: str) -> None:
         called.append(f"kind:{kind}")
-        manager.__dict__["_backend_kind"] = kind
 
     monkeypatch.setattr("qubex.system.system_manager.ConfigLoader", _FakeConfigLoader)
     monkeypatch.setattr(manager, "set_backend_kind", _fake_set_backend_kind)
@@ -1298,7 +1343,6 @@ def test_load_defaults_to_quel1_when_system_backend_is_missing(
 
     def _fake_set_backend_kind(kind: str) -> None:
         selected.append(kind)
-        manager.__dict__["_backend_kind"] = kind
 
     monkeypatch.setattr("qubex.system.system_manager.ConfigLoader", _FakeConfigLoader)
     monkeypatch.setattr(manager, "set_backend_kind", _fake_set_backend_kind)
@@ -1349,7 +1393,6 @@ def test_load_resolves_backend_kind_from_system_config(
 
     def _fake_set_backend_kind(kind: str) -> None:
         selected.append(kind)
-        manager.__dict__["_backend_kind"] = kind
 
     monkeypatch.setattr("qubex.system.system_manager.ConfigLoader", _FakeConfigLoader)
     monkeypatch.setattr(manager, "set_backend_kind", _fake_set_backend_kind)
@@ -1397,7 +1440,6 @@ def test_load_explicit_backend_kind_overrides_default_resolution(
 
     def _fake_set_backend_kind(kind: str) -> None:
         selected.append(kind)
-        manager.__dict__["_backend_kind"] = kind
 
     monkeypatch.setattr("qubex.system.system_manager.ConfigLoader", _FakeConfigLoader)
     monkeypatch.setattr(manager, "set_backend_kind", _fake_set_backend_kind)
@@ -1451,7 +1493,6 @@ def test_load_explicit_backend_kind_overrides_system_config(
 
     def _fake_set_backend_kind(kind: str) -> None:
         selected.append(kind)
-        manager.__dict__["_backend_kind"] = kind
 
     monkeypatch.setattr("qubex.system.system_manager.ConfigLoader", _FakeConfigLoader)
     monkeypatch.setattr(manager, "set_backend_kind", _fake_set_backend_kind)
@@ -1500,7 +1541,6 @@ def test_load_defaults_to_quel1_when_chip_and_system_backend_are_missing(
 
     def _fake_set_backend_kind(kind: str) -> None:
         selected.append(kind)
-        manager.__dict__["_backend_kind"] = kind
 
     monkeypatch.setattr("qubex.system.system_manager.ConfigLoader", _FakeConfigLoader)
     monkeypatch.setattr(manager, "set_backend_kind", _fake_set_backend_kind)
@@ -1547,7 +1587,6 @@ def test_load_ignores_unknown_backend_kind_in_chip_config(
 
     def _fake_set_backend_kind(kind: str) -> None:
         selected.append(kind)
-        manager.__dict__["_backend_kind"] = kind
 
     monkeypatch.setattr("qubex.system.system_manager.ConfigLoader", _FakeConfigLoader)
     monkeypatch.setattr(manager, "set_backend_kind", _fake_set_backend_kind)
@@ -1594,7 +1633,8 @@ def test_load_preserves_backend_kind_when_experiment_system_resolution_fails(
 ) -> None:
     """Given experiment-system resolution failure, when loading, then backend kind and config loader remain unchanged."""
     manager = SystemManager.shared()
-    manager.__dict__["_backend_kind"] = BACKEND_KIND_QUEL1
+    previous_controller = object.__new__(Quel1BackendController)
+    manager.__dict__["_backend_controller"] = previous_controller
     previous_loader = object()
     manager.__dict__["_config_loader"] = previous_loader
     selected: list[str] = []
@@ -1615,7 +1655,6 @@ def test_load_preserves_backend_kind_when_experiment_system_resolution_fails(
 
     def _fake_set_backend_kind(kind: str) -> None:
         selected.append(kind)
-        manager.__dict__["_backend_kind"] = kind
 
     monkeypatch.setattr(
         "qubex.system.system_manager.ConfigLoader",
@@ -1631,4 +1670,5 @@ def test_load_preserves_backend_kind_when_experiment_system_resolution_fails(
 
     assert selected == []
     assert manager.backend_kind == BACKEND_KIND_QUEL1
+    assert manager.backend_controller is previous_controller
     assert manager.__dict__["_config_loader"] is previous_loader

--- a/tests/experiment/test_experiment_util_sampling_period.py
+++ b/tests/experiment/test_experiment_util_sampling_period.py
@@ -4,7 +4,10 @@ from __future__ import annotations
 
 import numpy as np
 
-from qubex.experiment.experiment_util import ExperimentUtil
+from qubex.experiment.experiment_util import (
+    DEFAULT_BACKEND_SAMPLING_PERIOD_NS,
+    ExperimentUtil,
+)
 
 
 def test_discretize_time_range_uses_backend_sampling_period_by_default(
@@ -27,3 +30,23 @@ def test_discretize_time_range_uses_backend_sampling_period_by_default(
     )
 
     assert np.allclose(discretized, np.array([0.4, 0.8]))
+
+
+def test_resolve_sampling_period_uses_default_before_backend_selection(
+    monkeypatch,
+) -> None:
+    """Given no selected backend, when resolving sampling period, then the default is returned."""
+
+    class _SystemManager:
+        @property
+        def backend_controller(self) -> object:
+            raise RuntimeError("Backend controller is not initialized.")
+
+    monkeypatch.setattr(
+        "qubex.experiment.experiment_util.SystemManager.shared",
+        _SystemManager,
+    )
+
+    sampling_period = ExperimentUtil.resolve_sampling_period()
+
+    assert sampling_period == float(DEFAULT_BACKEND_SAMPLING_PERIOD_NS)


### PR DESCRIPTION
## Background

Importing the high-level `Experiment` facade eagerly initialized the default QuEL-1 controller through `SystemManager`. That pulled driver-dependent modules into the import path even when the caller only needed the simulator or QuEL-3 support.

## Summary

- defer QuEL-1 runtime patch and sequencer imports until the corresponding driver or execution path is used
- keep `SystemManager` without a backend controller until configuration or an explicit selector chooses one
- derive backend kind from the installed controller and create controllers and synchronizers together
- preserve the default sampling-period fallback before backend selection
- add subprocess import-boundary tests and update backend lifecycle tests

## User and API impact

- `from qubex import Experiment` no longer loads `qxdriver_quel1`, `quel_ic_config`, or `quelware_client`
- importing `qubex.backend.quel1` does not load its driver until controller initialization
- selecting QuEL-3 does not initialize QuEL-1 driver dependencies
- before backend selection, `SystemManager.backend_kind` is `None` and `backend_controller` raises `RuntimeError`
- after configuration loading, backend selection is unchanged: an explicit selector wins, then `system.yaml`, then the QuEL-1 default

## Compatibility

The pre-selection `SystemManager` state changes from an eagerly created QuEL-1 controller to an explicit unselected state. Direct callers that access `backend_controller` immediately after `SystemManager.shared()` must load configuration or call `set_backend_kind()` first. Normal `Experiment` and configuration-loading workflows retain the existing QuEL-1 default.

## Documentation

No documentation changes are included. The existing installation and configuration guides already describe backend selection during configuration loading and state that simulator-only installs do not require the QuEL-1 backend extra; this change brings import behavior in line with those documented expectations.

## Validation

- `uv run ruff check --fix` — passed
- `uv run ruff format` — 497 files unchanged
- `uv run pyright` — 0 errors, 0 warnings
- `uv run pytest tests/backend/test_backend_public_api.py tests/backend/test_driver_loader.py tests/backend/test_quel1_backend_executor_mode.py tests/backend/test_system_manager.py tests/experiment/test_experiment_util_sampling_period.py` — 69 passed
- `uv run pytest` — 1,105 passed
