### PR TITLE
docs: Remove blank lines after section headings in docstring guidelines

### DIFF
--- a/docs/developer-guide/docstring-guidelines.md
+++ b/docs/developer-guide/docstring-guidelines.md
@@ -23,7 +23,6 @@ Compute the fidelity between two states.
 
 Parameters
 ----------
-
 state_a : NDArray
     First state vector.
 state_b : NDArray
@@ -31,7 +30,6 @@ state_b : NDArray
 
 Returns
 -------
-
 float
     Fidelity in [0, 1].
 """
@@ -80,13 +78,11 @@ One‑sentence summary.
 
 Parameters
 ----------
-
 arg1 : type
     Description.
 
 Returns
 -------
-
 type
     Description.
 """


### PR DESCRIPTION
This is consistent with both the [numpy guidelines](https://numpydoc.readthedocs.io/en/latest/format.html#parameters) as well as the actual formatting used throughout the docs.