### PR TITLE
docs: improved parameter docs for top-level API, more progress bars

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
     "rich >= 13.0",
     "scikit-learn >= 1.0",
     "scipy >= 1.0",
-    "tqdm >= 4.0",
+    "tqdm >= 4.27.0",
     "typedunits >= 0.0",
     "typing_extensions >= 4.5",
 ]

--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -1000,7 +1000,21 @@ class Experiment:
         current_rabi_params: dict[str, RabiParam] | None = None,
         print_result: bool | None = None,
     ) -> dict[str, float]:
-        """Calculate control amplitudes for available targets."""
+        """
+        Calculate control amplitudes corresponding to a given target Rabi rate.
+
+        The calculation is done for all available targets.
+
+        Parameters
+        ----------
+        rabi_rate : float | None, optional
+            Target Rabi frequency to use for all targets in GHz. If None, uses
+            `qubex.experiment.experiment_constants.DEFAULT_RABI_FREQUENCY`.
+        current_rabi_params : dict[str, RabiParam] | None, optional
+            Dictionary that maps qubit label to existing Rabi parameters to use
+            for the calculation. If None, uses the values in
+            `self.pulse.rabi_params`.
+        """
         return self.pulse.calc_control_amplitudes(
             rabi_rate,
             current_amplitudes=current_amplitudes,
@@ -2412,7 +2426,32 @@ class Experiment:
         simultaneous: bool | None = None,
         **deprecated_options: Any,
     ) -> ExperimentResult[RabiData]:
-        """Obtain Rabi parameters for target qubits."""
+        """
+        Obtain Rabi parameters for target qubits by sweeping pulse duration.
+
+        Optionally stores the found Rabi parameters in `self.ctx` so that they
+        can be accessed via `self.pulse.rabi_params`.
+
+        Parameters
+        ----------
+        targets : Collection[str] | str, optional
+            Target qubits to calibrate.
+        time_range : ArrayLike | None, optional
+            Pulse durations to sweep in ns. If None, uses
+            `qubex.experiment.experiment_constants.DEFAULT_RABI_TIME_RANGE`.
+        amplitudes : dict[str, float] | None, optional
+            Dictionary that maps qubit label to qubit drive amplitude. If None,
+            uses the values from `self.params.control_amplitude`.
+        store_params : bool | None, optional
+            If True, update `self.ctx` with the acquired Rabi parameters. If
+            None, defaults to True.
+
+        Returns
+        -------
+        ExperimentResult[RabiData]
+            Result object containing result of Rabi fitting. The Rabi parameters
+            can be accessed with `result.data[qubit].rabi_param`.
+        """
         return self.measurement_service.obtain_rabi_params(
             targets=targets,
             time_range=time_range,
@@ -4732,7 +4771,24 @@ class Experiment:
         plot: bool | None = None,
         save_image: bool | None = None,
     ) -> Result:
-        """Scan resonator frequencies to find peaks."""
+        """
+        Scan resonator frequencies to find peaks.
+
+        Parameters
+        ----------
+        target : str | None, optional
+            Target qubit label.
+        frequency_range : ArrayLike | None, optional
+            Frequency values to scan in GHz. If None, uses values in
+            `self.experiment_system.get_readout_box_for_qubit(target).traits` to
+            determine the sweep values.
+        electrical_delay : float | None, optional
+            Electrical delay used for phase correction in ns. If None,
+            determined automatically using
+            `self.characterization_service.measure_electrical_delay`.
+        shot_interval : float | None, optional
+            Idle time between measurements in ns.
+        """
         return self.characterization_service.scan_resonator_frequencies(
             target=target,
             frequency_range=frequency_range,
@@ -4786,7 +4842,25 @@ class Experiment:
         plot: bool | None = None,
         save_image: bool | None = None,
     ) -> Result:
-        """Measure reflection coefficient around a center frequency."""
+        """
+        Measure reflection coefficient around a center frequency.
+
+        Parameters
+        ----------
+        target : str
+            Target qubit label.
+        center_frequency : float | None, optional
+            Center frequency around which to measure in GHz. If None, uses the
+            readout frequency corresponding to the target qubit from
+            `self.targets`, which in turn is determined by
+            `readout_frequency.yaml` or `resonator_frequency.yaml`.
+        df : float | None, optional
+            Frequency sweep step size in GHz. If None, uses 0.5 MHz step size by
+            default.
+        frequency_width : float | None, optional
+            Total width of the frequency sweep range in GHz. If None, uses 50
+            MHz by default.
+        """
         return self.characterization_service.measure_reflection_coefficient(
             target=target,
             center_frequency=center_frequency,
@@ -4817,7 +4891,21 @@ class Experiment:
         plot: bool | None = None,
         save_image: bool | None = None,
     ) -> Result:
-        """Scan qubit frequencies to locate resonances."""
+        """
+        Scan qubit frequencies to locate resonances.
+
+        Parameters
+        ----------
+        target : str
+            Target qubit label.
+        frequency_range : ArrayLike | None, optional
+            Control frequency values to scan in GHz. If None, uses values in
+            `self.experiment_system.get_control_box_for_qubit(target).traits` to
+            determine the sweep values.
+        control_amplitude : float | None, optional
+            Amplitude of the control pulse. If None, uses the value in
+            `self.params.control_amplitude`.
+        """
         return self.characterization_service.scan_qubit_frequencies(
             target=target,
             frequency_range=frequency_range,

--- a/src/qubex/experiment/models/rabi_param.py
+++ b/src/qubex/experiment/models/rabi_param.py
@@ -23,7 +23,7 @@ class RabiParam:
     amplitude : float
         Amplitude of the Rabi oscillation.
     frequency : float
-        Frequency of the Rabi oscillation.
+        Frequency of the Rabi oscillation in GHz.
     phase : float
         Phase of the Rabi oscillation in radians.
     offset : float

--- a/src/qubex/experiment/services/characterization_service.py
+++ b/src/qubex/experiment/services/characterization_service.py
@@ -23,7 +23,7 @@ from qxpulse import (
     Waveform,
 )
 from rich.prompt import Confirm
-from tqdm import tqdm
+from tqdm.auto import tqdm
 from typing_extensions import deprecated
 
 import qubex.visualization as viz
@@ -2433,7 +2433,7 @@ class CharacterizationService:
             if reset_awg_and_capunits:
                 self.ctx.reset_awg_and_capunits(box_ids=[read_box.id])
             phases = []
-            for freq in frequency_range:
+            for freq in tqdm(frequency_range, desc=f"electrical delay for {target}"):
                 with self.ctx.modified_frequencies({read_label: freq}):
                     result = self._measurement_service.measure(
                         {qubit_label: np.zeros(0)},
@@ -2606,7 +2606,9 @@ class CharacterizationService:
         ssb = read_box.traits.readout_ssb
         cnco_center = read_box.traits.readout_cnco_center
 
-        for subrange in subranges:
+        for subrange in tqdm(
+            subranges, desc=f"resonator freq. scan subranges for {target}"
+        ):
             f_center = (subrange[0] + subrange[-1]) / 2
             lo, cnco, _ = MixingUtil.calc_lo_cnco(
                 f_center * 1e9,
@@ -2619,7 +2621,13 @@ class CharacterizationService:
                 cnco_freq=cnco,
                 fnco_freq=0,
             ):
-                for sub_idx, freq in enumerate(subrange):
+                for sub_idx, freq in enumerate(
+                    tqdm(
+                        subrange,
+                        desc="resonator frequency within subrange",
+                        leave=False,
+                    )
+                ):
                     if idx > 0 and sub_idx == 0:
                         prev_freq = frequency_range[idx - 1]
                         with self.ctx.modified_frequencies({read_label: prev_freq}):
@@ -3081,7 +3089,7 @@ class CharacterizationService:
 
         self.ctx.reset_awg_and_capunits(qubits=[qubit_label])
 
-        for freq in freq_range:
+        for freq in tqdm(freq_range, desc=f"reflection coefficient for {target}"):
             with self.ctx.modified_frequencies({read_label: freq}):
                 result = self._measurement_service.measure(
                     {qubit_label: initialize_pulse},
@@ -3218,7 +3226,9 @@ class CharacterizationService:
 
         # measure the phase and amplitude
         idx = 0
-        for subrange in subranges:
+        for subrange in tqdm(
+            subranges, desc=f"qubit freq. scan subranges for {target}"
+        ):
             f_center = (subrange[0] + subrange[-1]) / 2
             lo, cnco, _ = MixingUtil.calc_lo_cnco(
                 f_center * 1e9,
@@ -3232,7 +3242,9 @@ class CharacterizationService:
                 fnco_freq=0,
             ):
                 self.ctx.reset_awg_and_capunits(qubits=[qubit])
-                for control_frequency in subrange:
+                for control_frequency in tqdm(
+                    subrange, desc="qubit frequency within subrange", leave=False
+                ):
                     with self.ctx.modified_frequencies(
                         {
                             qubit: control_frequency,
@@ -3702,7 +3714,7 @@ class CharacterizationService:
 
         power_range = np.array(power_range)
         result2d = []
-        for power in tqdm(power_range):
+        for power in tqdm(power_range, desc=f"control power sweep for {target}"):
             power_linear = 10 ** (power / 10)
             amplitude = np.sqrt(power_linear)
             result1d = self.scan_qubit_frequencies(

--- a/src/qubex/experiment/services/characterization_service.py
+++ b/src/qubex/experiment/services/characterization_service.py
@@ -2390,12 +2390,19 @@ class CharacterizationService:
 
         Parameters
         ----------
-        target
+        target : str
             Target qubit label.
-        f_start
-            Start frequency for the sweep.
-        n_samples
-            Number of frequency samples.
+        f_start : float | None, optional
+            Start frequency for the sweep in GHz.
+        df : float | None, optional
+            Frequency sweep step size in GHz.
+        n_samples : int | None, optional
+            Number of frequency steps.
+
+        Returns
+        -------
+        float
+            The electrical delay in ns.
         """
         if shots is None:
             shots = DEFAULT_SHOTS
@@ -3549,7 +3556,14 @@ class CharacterizationService:
         frequency_range
             Control frequency sweep range in GHz.
         target_rabi_rate
-            Target Rabi rate used for scaling.
+            Target Rabi rate used for scaling in GHz. If None, uses
+            `qubex.experiment.experiment_constants.DEFAULT_RABI_FREQUENCY`.
+
+        Returns
+        -------
+        Result
+            A Result object with the key 'estimated_amplitude', which is the
+            pulse amplitude that is predicted to produce the target Rabi rate.
         """
         if target_rabi_rate is None:
             target_rabi_rate = DEFAULT_RABI_FREQUENCY

--- a/src/qubex/experiment/services/session_service.py
+++ b/src/qubex/experiment/services/session_service.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import logging
+import time
 from collections.abc import Collection
 
 from qubex.experiment.experiment_context import ExperimentContext
@@ -62,12 +63,13 @@ class SessionService:
     ) -> None:
         """Connect measurement backend and synchronize sampling period."""
         try:
+            t = time.time()
             self.measurement.connect(
                 sync_clocks=sync_clocks,
                 parallel=parallel,
             )
             self._sync_pulse_sampling_period()
-            logger.info("Successfully connected.")
+            logger.info(f"Successfully connected in {time.time() - t:.1f} seconds.")
         except Exception:
             logger.exception("Failed to connect to the devices.")
             raise

--- a/uv.lock
+++ b/uv.lock
@@ -3506,7 +3506,7 @@ requires-dist = [
     { name = "rich", specifier = ">=13.0" },
     { name = "scikit-learn", specifier = ">=1.0" },
     { name = "scipy", specifier = ">=1.0" },
-    { name = "tqdm", specifier = ">=4.0" },
+    { name = "tqdm", specifier = ">=4.27.0" },
     { name = "typedunits", specifier = ">=0.0" },
     { name = "typing-extensions", specifier = ">=4.5" },
 ]


### PR DESCRIPTION
## Background

When starting out with qubex, it was hard to figure out units for parameters and where `None` defaults come from. The top-level `Experiment` methods are the main user-facing API, but their docstrings were one-liners with no parameter information.

Progress bars are useful for indicating that the measurement is successfully running. It is also useful to check that a sweep range is sensible by having an estimate of the remaining time.

## Summary of changes

- Extended docstrings with Parameters and Returns sections for 5 top-level `Experiment` methods: `calc_control_amplitudes`, `obtain_rabi_params`, `scan_resonator_frequencies`, `measure_reflection_coefficient`, `scan_qubit_frequencies`. Documented units, default values, and fallback behavior for most relevant parameters.
- Documented some additional parameters, units and return values in `CharacterizationService` and `RabiParam`.
- Replace bare `tqdm` import with `tqdm.auto` so that progress bars are nicely displayed in Jupyter
- Add `tqdm` progress bars to all iteration loops in `CharacterizationService` that sweep frequencies or powers (electrical delay, resonator scan, reflection coefficient, qubit scan, chevron).
- Print connection time in `SessionService.connect` for easier debugging of slow startup. (Currently it prints about 4-5 seconds for me.)


Some of the docstrings refer to internal implementation details (e.g. hard-coded 0.5 MHz default step size for `characteriztaion_service.measure_reflection_coefficient` ), but I think these are important to show explicitly in the top-level user-facing documentation. At least I read the documentation with `exp.measure_x?` in Jupyter or by looking at the source code, and it's very inefficient to jump between many different files.

## User/API impact

- Improved discoverability of `Experiment` method signatures via Jupyter `?`  syntax and source code inspection.
- No API changes.

## Compatibility

- No behavior changes.

## Validation

Open `src/qubex/experiment/experiment.py` with `exp.method?` in Jupyter to verify docstrings appear with parameter descriptions, units, and default value behavior.