### PR TITLE
Feature/spin lock

### DIFF
--- a/src/qubex/contrib/__init__.py
+++ b/src/qubex/contrib/__init__.py
@@ -101,6 +101,10 @@ from .experiment.simultaneous_coherence_measurement import (
 from .experiment.simultaneous_qubit_spectroscopy import (
     simultaneous_qubit_spectroscopy,
 )
+from .experiment.spin_lock_spectroscopy import (
+    spin_lock_sequence,
+    spin_lock_spectroscopy,
+)
 from .experiment.stark_characterization import (
     stark_ramsey_experiment,
     stark_t1_experiment,
@@ -185,6 +189,8 @@ __all__ = [
     "rzx_gate_property",
     "simultaneous_coherence_measurement",
     "simultaneous_qubit_spectroscopy",
+    "spin_lock_sequence",
+    "spin_lock_spectroscopy",
     "stark_ramsey_experiment",
     "stark_t1_experiment",
     "sweep_readout_snr",

--- a/src/qubex/contrib/experiment/__init__.py
+++ b/src/qubex/contrib/experiment/__init__.py
@@ -89,6 +89,10 @@ from .repeated_coherence_measurement import repeated_coherence_measurement
 from .rzx_gate import rzx, rzx_gate_property
 from .simultaneous_coherence_measurement import simultaneous_coherence_measurement
 from .simultaneous_qubit_spectroscopy import simultaneous_qubit_spectroscopy
+from .spin_lock_spectroscopy import (
+    spin_lock_sequence,
+    spin_lock_spectroscopy,
+)
 from .stark_characterization import stark_ramsey_experiment, stark_t1_experiment
 from .superconducting_gap import get_resistance_charge, get_superconducting_gap
 from .thermal_excitation_characterization import (
@@ -166,6 +170,8 @@ __all__ = [
     "rzx_gate_property",
     "simultaneous_coherence_measurement",
     "simultaneous_qubit_spectroscopy",
+    "spin_lock_sequence",
+    "spin_lock_spectroscopy",
     "stark_ramsey_experiment",
     "stark_t1_experiment",
     "sweep_readout_snr",

--- a/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
+++ b/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
@@ -1,0 +1,623 @@
+"""Spin-lock spectroscopy sequence helpers."""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from typing import Any
+
+import numpy as np
+import plotly.graph_objects as go
+from numpy.typing import ArrayLike
+
+import qubex.visualization as viz
+from qubex.analysis import FitStatus, fitting
+from qubex.experiment import Experiment
+from qubex.experiment.experiment_constants import DEFAULT_INTERVAL, DEFAULT_SHOTS
+from qubex.experiment.models.result import Result
+from qubex.pulse import PulseSchedule, Rect
+
+__all__ = ["spin_lock_sequence", "spin_lock_spectroscopy"]
+
+DEFAULT_SPIN_LOCK_FREQUENCY_RANGE = np.geomspace(0.001, 0.2, 21)
+DEFAULT_DURATION_RANGE = np.geomspace(100, 200e3, 31)
+DEFAULT_DRIVE_PHASE = 0.0
+
+
+def spin_lock_sequence(
+    exp: Experiment,
+    *,
+    target: str,
+    duration: float,
+    drive_amplitude: float,
+    drive_detuning: float | None = None,
+    drive_phase: float | None = None,
+    initial_phase: float | None = None,
+    final_phase: float | None = None,
+) -> PulseSchedule:
+    """
+    Build a simple spin-lock pulse schedule for one target qubit.
+
+    Sequence structure:
+
+    1. Initial half-pi pulse.
+    2. Continuous spin-lock drive.
+    3. Final half-pi pulse for projection.
+
+    Parameters
+    ----------
+    exp
+        Experiment instance used to obtain calibrated half-pi pulses.
+    target
+        Target qubit label.
+    duration
+        Spin-lock drive duration in ns.
+    drive_amplitude
+        Spin-lock drive amplitude.
+    drive_detuning
+        Optional spin-lock drive detuning in GHz.
+    drive_phase
+        Optional spin-lock drive phase in radians. Defaults to ``0``.
+    initial_phase
+        Optional phase for the initial half-pi pulse in radians. Defaults to
+        ``drive_phase - pi/2``.
+    final_phase
+        Optional phase for the final half-pi pulse in radians. Defaults to
+        ``drive_phase + pi/2``.
+
+    Returns
+    -------
+        PulseSchedule
+        Pulse schedule containing the spin-lock sequence.
+    """
+    if duration <= 0:
+        raise ValueError("duration must be positive.")
+    if not np.isfinite(drive_amplitude):
+        raise ValueError("drive_amplitude must be finite.")
+    if abs(drive_amplitude) > 1:
+        raise ValueError("drive_amplitude must not exceed 1.")
+    if drive_detuning is not None and not np.isfinite(drive_detuning):
+        raise ValueError("drive_detuning must be finite.")
+
+    with PulseSchedule([target]) as schedule:
+        _add_spin_lock_pulse(
+            schedule,
+            exp,
+            target=target,
+            duration=duration,
+            drive_amplitude=drive_amplitude,
+            drive_detuning=drive_detuning,
+            drive_phase=drive_phase,
+            initial_phase=initial_phase,
+            final_phase=final_phase,
+        )
+    return schedule
+
+
+def _resolve_phases(
+    *,
+    drive_phase: float | None,
+    initial_phase: float | None,
+    final_phase: float | None,
+) -> tuple[float, float, float]:
+    resolved_drive_phase = DEFAULT_DRIVE_PHASE if drive_phase is None else drive_phase
+    resolved_initial_phase = (
+        resolved_drive_phase - np.pi / 2 if initial_phase is None else initial_phase
+    )
+    resolved_final_phase = (
+        resolved_drive_phase + np.pi / 2 if final_phase is None else final_phase
+    )
+    return resolved_drive_phase, resolved_initial_phase, resolved_final_phase
+
+
+def _normalize_targets(
+    exp: Experiment,
+    targets: Collection[str] | str | None,
+) -> list[str]:
+    if targets is None:
+        return list(exp.ctx.qubit_labels)
+    if isinstance(targets, str):
+        return [targets]
+    return list(targets)
+
+
+def _resolve_frequency_range(
+    spin_lock_frequency_range: ArrayLike | None,
+) -> np.ndarray:
+    if spin_lock_frequency_range is None:
+        spin_lock_frequency_range = DEFAULT_SPIN_LOCK_FREQUENCY_RANGE
+    frequencies = np.asarray(spin_lock_frequency_range, dtype=np.float64)
+    if frequencies.ndim != 1 or frequencies.size == 0:
+        raise ValueError("spin_lock_frequency_range must be a non-empty 1D array.")
+    if not np.all(np.isfinite(frequencies)):
+        raise ValueError("spin_lock_frequency_range must contain finite values.")
+    if np.any(frequencies <= 0):
+        raise ValueError("spin_lock_frequency_range must contain positive values.")
+    return frequencies
+
+
+def _resolve_duration_range(
+    exp: Experiment,
+    duration_range: ArrayLike | None,
+) -> np.ndarray:
+    if duration_range is None:
+        duration_range = DEFAULT_DURATION_RANGE
+    durations = np.asarray(duration_range, dtype=np.float64)
+    if durations.ndim != 1 or durations.size == 0:
+        raise ValueError("duration_range must be a non-empty 1D array.")
+    if not np.all(np.isfinite(durations)):
+        raise ValueError("duration_range must contain finite values.")
+    if np.any(durations <= 0):
+        raise ValueError("duration_range must contain positive values.")
+
+    sampling_period = exp.ctx.measurement.sampling_period
+    discretized = exp.ctx.util.discretize_time_range(
+        durations,
+        sampling_period=sampling_period,
+    )
+    if discretized is None:
+        raise ValueError("duration_range could not be discretized.")
+
+    discretized = np.asarray(discretized, dtype=np.float64)
+    if np.any(discretized <= 0):
+        raise ValueError("duration_range contains values below the sampling grid.")
+    return discretized
+
+
+def _effective_spin_lock_frequency_range(
+    spin_lock_rabi_frequency_range: np.ndarray,
+    *,
+    drive_detuning: float | None,
+) -> np.ndarray:
+    if drive_detuning is None:
+        drive_detuning = 0.0
+    drive_detuning = float(drive_detuning)
+    if not np.isfinite(drive_detuning):
+        raise ValueError("drive_detuning must be finite.")
+    return np.sqrt(spin_lock_rabi_frequency_range**2 + drive_detuning**2)
+
+
+def _resolve_spin_lock_amplitudes(
+    exp: Experiment,
+    *,
+    targets: list[str],
+    spin_lock_frequency_range: np.ndarray,
+) -> dict[str, np.ndarray]:
+    amplitudes = {
+        target: np.asarray(
+            [
+                exp.pulse.calc_control_amplitude(target, float(frequency))
+                for frequency in spin_lock_frequency_range
+            ],
+            dtype=np.float64,
+        )
+        for target in targets
+    }
+    for target, values in amplitudes.items():
+        if not np.all(np.isfinite(values)):
+            raise ValueError(f"Spin-lock amplitudes for `{target}` must be finite.")
+        if np.any(np.abs(values) > 1):
+            raise ValueError(
+                f"Spin-lock amplitude for `{target}` must not exceed 1. "
+                "Reduce spin_lock_frequency_range."
+            )
+    return amplitudes
+
+
+def _add_spin_lock_pulse(
+    schedule: PulseSchedule,
+    exp: Experiment,
+    *,
+    target: str,
+    duration: float,
+    drive_amplitude: float,
+    drive_detuning: float | None,
+    drive_phase: float | None,
+    initial_phase: float | None,
+    final_phase: float | None,
+) -> None:
+    drive_phase, initial_phase, final_phase = _resolve_phases(
+        drive_phase=drive_phase,
+        initial_phase=initial_phase,
+        final_phase=final_phase,
+    )
+
+    half_pi = exp.pulse.get_hpi_pulse(target)
+    spin_lock_drive = Rect(
+        duration=duration,
+        amplitude=drive_amplitude,
+    ).shifted(drive_phase)
+
+    if drive_detuning is not None:
+        spin_lock_drive = spin_lock_drive.detuned(drive_detuning)
+
+    schedule.add(target, half_pi.shifted(initial_phase))
+    schedule.add(target, spin_lock_drive)
+    schedule.add(target, half_pi.shifted(final_phase))
+
+
+def _make_spin_lock_heatmap_figure(
+    *,
+    target: str,
+    spin_lock_rabi_frequency_range: np.ndarray,
+    duration_range: np.ndarray,
+    population: np.ndarray,
+) -> go.Figure:
+    fig = viz.make_figure()
+    fig.add_trace(
+        go.Heatmap(
+            x=spin_lock_rabi_frequency_range * 1e3,
+            y=duration_range,
+            z=population,
+            colorscale="Viridis",
+        )
+    )
+    fig.update_layout(
+        title=dict(
+            text=f"Spin-lock spectroscopy : {target}",
+            x=0.5,
+            xanchor="center",
+        ),
+        xaxis_title="Spin-lock Rabi frequency (MHz)",
+        xaxis_type="log",
+        yaxis_title="Duration (ns)",
+        yaxis_type="log",
+        width=700,
+        height=500,
+    )
+    return fig
+
+
+def _make_spin_lock_relaxation_figure(
+    *,
+    target: str,
+    spin_lock_rabi_frequency_range: np.ndarray,
+    relaxation_times: np.ndarray,
+    relaxation_time_errors: np.ndarray,
+) -> go.Figure:
+    fig = viz.make_figure()
+    fig.add_trace(
+        go.Scatter(
+            x=spin_lock_rabi_frequency_range * 1e3,
+            y=relaxation_times * 1e-3,
+            error_y=dict(
+                type="data",
+                array=relaxation_time_errors * 1e-3,
+                visible=True,
+            ),
+            mode="markers+lines",
+            name=target,
+        )
+    )
+    fig.update_layout(
+        title=dict(
+            text=f"Spin-lock relaxation : {target}",
+            x=0.5,
+            xanchor="center",
+        ),
+        xaxis_title="Spin-lock Rabi frequency (MHz)",
+        xaxis_type="log",
+        yaxis_title="Relaxation time (us)",
+        yaxis_rangemode="tozero",
+        width=700,
+        height=450,
+    )
+    return fig
+
+
+def spin_lock_spectroscopy(
+    exp: Experiment,
+    targets: Collection[str] | str | None = None,
+    *,
+    spin_lock_frequency_range: ArrayLike | None = None,
+    duration_range: ArrayLike | None = None,
+    drive_detuning: float | None = None,
+    drive_phase: float | None = None,
+    initial_phase: float | None = None,
+    final_phase: float | None = None,
+    n_shots: int | None = None,
+    shot_interval: float | None = None,
+    plot: bool | None = None,
+    save_image: bool | None = None,
+    enable_tqdm: bool | None = None,
+) -> Result:
+    """
+    Run a simple spin-lock spectroscopy measurement.
+
+    This experiment prepares each qubit along the spin-lock drive axis, applies
+    a continuous drive for each requested duration, and projects the state back
+    for readout. The requested spin-lock frequencies are interpreted as Rabi
+    rates in GHz and are converted to hardware amplitudes with
+    ``exp.pulse.calc_control_amplitude(target, rabi_rate)``. When
+    ``drive_detuning`` is nonzero, the effective lock frequency is also stored
+    as ``sqrt(rabi_rate**2 + drive_detuning**2)``.
+
+    All ``(spin_lock_frequency, duration)`` points are flattened into one
+    ``sweep_parameter()`` call, following the same pattern as the chevron
+    measurement helpers.
+
+    Parameters
+    ----------
+    exp
+        Experiment instance used for pulse generation, measurement, and fitting.
+    targets
+        Target qubit labels. When omitted, all qubits in ``exp.ctx.qubit_labels``
+        are measured.
+    spin_lock_frequency_range
+        Spin-lock frequencies in GHz. These values are treated as desired Rabi
+        rates. If omitted, ``np.geomspace(0.001, 0.2, 21)`` is used, i.e.
+        1 MHz to 200 MHz.
+    duration_range
+        Spin-lock drive durations in ns. Values must be positive because the
+        heatmap and fit figures use a log time axis. The range is discretized to
+        ``exp.ctx.measurement.sampling_period``. If omitted,
+        ``np.geomspace(100, 200e3, 31)`` is used.
+    drive_detuning
+        Optional spin-lock drive detuning in GHz.
+    drive_phase
+        Spin-lock drive phase in radians. When omitted, ``0`` is used.
+    initial_phase
+        Initial half-pi pulse phase in radians. When omitted,
+        ``drive_phase - pi/2`` is used.
+    final_phase
+        Final half-pi pulse phase in radians. When omitted,
+        ``drive_phase + pi/2`` is used.
+    n_shots
+        Number of shots per sweep point. Defaults to ``DEFAULT_SHOTS``.
+    shot_interval
+        Measurement interval. Defaults to ``DEFAULT_INTERVAL``.
+    plot
+        Whether to display the heatmap and relaxation-time figures.
+    save_image
+        Whether to save the heatmap and relaxation-time figures.
+    enable_tqdm
+        Whether to show progress bars inside ``sweep_parameter()``. Defaults to
+        ``False`` to match the measurement service default.
+
+    Returns
+    -------
+    Result
+        Generic result containing measured arrays, fit summaries, and figures.
+        Important payload keys are:
+
+        ``spin_lock_rabi_frequency_range``
+            Requested spin-lock Rabi-frequency axis in GHz.
+        ``effective_spin_lock_frequency_range``
+            Effective lock-frequency axis in GHz including ``drive_detuning``.
+        ``spin_lock_frequency_range``
+            Alias of ``spin_lock_rabi_frequency_range`` kept for convenience.
+        ``duration_range``
+            Discretized duration axis in ns.
+        ``drive_amplitudes``
+            Per-target drive amplitudes calculated from the requested spin-lock
+            frequencies.
+        ``raw_data``
+            Per-target raw IQ data with shape
+            ``(len(spin_lock_frequency_range), len(duration_range))``.
+        ``population``
+            Per-target heatmap data with shape
+            ``(len(duration_range), len(spin_lock_frequency_range))``.
+        ``normalized_signal``
+            Per-target normalized signal before converting to population.
+        ``relaxation_times``
+            Per-target fitted spin-lock relaxation times in ns.
+        ``relaxation_time_errors``
+            Per-target one-sigma fit errors for the relaxation times in ns.
+        ``r2``
+            Per-target fit R² values.
+        ``fit_results``
+            Per-frequency fit metadata and fit parameters.
+
+        The ``figures`` mapping contains ``"{target}_heatmap"`` and
+        ``"{target}_relaxation"`` for each target, plus per-frequency fit figures
+        named ``"{target}_fit_{frequency_mhz}_MHz"``.
+
+    Notes
+    -----
+    - ``spin_lock_frequency_range`` is not a detuning sweep; it is the target
+      Rabi rate of the locking drive. The figure x-axis uses this Rabi-rate
+      axis, not the detuning-corrected effective lock frequency.
+    - The implementation raises an error if any calculated drive amplitude has
+      absolute value larger than 1.
+    - The fitted relaxation uses ``0.5 * (1 + normalized_signal)`` and
+      ``fitting.fit_exp_decay()``, matching the sign convention used by the T2
+      echo analysis path.
+    """
+    target_list = _normalize_targets(exp, targets)
+    if len(target_list) == 0:
+        raise ValueError("targets must contain at least one target.")
+
+    if n_shots is None:
+        n_shots = DEFAULT_SHOTS
+    if shot_interval is None:
+        shot_interval = DEFAULT_INTERVAL
+    if plot is None:
+        plot = True
+    if save_image is None:
+        save_image = False
+    if enable_tqdm is None:
+        enable_tqdm = False
+
+    exp.pulse.validate_rabi_params(target_list)
+
+    rabi_frequency_range = _resolve_frequency_range(spin_lock_frequency_range)
+    effective_frequency_range = _effective_spin_lock_frequency_range(
+        rabi_frequency_range,
+        drive_detuning=drive_detuning,
+    )
+    durations = _resolve_duration_range(exp, duration_range)
+    amplitude_map = _resolve_spin_lock_amplitudes(
+        exp,
+        targets=target_list,
+        spin_lock_frequency_range=rabi_frequency_range,
+    )
+
+    sweep_points = [
+        (frequency_index, duration_index)
+        for frequency_index in range(rabi_frequency_range.size)
+        for duration_index in range(durations.size)
+    ]
+
+    def sequence(point_index: int) -> PulseSchedule:
+        frequency_index, duration_index = sweep_points[int(point_index)]
+        with PulseSchedule(target_list) as schedule:
+            for target in target_list:
+                _add_spin_lock_pulse(
+                    schedule,
+                    exp,
+                    target=target,
+                    duration=float(durations[duration_index]),
+                    drive_amplitude=float(amplitude_map[target][frequency_index]),
+                    drive_detuning=drive_detuning,
+                    drive_phase=drive_phase,
+                    initial_phase=initial_phase,
+                    final_phase=final_phase,
+                )
+        return schedule
+
+    with exp.ctx.util.no_output():
+        sweep_result = exp.measurement_service.sweep_parameter(
+            sequence=sequence,
+            sweep_range=np.arange(len(sweep_points)),
+            n_shots=n_shots,
+            shot_interval=shot_interval,
+            plot=False,
+            enable_tqdm=enable_tqdm,
+            title="Spin-lock spectroscopy",
+            xlabel="Sweep point",
+            ylabel="Measured value",
+        )
+
+    normalized_signal: dict[str, np.ndarray] = {}
+    population: dict[str, np.ndarray] = {}
+    raw_data: dict[str, np.ndarray] = {}
+    relaxation_times: dict[str, np.ndarray] = {}
+    relaxation_time_errors: dict[str, np.ndarray] = {}
+    r2_values: dict[str, np.ndarray] = {}
+    fit_results: dict[str, list[dict[str, Any]]] = {}
+    figures: dict[str, go.Figure] = {}
+
+    for target in target_list:
+        sweep_data = sweep_result.data[target]
+        raw = np.asarray(sweep_data.data, dtype=np.complex128).reshape(
+            rabi_frequency_range.size,
+            durations.size,
+        )
+        measured = np.asarray(sweep_data.normalized, dtype=np.float64).reshape(
+            rabi_frequency_range.size,
+            durations.size,
+        )
+        fit_population = 0.5 * (1 + measured)
+        # Plot with duration on the vertical axis and frequency on the horizontal axis.
+        normalized_signal[target] = measured.T
+        population[target] = fit_population.T
+        raw_data[target] = raw
+
+        target_t1rho = np.full(rabi_frequency_range.shape, np.nan, dtype=np.float64)
+        target_t1rho_err = np.full(
+            rabi_frequency_range.shape,
+            np.nan,
+            dtype=np.float64,
+        )
+        target_r2 = np.full(rabi_frequency_range.shape, np.nan, dtype=np.float64)
+        target_fit_results: list[dict[str, Any]] = []
+
+        for frequency_index, frequency in enumerate(rabi_frequency_range):
+            try:
+                fit_result = fitting.fit_exp_decay(
+                    target=f"{target}_{frequency * 1e3:.6g}_MHz",
+                    x=durations,
+                    y=fit_population[frequency_index],
+                    plot=False,
+                    title="Spin-lock relaxation",
+                    xlabel="Duration (us)",
+                    ylabel="Normalized signal",
+                    xaxis_type="log",
+                    yaxis_type="linear",
+                )
+            except Exception as exc:
+                target_fit_results.append(
+                    {
+                        "frequency": float(frequency),
+                        "rabi_frequency": float(frequency),
+                        "effective_frequency": float(
+                            effective_frequency_range[frequency_index]
+                        ),
+                        "status": FitStatus.ERROR.value,
+                        "message": str(exc),
+                        "data": {},
+                    }
+                )
+                continue
+
+            if fit_result.status is FitStatus.SUCCESS:
+                target_t1rho[frequency_index] = float(fit_result["tau"])
+                target_t1rho_err[frequency_index] = float(fit_result["tau_err"])
+                target_r2[frequency_index] = float(fit_result["r2"])
+            target_fit_results.append(
+                {
+                    "frequency": float(frequency),
+                    "rabi_frequency": float(frequency),
+                    "effective_frequency": float(
+                        effective_frequency_range[frequency_index]
+                    ),
+                    "status": fit_result.status.value,
+                    "message": fit_result.message,
+                    "data": {
+                        key: value
+                        for key, value in fit_result.data.items()
+                        if key != "fig"
+                    },
+                }
+            )
+            if fit_result.figure is not None:
+                figures[f"{target}_fit_{frequency * 1e3:.6f}_MHz"] = fit_result.figure
+
+        relaxation_times[target] = target_t1rho
+        relaxation_time_errors[target] = target_t1rho_err
+        r2_values[target] = target_r2
+        fit_results[target] = target_fit_results
+
+        heatmap = _make_spin_lock_heatmap_figure(
+            target=target,
+            spin_lock_rabi_frequency_range=rabi_frequency_range,
+            duration_range=durations,
+            population=population[target],
+        )
+        relaxation = _make_spin_lock_relaxation_figure(
+            target=target,
+            spin_lock_rabi_frequency_range=rabi_frequency_range,
+            relaxation_times=target_t1rho,
+            relaxation_time_errors=target_t1rho_err,
+        )
+        figures[f"{target}_heatmap"] = heatmap
+        figures[f"{target}_relaxation"] = relaxation
+
+        if plot:
+            heatmap.show(config=viz.get_config(filename=f"spin_lock_heatmap_{target}"))
+            relaxation.show(
+                config=viz.get_config(filename=f"spin_lock_relaxation_{target}")
+            )
+        if save_image:
+            viz.save_figure(heatmap, name=f"spin_lock_heatmap_{target}")
+            viz.save_figure(relaxation, name=f"spin_lock_relaxation_{target}")
+
+    primary_figure = figures.get(f"{target_list[0]}_relaxation")
+    return Result(
+        data={
+            "targets": target_list,
+            "spin_lock_frequency_range": rabi_frequency_range,
+            "spin_lock_rabi_frequency_range": rabi_frequency_range,
+            "effective_spin_lock_frequency_range": effective_frequency_range,
+            "duration_range": durations,
+            "drive_amplitudes": amplitude_map,
+            "raw_data": raw_data,
+            "normalized_signal": normalized_signal,
+            "population": population,
+            "relaxation_times": relaxation_times,
+            "relaxation_time_errors": relaxation_time_errors,
+            "r2": r2_values,
+            "fit_results": fit_results,
+        },
+        figure=primary_figure,
+        figures=figures,
+    )

--- a/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
+++ b/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
@@ -4,11 +4,12 @@ from __future__ import annotations
 
 from collections.abc import Collection
 from dataclasses import dataclass
-from typing import Any, cast
+from typing import Any, Literal, cast
 
 import numpy as np
 import plotly.graph_objects as go
 from numpy.typing import ArrayLike
+from tqdm import tqdm
 
 import qubex.visualization as viz
 from qubex.analysis import FitStatus, fitting
@@ -22,26 +23,24 @@ from qubex.pulse import PulseSchedule, Rect
 
 __all__ = ["spin_lock_sequence", "spin_lock_spectroscopy"]
 
-DEFAULT_SPIN_LOCK_FREQUENCY_RANGE = np.geomspace(0.01, 0.15, 16)
+DEFAULT_SPIN_LOCK_FREQUENCY_RANGE = 0.01 + 0.11 * np.tan(
+    np.pi / 3 * np.linspace(0, 1, 12)
+) / np.sqrt(3)
 DEFAULT_DURATION_RANGE = np.geomspace(100, 200e3, 31)
 DEFAULT_DRIVE_PHASE = 0.0
 FINAL_PROJECTION_PHASE_CORRECTION_SIGN = -1.0
 CHEVRON_REFERENCE_RABI_FREQUENCY = 0.0125
 CHEVRON_REFERENCE_DETUNING_HALF_WIDTH = 0.05
-CHEVRON_MAX_DETUNING_HALF_WIDTH = 0.2
+CHEVRON_NYQUIST_DETUNING_MARGIN = 0.8
 CHEVRON_REFERENCE_TIME_MAX = 250.0
 CHEVRON_DETUNING_POINTS = 41
 CHEVRON_TIME_POINTS = 26
 CHEVRON_OMEGA_RABI_POINTS = 128
-MIN_CHEVRON_TIME_POINTS = 3
 MIN_DECAY_FIT_POINTS = 3
-QUEL1_AWG_MAX_FREQUENCY = 0.25  # GHz
-QUEL1_SAMPLING_PERIOD_NS = 2.0
-QUEL1_WORD_LENGTH_SAMPLES = 4
-QUEL1_BLOCK_LENGTH_SAMPLES = 64
 
 ArrayMap = dict[str, np.ndarray]
 ChevronMetadataMap = dict[str, list[dict[str, Any]]]
+ChevronSource = Literal["measured", "provided", "none"]
 FigureMap = dict[str, go.Figure]
 
 
@@ -55,6 +54,29 @@ class _TargetAnalysis:
     r2: np.ndarray
     fit_results: list[dict[str, Any]]
     sort_indices: np.ndarray
+    figures: FigureMap
+
+
+@dataclass(frozen=True)
+class _SpinLockCalibration:
+    qubit_frequency_map: ArrayMap
+    rabi_frequency_map: ArrayMap
+    chevron_results: ChevronMetadataMap
+    chevron_figures: FigureMap
+    chevron_source: ChevronSource
+    chevron_n_shots: int | None
+
+
+@dataclass(frozen=True)
+class _SpinLockAnalysis:
+    raw_data: ArrayMap
+    normalized_signal: ArrayMap
+    population: ArrayMap
+    relaxation_times: ArrayMap
+    relaxation_time_errors: ArrayMap
+    r2: ArrayMap
+    fit_results: dict[str, list[dict[str, Any]]]
+    rabi_sort_indices: ArrayMap
     figures: FigureMap
 
 
@@ -192,7 +214,7 @@ def _resolve_duration_range(
     if np.any(durations <= 0):
         raise ValueError("duration_range must contain positive values.")
 
-    sampling_period = exp.ctx.measurement.sampling_period
+    sampling_period = _measurement_sampling_period_ns(exp)
     discretized = exp.ctx.util.discretize_time_range(
         durations,
         sampling_period=sampling_period,
@@ -296,6 +318,36 @@ def _nan_array_map(
     }
 
 
+def _measurement_sampling_period_ns(exp: Experiment) -> float:
+    sampling_period = float(exp.ctx.measurement.sampling_period)
+    if not np.isfinite(sampling_period) or sampling_period <= 0:
+        raise ValueError("measurement sampling_period must be positive and finite.")
+    return sampling_period
+
+
+def _chevron_detuning_half_width_limit(exp: Experiment) -> float:
+    return CHEVRON_NYQUIST_DETUNING_MARGIN * 0.5 / _measurement_sampling_period_ns(exp)
+
+
+def _discretized_chevron_time_step(exp: Experiment, time_step: float) -> float:
+    sampling_period = _measurement_sampling_period_ns(exp)
+    discretized_time_step = exp.ctx.util.discretize_time_range(
+        [time_step],
+        sampling_period=sampling_period,
+    )
+    if discretized_time_step is None:
+        raise ValueError("chevron time step could not be discretized.")
+
+    discretized_time_step = np.asarray(discretized_time_step, dtype=np.float64)
+    if discretized_time_step.size == 0:
+        raise ValueError("chevron time step could not be discretized.")
+
+    time_step = float(discretized_time_step[0])
+    if not np.isfinite(time_step):
+        raise ValueError("chevron time step must be finite after discretization.")
+    return max(time_step, sampling_period)
+
+
 def _scaled_chevron_ranges(
     exp: Experiment,
     *,
@@ -307,7 +359,7 @@ def _scaled_chevron_ranges(
 
     detuning_half_width = min(
         CHEVRON_REFERENCE_DETUNING_HALF_WIDTH * scale,
-        CHEVRON_MAX_DETUNING_HALF_WIDTH,
+        _chevron_detuning_half_width_limit(exp),
     )
     detuning_range = np.linspace(
         -detuning_half_width,
@@ -315,19 +367,11 @@ def _scaled_chevron_ranges(
         CHEVRON_DETUNING_POINTS,
     )
 
-    time_max = CHEVRON_REFERENCE_TIME_MAX / scale
-    time_range = exp.ctx.util.discretize_time_range(
-        np.linspace(0, time_max, CHEVRON_TIME_POINTS),
-        sampling_period=exp.ctx.measurement.sampling_period,
+    time_step = _discretized_chevron_time_step(
+        exp,
+        CHEVRON_REFERENCE_TIME_MAX / scale / (CHEVRON_TIME_POINTS - 1),
     )
-    if time_range is None:
-        raise ValueError("chevron time_range could not be discretized.")
-    time_range = np.unique(np.asarray(time_range, dtype=np.float64))
-    if time_range.size < MIN_CHEVRON_TIME_POINTS:
-        raise ValueError(
-            "chevron time_range must contain at least "
-            f"{MIN_CHEVRON_TIME_POINTS} unique points after discretization."
-        )
+    time_range = time_step * np.arange(CHEVRON_TIME_POINTS, dtype=np.float64)
 
     omega_rabi_range = (
         expected_rabi_frequency
@@ -340,140 +384,6 @@ def _scaled_chevron_ranges(
 
 def _target_base_frequencies(exp: Experiment, targets: list[str]) -> dict[str, float]:
     return {target: float(exp.ctx.targets[target].frequency) for target in targets}
-
-
-def _chevron_drive_frequency_range(
-    *,
-    base_frequency: float,
-    detuning_range: np.ndarray,
-) -> np.ndarray:
-    return float(base_frequency) + np.asarray(detuning_range, dtype=np.float64)
-
-
-def _chevron_awg_frequency_range(
-    exp: Experiment,
-    *,
-    target: str,
-    drive_frequency_range: np.ndarray,
-) -> np.ndarray:
-    experiment_system = exp.ctx.experiment_system
-    target_info = experiment_system.get_target(target)
-    nco_frequency = float(experiment_system.get_nco_frequency(target))
-
-    if target_info.sideband == "L":
-        return nco_frequency - drive_frequency_range
-    return drive_frequency_range - nco_frequency
-
-
-def _looks_like_quel1_constraint_profile(constraint_profile: Any) -> bool:
-    if constraint_profile is None:
-        return False
-
-    strict_quel1_flags = all(
-        bool(getattr(constraint_profile, name, False))
-        for name in (
-            "require_workaround_capture",
-            "enforce_word_alignment",
-            "enforce_block_alignment",
-            "enforce_capture_spacing",
-        )
-    )
-    if not strict_quel1_flags:
-        return False
-
-    try:
-        sampling_period_ns = float(
-            getattr(constraint_profile, "sampling_period_ns", np.nan)
-        )
-        word_length_samples = int(
-            getattr(constraint_profile, "word_length_samples", -1)
-        )
-        block_length_samples = int(
-            getattr(constraint_profile, "block_length_samples", -1)
-        )
-    except (TypeError, ValueError):
-        return False
-
-    sampling_period_matches = bool(
-        np.isclose(sampling_period_ns, QUEL1_SAMPLING_PERIOD_NS)
-    )
-    return (
-        sampling_period_matches
-        and word_length_samples == QUEL1_WORD_LENGTH_SAMPLES
-        and block_length_samples == QUEL1_BLOCK_LENGTH_SAMPLES
-    )
-
-
-def _resolve_awg_max_frequency(exp: Experiment) -> float | None:
-    constraint_profile = getattr(exp.ctx.measurement, "constraint_profile", None)
-    if constraint_profile is None:
-        return None
-
-    awg_max_frequency_hz = getattr(constraint_profile, "awg_max_frequency_hz", None)
-    if awg_max_frequency_hz is not None:
-        awg_max_frequency = float(awg_max_frequency_hz) * 1e-9
-        if not np.isfinite(awg_max_frequency) or awg_max_frequency <= 0:
-            raise ValueError("awg_max_frequency_hz must be positive and finite.")
-        return awg_max_frequency
-
-    if _looks_like_quel1_constraint_profile(constraint_profile):
-        return QUEL1_AWG_MAX_FREQUENCY
-
-    return None
-
-
-def _validate_awg_frequency_ranges(
-    exp: Experiment,
-    *,
-    targets: list[str],
-    drive_frequency_ranges: ArrayMap,
-    description: str,
-) -> None:
-    awg_max_frequency = _resolve_awg_max_frequency(exp)
-    if awg_max_frequency is None:
-        return
-
-    for target in targets:
-        drive_frequency_range = drive_frequency_ranges[target]
-        awg_frequency_range = _chevron_awg_frequency_range(
-            exp,
-            target=target,
-            drive_frequency_range=drive_frequency_range,
-        )
-        max_abs_awg_frequency = float(np.max(np.abs(awg_frequency_range)))
-        if max_abs_awg_frequency <= awg_max_frequency + 1e-12:
-            continue
-
-        raise ValueError(
-            f"{description} for `{target}` requires AWG modulation up to "
-            f"{max_abs_awg_frequency * 1e3:.3f} MHz, exceeding "
-            f"{awg_max_frequency * 1e3:.3f} MHz with the current NCO setting. "
-            "Reduce spin_lock_frequency_range or retune the backend settings. "
-            f"Drive frequency range is {np.min(drive_frequency_range):.9g} GHz to "
-            f"{np.max(drive_frequency_range):.9g} GHz."
-        )
-
-
-def _validate_chevron_awg_frequency_range(
-    exp: Experiment,
-    *,
-    targets: list[str],
-    base_frequencies: dict[str, float],
-    detuning_range: np.ndarray,
-) -> None:
-    drive_frequency_ranges = {
-        target: _chevron_drive_frequency_range(
-            base_frequency=base_frequencies[target],
-            detuning_range=detuning_range,
-        )
-        for target in targets
-    }
-    _validate_awg_frequency_ranges(
-        exp,
-        targets=targets,
-        drive_frequency_ranges=drive_frequency_ranges,
-        description="Chevron detuning_range",
-    )
 
 
 def _constant_frequency_map(
@@ -570,12 +480,125 @@ def _final_projection_phase_maps(
     return phase_corrections, final_phases
 
 
+def _chevron_value(
+    entry: dict[str, Any],
+    *,
+    primary_key: str,
+    fallback_key: str | None,
+    target: str,
+    frequency_index: int,
+) -> float:
+    value = entry.get(primary_key)
+    if value is None and fallback_key is not None:
+        value = entry.get(fallback_key)
+    if value is None:
+        raise ValueError(
+            f"chevron_results for `{target}` at index {frequency_index} "
+            f"must contain `{primary_key}`."
+        )
+    return float(value)
+
+
+def _validate_matching_chevron_value(
+    entry: dict[str, Any],
+    *,
+    key: str,
+    expected: float,
+    target: str,
+    frequency_index: int,
+) -> None:
+    if key not in entry:
+        raise ValueError(
+            f"chevron_results for `{target}` at index {frequency_index} "
+            f"must contain `{key}`."
+        )
+
+    value = float(entry[key])
+    if not np.isclose(value, expected, rtol=1e-6, atol=1e-12):
+        raise ValueError(
+            f"chevron_results for `{target}` at index {frequency_index} "
+            f"has {key}={value:.9g}, but expected {expected:.9g}."
+        )
+
+
+def _resolve_spin_lock_parameters_from_chevron_results(
+    *,
+    targets: list[str],
+    requested_rabi_frequency_range: np.ndarray,
+    amplitude_map: ArrayMap,
+    chevron_results: ChevronMetadataMap,
+) -> tuple[ArrayMap, ArrayMap, ChevronMetadataMap]:
+    qubit_frequency_map = _nan_array_map(
+        targets=targets,
+        shape=requested_rabi_frequency_range.shape,
+    )
+    measured_rabi_frequency_map = _nan_array_map(
+        targets=targets,
+        shape=requested_rabi_frequency_range.shape,
+    )
+    resolved_chevron_results: ChevronMetadataMap = {}
+
+    for target in targets:
+        target_results = list(chevron_results.get(target, []))
+        if len(target_results) != requested_rabi_frequency_range.size:
+            raise ValueError(
+                f"chevron_results for `{target}` must contain "
+                f"{requested_rabi_frequency_range.size} entries."
+            )
+        resolved_chevron_results[target] = target_results
+
+        for frequency_index, entry in enumerate(target_results):
+            _validate_matching_chevron_value(
+                entry,
+                key="requested_rabi_frequency",
+                expected=float(requested_rabi_frequency_range[frequency_index]),
+                target=target,
+                frequency_index=frequency_index,
+            )
+            _validate_matching_chevron_value(
+                entry,
+                key="drive_amplitude",
+                expected=float(amplitude_map[target][frequency_index]),
+                target=target,
+                frequency_index=frequency_index,
+            )
+
+            qubit_frequency = _chevron_value(
+                entry,
+                primary_key="qubit_frequency",
+                fallback_key="omega_q",
+                target=target,
+                frequency_index=frequency_index,
+            )
+            rabi_frequency = _chevron_value(
+                entry,
+                primary_key="rabi_frequency",
+                fallback_key="omega_rabi",
+                target=target,
+                frequency_index=frequency_index,
+            )
+            if not np.isfinite(qubit_frequency):
+                raise ValueError(
+                    f"Chevron qubit frequency for `{target}` must be finite."
+                )
+            if not np.isfinite(rabi_frequency) or rabi_frequency <= 0:
+                raise ValueError(
+                    f"Chevron Rabi frequency for `{target}` must be positive and finite."
+                )
+
+            qubit_frequency_map[target][frequency_index] = qubit_frequency
+            measured_rabi_frequency_map[target][frequency_index] = rabi_frequency
+
+    return qubit_frequency_map, measured_rabi_frequency_map, resolved_chevron_results
+
+
 def _estimate_spin_lock_parameters_with_chevron(
     exp: Experiment,
     *,
     targets: list[str],
     requested_rabi_frequency_range: np.ndarray,
     amplitude_map: ArrayMap,
+    base_frequencies: dict[str, float],
     chevron_n_shots: int,
     shot_interval: float,
     return_chevron_figures: bool,
@@ -585,7 +608,6 @@ def _estimate_spin_lock_parameters_with_chevron(
     ChevronMetadataMap,
     FigureMap,
 ]:
-    base_frequencies = _target_base_frequencies(exp, targets)
     measured_qubit_frequencies = _nan_array_map(
         targets=targets,
         shape=requested_rabi_frequency_range.shape,
@@ -597,18 +619,15 @@ def _estimate_spin_lock_parameters_with_chevron(
     chevron_results: ChevronMetadataMap = {target: [] for target in targets}
     chevron_figures: FigureMap = {}
 
-    for frequency_index, expected_rabi_frequency in enumerate(
-        requested_rabi_frequency_range
-    ):
+    progress = tqdm(
+        requested_rabi_frequency_range,
+        desc="Chevron pre-measurements",
+        unit="freq",
+    )
+    for frequency_index, expected_rabi_frequency in enumerate(progress):
         detuning_range, time_range, omega_rabi_range = _scaled_chevron_ranges(
             exp,
             expected_rabi_frequency=float(expected_rabi_frequency),
-        )
-        _validate_chevron_awg_frequency_range(
-            exp,
-            targets=targets,
-            base_frequencies=base_frequencies,
-            detuning_range=detuning_range,
         )
         with exp.ctx.util.no_output():
             chevron_result = estimate_qubit_frequency_from_chevron(
@@ -679,6 +698,86 @@ def _estimate_spin_lock_parameters_with_chevron(
     )
 
 
+def _resolve_spin_lock_calibration(
+    exp: Experiment,
+    *,
+    targets: list[str],
+    requested_rabi_frequency_range: np.ndarray,
+    amplitude_map: ArrayMap,
+    base_frequencies: dict[str, float],
+    estimate_with_chevron: bool,
+    chevron_results: ChevronMetadataMap | None,
+    chevron_n_shots: int | None,
+    n_shots: int,
+    shot_interval: float,
+    return_chevron_figures: bool,
+) -> _SpinLockCalibration:
+    if chevron_results is not None:
+        (
+            qubit_frequency_map,
+            rabi_frequency_map,
+            resolved_chevron_results,
+        ) = _resolve_spin_lock_parameters_from_chevron_results(
+            targets=targets,
+            requested_rabi_frequency_range=requested_rabi_frequency_range,
+            amplitude_map=amplitude_map,
+            chevron_results=chevron_results,
+        )
+        return _SpinLockCalibration(
+            qubit_frequency_map=qubit_frequency_map,
+            rabi_frequency_map=rabi_frequency_map,
+            chevron_results=resolved_chevron_results,
+            chevron_figures={},
+            chevron_source="provided",
+            chevron_n_shots=None,
+        )
+
+    if estimate_with_chevron:
+        chevron_n_shots_value = _resolve_positive_integer(
+            chevron_n_shots,
+            name="chevron_n_shots",
+            default=max(1, n_shots // 4),
+        )
+        (
+            qubit_frequency_map,
+            rabi_frequency_map,
+            measured_chevron_results,
+            chevron_figures,
+        ) = _estimate_spin_lock_parameters_with_chevron(
+            exp,
+            targets=targets,
+            requested_rabi_frequency_range=requested_rabi_frequency_range,
+            amplitude_map=amplitude_map,
+            base_frequencies=base_frequencies,
+            chevron_n_shots=chevron_n_shots_value,
+            shot_interval=shot_interval,
+            return_chevron_figures=return_chevron_figures,
+        )
+        return _SpinLockCalibration(
+            qubit_frequency_map=qubit_frequency_map,
+            rabi_frequency_map=rabi_frequency_map,
+            chevron_results=measured_chevron_results,
+            chevron_figures=chevron_figures,
+            chevron_source="measured",
+            chevron_n_shots=chevron_n_shots_value,
+        )
+
+    return _SpinLockCalibration(
+        qubit_frequency_map=_constant_frequency_map(
+            targets=targets,
+            values=base_frequencies,
+            shape=requested_rabi_frequency_range.shape,
+        ),
+        rabi_frequency_map={
+            target: requested_rabi_frequency_range.copy() for target in targets
+        },
+        chevron_results={target: [] for target in targets},
+        chevron_figures={},
+        chevron_source="none",
+        chevron_n_shots=None,
+    )
+
+
 def _add_spin_lock_pulse(
     schedule: PulseSchedule,
     exp: Experiment,
@@ -742,7 +841,7 @@ def _make_spin_lock_heatmap_figure(
             xanchor="center",
         ),
         xaxis_title="Spin-lock Rabi frequency (MHz)",
-        xaxis_type="log",
+        xaxis_type="linear",
         yaxis_title="Duration (ns)",
         yaxis_type="log",
         width=700,
@@ -793,7 +892,7 @@ def _make_spin_lock_relaxation_figure(
             xanchor="center",
         ),
         xaxis_title="Spin-lock Rabi frequency (MHz)",
-        xaxis_type="log",
+        xaxis_type="linear",
         yaxis_title="Relaxation time (μs)",
         yaxis_range=[0, yaxis_upper],
         width=700,
@@ -837,7 +936,8 @@ def _make_fit_summary(
 
 
 def _fit_data_without_figure(fit_result: Any) -> dict[str, Any]:
-    return {key: value for key, value in fit_result.data.items() if key != "fig"}
+    data = getattr(fit_result, "data", {})
+    return {key: value for key, value in dict(data).items() if key != "fig"}
 
 
 def _analyze_spin_lock_target(
@@ -887,7 +987,7 @@ def _analyze_spin_lock_target(
                 y=fit_population[frequency_index],
                 plot=False,
                 title="Spin-lock relaxation",
-                xlabel="Duration (μs)",
+                xlabel="Duration (ns)",
                 ylabel="Normalized signal",
                 xaxis_type="log",
                 yaxis_type="linear",
@@ -958,6 +1058,84 @@ def _analyze_spin_lock_target(
     )
 
 
+def _analyze_spin_lock_targets(
+    *,
+    targets: list[str],
+    sweep_result: Any,
+    durations: np.ndarray,
+    requested_rabi_frequency_range: np.ndarray,
+    rabi_frequency_map: ArrayMap,
+    effective_frequency_map: ArrayMap,
+    drive_frequency_map: ArrayMap,
+    qubit_frequency_map: ArrayMap,
+    initial_figures: FigureMap,
+) -> _SpinLockAnalysis:
+    raw_data: ArrayMap = {}
+    normalized_signal: ArrayMap = {}
+    population: ArrayMap = {}
+    relaxation_times: ArrayMap = {}
+    relaxation_time_errors: ArrayMap = {}
+    r2_values: ArrayMap = {}
+    fit_results: dict[str, list[dict[str, Any]]] = {}
+    rabi_sort_indices: ArrayMap = {}
+    figures: FigureMap = dict(initial_figures)
+
+    for target in targets:
+        analysis = _analyze_spin_lock_target(
+            target=target,
+            sweep_data=sweep_result.data[target],
+            durations=durations,
+            requested_rabi_frequency_range=requested_rabi_frequency_range,
+            rabi_frequency_range=rabi_frequency_map[target],
+            effective_frequency_range=effective_frequency_map[target],
+            drive_frequencies=drive_frequency_map[target],
+            qubit_frequencies=qubit_frequency_map[target],
+        )
+
+        raw_data[target] = analysis.raw_data
+        normalized_signal[target] = analysis.normalized_signal
+        population[target] = analysis.population
+        relaxation_times[target] = analysis.relaxation_times
+        relaxation_time_errors[target] = analysis.relaxation_time_errors
+        r2_values[target] = analysis.r2
+        fit_results[target] = analysis.fit_results
+        rabi_sort_indices[target] = analysis.sort_indices
+        figures.update(analysis.figures)
+
+    return _SpinLockAnalysis(
+        raw_data=raw_data,
+        normalized_signal=normalized_signal,
+        population=population,
+        relaxation_times=relaxation_times,
+        relaxation_time_errors=relaxation_time_errors,
+        r2=r2_values,
+        fit_results=fit_results,
+        rabi_sort_indices=rabi_sort_indices,
+        figures=figures,
+    )
+
+
+def _show_or_save_spin_lock_figures(
+    *,
+    targets: list[str],
+    figures: FigureMap,
+    plot: bool,
+    save_image: bool,
+) -> None:
+    for target in targets:
+        heatmap = figures[f"{target}_heatmap"]
+        relaxation = figures[f"{target}_relaxation"]
+
+        if plot:
+            heatmap.show(config=viz.get_config(filename=f"spin_lock_heatmap_{target}"))
+            relaxation.show(
+                config=viz.get_config(filename=f"spin_lock_relaxation_{target}")
+            )
+        if save_image:
+            viz.save_figure(heatmap, name=f"spin_lock_heatmap_{target}")
+            viz.save_figure(relaxation, name=f"spin_lock_relaxation_{target}")
+
+
 def _measure_spin_lock_grid(
     exp: Experiment,
     *,
@@ -1016,6 +1194,7 @@ def spin_lock_spectroscopy(
     *,
     spin_lock_frequency_range: ArrayLike | None = None,
     duration_range: ArrayLike | None = None,
+    chevron_results: ChevronMetadataMap | None = None,
     estimate_with_chevron: bool | None = None,
     chevron_n_shots: int | None = None,
     return_chevron_figures: bool | None = None,
@@ -1052,23 +1231,31 @@ def spin_lock_spectroscopy(
         are measured.
     spin_lock_frequency_range
         Spin-lock frequencies in GHz. These values are treated as desired Rabi
-        rates. If omitted, ``np.geomspace(0.01, 0.15, 16)`` is used, i.e.
-        10 MHz to 150 MHz.
+        rates. If omitted,
+        ``0.01 + 0.11 * tan(pi / 3 * linspace(0, 1, 12)) / sqrt(3)`` is used,
+        i.e. 10 MHz to 120 MHz with denser points at low frequencies.
     duration_range
         Spin-lock drive durations in ns. Values must be positive because the
         heatmap and fit figures use a log time axis. The range is discretized to
         ``exp.ctx.measurement.sampling_period``. If omitted,
         ``np.geomspace(100, 200e3, 31)`` is used.
+    chevron_results
+        Previously returned ``Result.data["chevron_results"]``. When supplied,
+        these values are reused and chevron pre-measurements are skipped. The
+        entries must match the requested spin-lock frequency range and
+        calculated drive amplitudes for the current targets.
     estimate_with_chevron
         Whether to run ``estimate_qubit_frequency_from_chevron()`` before the
         spin-lock sweep for each requested spin-lock frequency. When ``True``,
         the spin-lock pulse frequency is shifted to the AC-Stark-shifted qubit
         frequency estimated by chevron, and the figure x-axes use the measured
         Rabi frequencies from chevron. The chevron detuning half-width is scaled
-        from the expected Rabi rate and capped at 200 MHz.
+        from the expected Rabi rate and capped at 80% of the Nyquist frequency
+        implied by ``exp.ctx.measurement.sampling_period``. Defaults to
+        ``True``. Ignored when ``chevron_results`` is supplied.
     chevron_n_shots
         Number of shots for each pre-measurement chevron sweep point. Used only
-        when ``estimate_with_chevron=True`` and defaults to
+        when chevrons are measured in this call and defaults to
         ``max(1, n_shots // 4)``.
     return_chevron_figures
         Whether to include the intermediate chevron measurement and transform
@@ -1096,7 +1283,9 @@ def spin_lock_spectroscopy(
         Whether to save the heatmap and relaxation-time figures.
     enable_tqdm
         Whether to show progress bars inside ``sweep_parameter()``. Defaults to
-        ``False`` to match the measurement service default.
+        ``False`` to match the measurement service default. Chevron
+        pre-measurement progress is shown separately whenever chevrons are
+        measured.
 
     Returns
     -------
@@ -1108,16 +1297,15 @@ def spin_lock_spectroscopy(
             Requested spin-lock Rabi-frequency axis in GHz.
         ``measured_spin_lock_rabi_frequency_range``
             Per-target Rabi-frequency axis in GHz used for plotting and fit
-            metadata. This matches the requested axis unless
-            ``estimate_with_chevron=True``.
+            metadata. This matches the requested axis unless chevron
+            calibration is measured or supplied.
         ``spin_lock_qubit_frequencies``
             Per-target qubit frequencies in GHz used as the spin-lock frequency
             reference before adding ``drive_detuning``.
         ``spin_lock_drive_frequencies``
             Per-target microwave drive frequencies in GHz including
-            ``drive_detuning``. When ``estimate_with_chevron=True``, these are
-            AC-Stark-shifted qubit frequencies estimated by chevron plus
-            ``drive_detuning``.
+            ``drive_detuning``. With chevron calibration, these are
+            AC-Stark-shifted qubit frequencies plus ``drive_detuning``.
         ``spin_lock_frequency_offsets``
             Per-target detunings in GHz applied to the spin-lock pulse relative
             to the calibrated qubit frequencies.
@@ -1153,14 +1341,23 @@ def spin_lock_spectroscopy(
         ``fit_results``
             Per-frequency fit metadata and fit parameters.
         ``chevron_results``
-            Per-frequency chevron metadata. Empty unless
-            ``estimate_with_chevron=True``.
+            Per-frequency chevron metadata. Empty unless chevron calibration is
+            measured or supplied through ``chevron_results``.
+        ``chevron_source``
+            ``"measured"``, ``"provided"``, or ``"none"`` depending on how the
+            chevron calibration values were obtained.
+        ``use_chevron_calibration``
+            Whether chevron-derived qubit and Rabi frequencies were used for the
+            spin-lock sweep.
+        ``estimate_with_chevron``
+            Whether chevrons were measured in this call. ``False`` when
+            ``chevron_results`` was supplied and reused.
         ``return_chevron_figures``
             Whether intermediate chevron figures were included in
             ``Result.figures``.
         ``chevron_n_shots``
             Number of shots used for each chevron sweep point, or ``None`` when
-            ``estimate_with_chevron=False``.
+            chevrons were not measured in this call.
         ``spin_lock_rabi_sort_indices``
             Per-target indices used to sort measured Rabi frequencies for
             plotting. Measured arrays in the payload keep the acquisition order.
@@ -1172,20 +1369,23 @@ def spin_lock_spectroscopy(
     Notes
     -----
     - ``spin_lock_frequency_range`` is not a detuning sweep; it is the target
-      Rabi rate of the locking drive. With ``estimate_with_chevron=True``, the
-      figure x-axis uses the measured Rabi-rate axis from chevron; otherwise it
-      uses this requested Rabi-rate axis.
+      Rabi rate of the locking drive. With chevron calibration, either measured
+      in this call or supplied through ``chevron_results``, the figure x-axis
+      uses the measured Rabi-rate axis from chevron; otherwise it uses this
+      requested Rabi-rate axis.
     - The initial and final half-pi pulses are left at the calibrated qubit
       frequency. When the spin-lock drive is detuned from that frequency, the
       final half-pi pulse phase is shifted by
-      ``-2 * pi * drive_detuning * duration`` to follow the detuned drive frame.
+      ``-2 * pi * spin_lock_frequency_offset * duration`` to follow the
+      spin-lock drive frame, including AC-Stark-shifted frequency offsets when
+      chevron calibration is used.
     - The implementation raises an error if any calculated drive amplitude has
       absolute value larger than 1.
-    - If the active measurement constraint profile defines
-      ``awg_max_frequency_hz``, chevron pre-measurements and the final spin-lock
-      drive frequencies are checked against that AWG modulation limit using the
-      current NCO setting. For current QuEL-1-style strict timing profiles that
-      do not expose such a field, a local 250 MHz contrib fallback is used.
+    - Chevron detuning ranges are capped to stay within 80% of the Nyquist
+      frequency implied by the measurement sampling period.
+    - Spin-lock durations and chevron time steps are discretized on
+      ``exp.ctx.measurement.sampling_period``. Backend-specific word or block
+      alignment, if required, is left to the measurement stack.
     - The fitted relaxation uses ``0.5 * (1 + normalized_signal)`` and
       ``fitting.fit_exp_decay()``, matching the sign convention used by the T2
       echo analysis path.
@@ -1207,7 +1407,7 @@ def spin_lock_spectroscopy(
     plot = _resolve_bool(plot, default=True)
     save_image = _resolve_bool(save_image, default=False)
     enable_tqdm = _resolve_bool(enable_tqdm, default=False)
-    estimate_with_chevron = _resolve_bool(estimate_with_chevron, default=False)
+    estimate_with_chevron = _resolve_bool(estimate_with_chevron, default=True)
     return_chevron_figures = _resolve_bool(return_chevron_figures, default=False)
 
     exp.pulse.validate_rabi_params(target_list)
@@ -1226,48 +1426,24 @@ def spin_lock_spectroscopy(
         spin_lock_frequency_range=requested_rabi_frequency_range,
     )
     base_frequencies = _target_base_frequencies(exp, target_list)
-    chevron_results: ChevronMetadataMap = {target: [] for target in target_list}
-    chevron_figures: FigureMap = {}
-    chevron_n_shots_value: int | None = None
-    if estimate_with_chevron:
-        chevron_n_shots_value = _resolve_positive_integer(
-            chevron_n_shots,
-            name="chevron_n_shots",
-            default=max(1, n_shots // 4),
-        )
-        (
-            qubit_frequency_map,
-            measured_rabi_frequency_map,
-            chevron_results,
-            chevron_figures,
-        ) = _estimate_spin_lock_parameters_with_chevron(
-            exp,
-            targets=target_list,
-            requested_rabi_frequency_range=requested_rabi_frequency_range,
-            amplitude_map=amplitude_map,
-            chevron_n_shots=chevron_n_shots_value,
-            shot_interval=shot_interval,
-            return_chevron_figures=return_chevron_figures,
-        )
-    else:
-        qubit_frequency_map = _constant_frequency_map(
-            targets=target_list,
-            values=base_frequencies,
-            shape=requested_rabi_frequency_range.shape,
-        )
-        measured_rabi_frequency_map = {
-            target: requested_rabi_frequency_range.copy() for target in target_list
-        }
-    drive_frequency_map = {
-        target: qubit_frequency_map[target] + drive_detuning_value
-        for target in target_list
-    }
-    _validate_awg_frequency_ranges(
+    calibration = _resolve_spin_lock_calibration(
         exp,
         targets=target_list,
-        drive_frequency_ranges=drive_frequency_map,
-        description="Spin-lock drive frequencies",
+        requested_rabi_frequency_range=requested_rabi_frequency_range,
+        amplitude_map=amplitude_map,
+        base_frequencies=base_frequencies,
+        estimate_with_chevron=estimate_with_chevron,
+        chevron_results=chevron_results,
+        chevron_n_shots=chevron_n_shots,
+        n_shots=n_shots,
+        shot_interval=shot_interval,
+        return_chevron_figures=return_chevron_figures,
     )
+
+    drive_frequency_map = {
+        target: calibration.qubit_frequency_map[target] + drive_detuning_value
+        for target in target_list
+    }
     frequency_offset_map = {
         target: drive_frequency_map[target] - base_frequencies[target]
         for target in target_list
@@ -1282,7 +1458,7 @@ def spin_lock_spectroscopy(
         final_phase=final_phase,
     )
     effective_measured_frequency_map = _effective_frequency_map(
-        rabi_frequency_map=measured_rabi_frequency_map,
+        rabi_frequency_map=calibration.rabi_frequency_map,
         drive_detuning=drive_detuning_value,
     )
 
@@ -1301,76 +1477,53 @@ def spin_lock_spectroscopy(
         enable_tqdm=enable_tqdm,
     )
 
-    normalized_signal: ArrayMap = {}
-    population: ArrayMap = {}
-    raw_data: ArrayMap = {}
-    relaxation_times: ArrayMap = {}
-    relaxation_time_errors: ArrayMap = {}
-    r2_values: ArrayMap = {}
-    fit_results: dict[str, list[dict[str, Any]]] = {}
-    rabi_sort_indices: ArrayMap = {}
-    figures: FigureMap = dict(chevron_figures)
+    analysis = _analyze_spin_lock_targets(
+        targets=target_list,
+        sweep_result=sweep_result,
+        durations=durations,
+        requested_rabi_frequency_range=requested_rabi_frequency_range,
+        rabi_frequency_map=calibration.rabi_frequency_map,
+        effective_frequency_map=effective_measured_frequency_map,
+        drive_frequency_map=drive_frequency_map,
+        qubit_frequency_map=calibration.qubit_frequency_map,
+        initial_figures=calibration.chevron_figures,
+    )
+    _show_or_save_spin_lock_figures(
+        targets=target_list,
+        figures=analysis.figures,
+        plot=plot,
+        save_image=save_image,
+    )
 
-    for target in target_list:
-        analysis = _analyze_spin_lock_target(
-            target=target,
-            sweep_data=sweep_result.data[target],
-            durations=durations,
-            requested_rabi_frequency_range=requested_rabi_frequency_range,
-            rabi_frequency_range=measured_rabi_frequency_map[target],
-            effective_frequency_range=effective_measured_frequency_map[target],
-            drive_frequencies=drive_frequency_map[target],
-            qubit_frequencies=qubit_frequency_map[target],
-        )
-
-        raw_data[target] = analysis.raw_data
-        normalized_signal[target] = analysis.normalized_signal
-        population[target] = analysis.population
-        relaxation_times[target] = analysis.relaxation_times
-        relaxation_time_errors[target] = analysis.relaxation_time_errors
-        r2_values[target] = analysis.r2
-        fit_results[target] = analysis.fit_results
-        rabi_sort_indices[target] = analysis.sort_indices
-        figures.update(analysis.figures)
-        heatmap = figures[f"{target}_heatmap"]
-        relaxation = figures[f"{target}_relaxation"]
-
-        if plot:
-            heatmap.show(config=viz.get_config(filename=f"spin_lock_heatmap_{target}"))
-            relaxation.show(
-                config=viz.get_config(filename=f"spin_lock_relaxation_{target}")
-            )
-        if save_image:
-            viz.save_figure(heatmap, name=f"spin_lock_heatmap_{target}")
-            viz.save_figure(relaxation, name=f"spin_lock_relaxation_{target}")
-
-    primary_figure = figures.get(f"{target_list[0]}_relaxation")
+    primary_figure = analysis.figures.get(f"{target_list[0]}_relaxation")
     return Result(
         data={
             "targets": target_list,
             "requested_spin_lock_rabi_frequency_range": requested_rabi_frequency_range,
-            "measured_spin_lock_rabi_frequency_range": measured_rabi_frequency_map,
+            "measured_spin_lock_rabi_frequency_range": calibration.rabi_frequency_map,
             "effective_spin_lock_frequency_range": effective_measured_frequency_map,
-            "spin_lock_qubit_frequencies": qubit_frequency_map,
+            "spin_lock_qubit_frequencies": calibration.qubit_frequency_map,
             "spin_lock_drive_frequencies": drive_frequency_map,
             "spin_lock_frequency_offsets": frequency_offset_map,
             "final_projection_phase_corrections": final_projection_phase_corrections,
             "final_projection_phases": final_projection_phases,
             "duration_range": durations,
             "drive_amplitudes": amplitude_map,
-            "estimate_with_chevron": estimate_with_chevron,
-            "chevron_n_shots": chevron_n_shots_value,
+            "use_chevron_calibration": calibration.chevron_source != "none",
+            "estimate_with_chevron": calibration.chevron_source == "measured",
+            "chevron_n_shots": calibration.chevron_n_shots,
             "return_chevron_figures": return_chevron_figures,
-            "chevron_results": chevron_results,
-            "spin_lock_rabi_sort_indices": rabi_sort_indices,
-            "raw_data": raw_data,
-            "normalized_signal": normalized_signal,
-            "population": population,
-            "relaxation_times": relaxation_times,
-            "relaxation_time_errors": relaxation_time_errors,
-            "r2": r2_values,
-            "fit_results": fit_results,
+            "chevron_source": calibration.chevron_source,
+            "chevron_results": calibration.chevron_results,
+            "spin_lock_rabi_sort_indices": analysis.rabi_sort_indices,
+            "raw_data": analysis.raw_data,
+            "normalized_signal": analysis.normalized_signal,
+            "population": analysis.population,
+            "relaxation_times": analysis.relaxation_times,
+            "relaxation_time_errors": analysis.relaxation_time_errors,
+            "r2": analysis.r2,
+            "fit_results": analysis.fit_results,
         },
         figure=primary_figure,
-        figures=figures,
+        figures=analysis.figures,
     )

--- a/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
+++ b/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 from collections.abc import Collection
-from typing import Any
+from dataclasses import dataclass
+from typing import Any, cast
 
 import numpy as np
 import plotly.graph_objects as go
@@ -11,6 +12,9 @@ from numpy.typing import ArrayLike
 
 import qubex.visualization as viz
 from qubex.analysis import FitStatus, fitting
+from qubex.contrib.experiment.chevron_matched_transform import (
+    estimate_qubit_frequency_from_chevron,
+)
 from qubex.experiment import Experiment
 from qubex.experiment.experiment_constants import DEFAULT_INTERVAL, DEFAULT_SHOTS
 from qubex.experiment.models.result import Result
@@ -18,9 +22,39 @@ from qubex.pulse import PulseSchedule, Rect
 
 __all__ = ["spin_lock_sequence", "spin_lock_spectroscopy"]
 
-DEFAULT_SPIN_LOCK_FREQUENCY_RANGE = np.geomspace(0.001, 0.2, 21)
+DEFAULT_SPIN_LOCK_FREQUENCY_RANGE = np.geomspace(0.01, 0.2, 16)
 DEFAULT_DURATION_RANGE = np.geomspace(100, 200e3, 31)
 DEFAULT_DRIVE_PHASE = 0.0
+CHEVRON_REFERENCE_RABI_FREQUENCY = 0.0125
+CHEVRON_REFERENCE_DETUNING_HALF_WIDTH = 0.05
+CHEVRON_MAX_DETUNING_HALF_WIDTH = 0.2
+CHEVRON_REFERENCE_TIME_MAX = 250.0
+CHEVRON_DETUNING_POINTS = 41
+CHEVRON_TIME_POINTS = 26
+CHEVRON_OMEGA_RABI_POINTS = 128
+MIN_CHEVRON_TIME_POINTS = 3
+MIN_DECAY_FIT_POINTS = 3
+QUEL1_AWG_MAX_FREQUENCY = 0.25  # GHz
+QUEL1_SAMPLING_PERIOD_NS = 2.0
+QUEL1_WORD_LENGTH_SAMPLES = 4
+QUEL1_BLOCK_LENGTH_SAMPLES = 64
+
+ArrayMap = dict[str, np.ndarray]
+ChevronMetadataMap = dict[str, list[dict[str, Any]]]
+FigureMap = dict[str, go.Figure]
+
+
+@dataclass(frozen=True)
+class _TargetAnalysis:
+    raw_data: np.ndarray
+    normalized_signal: np.ndarray
+    population: np.ndarray
+    relaxation_times: np.ndarray
+    relaxation_time_errors: np.ndarray
+    r2: np.ndarray
+    fit_results: list[dict[str, Any]]
+    sort_indices: np.ndarray
+    figures: FigureMap
 
 
 def spin_lock_sequence(
@@ -69,8 +103,8 @@ def spin_lock_sequence(
         PulseSchedule
         Pulse schedule containing the spin-lock sequence.
     """
-    if duration <= 0:
-        raise ValueError("duration must be positive.")
+    if not np.isfinite(duration) or duration <= 0:
+        raise ValueError("duration must be positive and finite.")
     if not np.isfinite(drive_amplitude):
         raise ValueError("drive_amplitude must be finite.")
     if abs(drive_amplitude) > 1:
@@ -106,6 +140,12 @@ def _resolve_phases(
     resolved_final_phase = (
         resolved_drive_phase + np.pi / 2 if final_phase is None else final_phase
     )
+    if not np.all(
+        np.isfinite(
+            [resolved_drive_phase, resolved_initial_phase, resolved_final_phase]
+        )
+    ):
+        raise ValueError("drive_phase, initial_phase, and final_phase must be finite.")
     return resolved_drive_phase, resolved_initial_phase, resolved_final_phase
 
 
@@ -160,20 +200,22 @@ def _resolve_duration_range(
     discretized = np.asarray(discretized, dtype=np.float64)
     if np.any(discretized <= 0):
         raise ValueError("duration_range contains values below the sampling grid.")
+    discretized = np.unique(discretized)
+    if discretized.size < MIN_DECAY_FIT_POINTS:
+        raise ValueError(
+            "duration_range must contain at least "
+            f"{MIN_DECAY_FIT_POINTS} unique points after discretization."
+        )
     return discretized
 
 
-def _effective_spin_lock_frequency_range(
-    spin_lock_rabi_frequency_range: np.ndarray,
-    *,
-    drive_detuning: float | None,
-) -> np.ndarray:
+def _resolve_drive_detuning(drive_detuning: float | None) -> float:
     if drive_detuning is None:
-        drive_detuning = 0.0
-    drive_detuning = float(drive_detuning)
-    if not np.isfinite(drive_detuning):
+        return 0.0
+    resolved_drive_detuning = float(drive_detuning)
+    if not np.isfinite(resolved_drive_detuning):
         raise ValueError("drive_detuning must be finite.")
-    return np.sqrt(spin_lock_rabi_frequency_range**2 + drive_detuning**2)
+    return resolved_drive_detuning
 
 
 def _resolve_spin_lock_amplitudes(
@@ -181,7 +223,7 @@ def _resolve_spin_lock_amplitudes(
     *,
     targets: list[str],
     spin_lock_frequency_range: np.ndarray,
-) -> dict[str, np.ndarray]:
+) -> ArrayMap:
     amplitudes = {
         target: np.asarray(
             [
@@ -201,6 +243,370 @@ def _resolve_spin_lock_amplitudes(
                 "Reduce spin_lock_frequency_range."
             )
     return amplitudes
+
+
+def _resolve_positive_integer(value: int | None, *, name: str, default: int) -> int:
+    if value is None:
+        value = default
+    if isinstance(value, bool) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"{name} must be a positive integer.")
+    value = int(value)
+    if value <= 0:
+        raise ValueError(f"{name} must be a positive integer.")
+    return value
+
+
+def _resolve_nonnegative_finite_float(
+    value: float | None,
+    *,
+    name: str,
+    default: float,
+) -> float:
+    if value is None:
+        value = default
+    value = float(value)
+    if not np.isfinite(value) or value < 0:
+        raise ValueError(f"{name} must be finite and nonnegative.")
+    return value
+
+
+def _resolve_bool(value: bool | None, *, default: bool) -> bool:
+    if value is None:
+        return default
+    if not isinstance(value, bool):
+        raise TypeError("Boolean options must be bool or None.")
+    return value
+
+
+def _nan_array_map(
+    *,
+    targets: list[str],
+    shape: tuple[int, ...],
+) -> ArrayMap:
+    return {
+        target: np.full(
+            shape,
+            np.nan,
+            dtype=np.float64,
+        )
+        for target in targets
+    }
+
+
+def _scaled_chevron_ranges(
+    exp: Experiment,
+    *,
+    expected_rabi_frequency: float,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    scale = expected_rabi_frequency / CHEVRON_REFERENCE_RABI_FREQUENCY
+    if not np.isfinite(scale) or scale <= 0:
+        raise ValueError("expected_rabi_frequency must be positive and finite.")
+
+    detuning_half_width = min(
+        CHEVRON_REFERENCE_DETUNING_HALF_WIDTH * scale,
+        CHEVRON_MAX_DETUNING_HALF_WIDTH,
+    )
+    detuning_range = np.linspace(
+        -detuning_half_width,
+        detuning_half_width,
+        CHEVRON_DETUNING_POINTS,
+    )
+
+    time_max = CHEVRON_REFERENCE_TIME_MAX / scale
+    time_range = exp.ctx.util.discretize_time_range(
+        np.linspace(0, time_max, CHEVRON_TIME_POINTS),
+        sampling_period=exp.ctx.measurement.sampling_period,
+    )
+    if time_range is None:
+        raise ValueError("chevron time_range could not be discretized.")
+    time_range = np.unique(np.asarray(time_range, dtype=np.float64))
+    if time_range.size < MIN_CHEVRON_TIME_POINTS:
+        raise ValueError(
+            "chevron time_range must contain at least "
+            f"{MIN_CHEVRON_TIME_POINTS} unique points after discretization."
+        )
+
+    omega_rabi_range = (
+        expected_rabi_frequency
+        * 2
+        * (10 ** np.linspace(0, 1, CHEVRON_OMEGA_RABI_POINTS) - 1)
+        / 9
+    )
+    return detuning_range, time_range, omega_rabi_range
+
+
+def _target_base_frequencies(exp: Experiment, targets: list[str]) -> dict[str, float]:
+    return {target: float(exp.ctx.targets[target].frequency) for target in targets}
+
+
+def _chevron_drive_frequency_range(
+    *,
+    base_frequency: float,
+    detuning_range: np.ndarray,
+) -> np.ndarray:
+    return float(base_frequency) + np.asarray(detuning_range, dtype=np.float64)
+
+
+def _chevron_awg_frequency_range(
+    exp: Experiment,
+    *,
+    target: str,
+    drive_frequency_range: np.ndarray,
+) -> np.ndarray:
+    experiment_system = exp.ctx.experiment_system
+    target_info = experiment_system.get_target(target)
+    nco_frequency = float(experiment_system.get_nco_frequency(target))
+
+    if target_info.sideband == "L":
+        return nco_frequency - drive_frequency_range
+    return drive_frequency_range - nco_frequency
+
+
+def _looks_like_quel1_constraint_profile(constraint_profile: Any) -> bool:
+    if constraint_profile is None:
+        return False
+
+    strict_quel1_flags = all(
+        bool(getattr(constraint_profile, name, False))
+        for name in (
+            "require_workaround_capture",
+            "enforce_word_alignment",
+            "enforce_block_alignment",
+            "enforce_capture_spacing",
+        )
+    )
+    if not strict_quel1_flags:
+        return False
+
+    try:
+        sampling_period_ns = float(
+            getattr(constraint_profile, "sampling_period_ns", np.nan)
+        )
+        word_length_samples = int(
+            getattr(constraint_profile, "word_length_samples", -1)
+        )
+        block_length_samples = int(
+            getattr(constraint_profile, "block_length_samples", -1)
+        )
+    except (TypeError, ValueError):
+        return False
+
+    sampling_period_matches = bool(
+        np.isclose(sampling_period_ns, QUEL1_SAMPLING_PERIOD_NS)
+    )
+    return (
+        sampling_period_matches
+        and word_length_samples == QUEL1_WORD_LENGTH_SAMPLES
+        and block_length_samples == QUEL1_BLOCK_LENGTH_SAMPLES
+    )
+
+
+def _resolve_awg_max_frequency(exp: Experiment) -> float | None:
+    constraint_profile = getattr(exp.ctx.measurement, "constraint_profile", None)
+    if constraint_profile is None:
+        return None
+
+    awg_max_frequency_hz = getattr(constraint_profile, "awg_max_frequency_hz", None)
+    if awg_max_frequency_hz is not None:
+        awg_max_frequency = float(awg_max_frequency_hz) * 1e-9
+        if not np.isfinite(awg_max_frequency) or awg_max_frequency <= 0:
+            raise ValueError("awg_max_frequency_hz must be positive and finite.")
+        return awg_max_frequency
+
+    if _looks_like_quel1_constraint_profile(constraint_profile):
+        return QUEL1_AWG_MAX_FREQUENCY
+
+    return None
+
+
+def _validate_awg_frequency_ranges(
+    exp: Experiment,
+    *,
+    targets: list[str],
+    drive_frequency_ranges: ArrayMap,
+    description: str,
+) -> None:
+    awg_max_frequency = _resolve_awg_max_frequency(exp)
+    if awg_max_frequency is None:
+        return
+
+    for target in targets:
+        drive_frequency_range = drive_frequency_ranges[target]
+        awg_frequency_range = _chevron_awg_frequency_range(
+            exp,
+            target=target,
+            drive_frequency_range=drive_frequency_range,
+        )
+        max_abs_awg_frequency = float(np.max(np.abs(awg_frequency_range)))
+        if max_abs_awg_frequency <= awg_max_frequency + 1e-12:
+            continue
+
+        raise ValueError(
+            f"{description} for `{target}` requires AWG modulation up to "
+            f"{max_abs_awg_frequency * 1e3:.3f} MHz, exceeding "
+            f"{awg_max_frequency * 1e3:.3f} MHz with the current NCO setting. "
+            "Reduce spin_lock_frequency_range or retune the backend settings. "
+            f"Drive frequency range is {np.min(drive_frequency_range):.9g} GHz to "
+            f"{np.max(drive_frequency_range):.9g} GHz."
+        )
+
+
+def _validate_chevron_awg_frequency_range(
+    exp: Experiment,
+    *,
+    targets: list[str],
+    base_frequencies: dict[str, float],
+    detuning_range: np.ndarray,
+) -> None:
+    drive_frequency_ranges = {
+        target: _chevron_drive_frequency_range(
+            base_frequency=base_frequencies[target],
+            detuning_range=detuning_range,
+        )
+        for target in targets
+    }
+    _validate_awg_frequency_ranges(
+        exp,
+        targets=targets,
+        drive_frequency_ranges=drive_frequency_ranges,
+        description="Chevron detuning_range",
+    )
+
+
+def _constant_frequency_map(
+    *,
+    targets: list[str],
+    values: dict[str, float],
+    shape: tuple[int, ...],
+) -> ArrayMap:
+    return {
+        target: np.full(
+            shape,
+            values[target],
+            dtype=np.float64,
+        )
+        for target in targets
+    }
+
+
+def _effective_frequency_map(
+    *,
+    rabi_frequency_map: ArrayMap,
+    drive_detuning: float,
+) -> ArrayMap:
+    return {
+        target: np.sqrt(rabi_frequency**2 + drive_detuning**2)
+        for target, rabi_frequency in rabi_frequency_map.items()
+    }
+
+
+def _estimate_spin_lock_parameters_with_chevron(
+    exp: Experiment,
+    *,
+    targets: list[str],
+    requested_rabi_frequency_range: np.ndarray,
+    amplitude_map: ArrayMap,
+    chevron_n_shots: int,
+    shot_interval: float,
+    return_chevron_figures: bool,
+) -> tuple[
+    ArrayMap,
+    ArrayMap,
+    ChevronMetadataMap,
+    FigureMap,
+]:
+    base_frequencies = _target_base_frequencies(exp, targets)
+    measured_qubit_frequencies = _nan_array_map(
+        targets=targets,
+        shape=requested_rabi_frequency_range.shape,
+    )
+    measured_rabi_frequencies = _nan_array_map(
+        targets=targets,
+        shape=requested_rabi_frequency_range.shape,
+    )
+    chevron_results: ChevronMetadataMap = {target: [] for target in targets}
+    chevron_figures: FigureMap = {}
+
+    for frequency_index, expected_rabi_frequency in enumerate(
+        requested_rabi_frequency_range
+    ):
+        detuning_range, time_range, omega_rabi_range = _scaled_chevron_ranges(
+            exp,
+            expected_rabi_frequency=float(expected_rabi_frequency),
+        )
+        _validate_chevron_awg_frequency_range(
+            exp,
+            targets=targets,
+            base_frequencies=base_frequencies,
+            detuning_range=detuning_range,
+        )
+        with exp.ctx.util.no_output():
+            chevron_result = estimate_qubit_frequency_from_chevron(
+                exp,
+                targets,
+                detuning_range=detuning_range,
+                time_range=time_range,
+                frequencies=base_frequencies,
+                amplitudes={
+                    target: float(amplitude_map[target][frequency_index])
+                    for target in targets
+                },
+                omega_rabi_range=omega_rabi_range,
+                n_shots=chevron_n_shots,
+                shot_interval=shot_interval,
+                plot=False,
+                save_image=False,
+            )
+
+        results = cast(dict[str, dict[str, Any]], chevron_result.data["results"])
+        for target in targets:
+            result = results[target]
+            measured_qubit_frequencies[target][frequency_index] = float(
+                result["omega_q"]
+            )
+            measured_rabi_frequencies[target][frequency_index] = float(
+                result["omega_rabi"]
+            )
+            if not np.isfinite(measured_qubit_frequencies[target][frequency_index]):
+                raise ValueError(
+                    f"Chevron qubit frequency for `{target}` is not finite."
+                )
+            if (
+                not np.isfinite(measured_rabi_frequencies[target][frequency_index])
+                or measured_rabi_frequencies[target][frequency_index] <= 0
+            ):
+                raise ValueError(
+                    f"Chevron Rabi frequency for `{target}` must be positive and finite."
+                )
+            chevron_results[target].append(
+                {
+                    "requested_rabi_frequency": float(expected_rabi_frequency),
+                    "drive_amplitude": float(amplitude_map[target][frequency_index]),
+                    "qubit_frequency": float(result["omega_q"]),
+                    "rabi_frequency": float(result["omega_rabi"]),
+                    "peak_background_rms_ratio": float(
+                        result["peak_background_rms_ratio"]
+                    ),
+                    "detuning_range": detuning_range,
+                    "time_range": time_range,
+                    "omega_rabi_range": omega_rabi_range,
+                }
+            )
+
+        if return_chevron_figures and chevron_result.figures is not None:
+            for name, figure in chevron_result.figures.items():
+                figure_name = (
+                    f"chevron_{frequency_index:03d}_"
+                    f"{expected_rabi_frequency * 1e3:.6f}_MHz_{name}"
+                )
+                chevron_figures[figure_name] = figure
+
+    return (
+        measured_qubit_frequencies,
+        measured_rabi_frequencies,
+        chevron_results,
+        chevron_figures,
+    )
 
 
 def _add_spin_lock_pulse(
@@ -249,6 +655,8 @@ def _make_spin_lock_heatmap_figure(
             y=duration_range,
             z=population,
             colorscale="Viridis",
+            zmin=0,
+            zmax=1,
         )
     )
     fig.update_layout(
@@ -274,14 +682,28 @@ def _make_spin_lock_relaxation_figure(
     relaxation_times: np.ndarray,
     relaxation_time_errors: np.ndarray,
 ) -> go.Figure:
+    relaxation_times_us = relaxation_times * 1e-3
+    relaxation_time_errors_us = relaxation_time_errors * 1e-3
+    upper_candidates = relaxation_times_us + np.where(
+        np.isfinite(relaxation_time_errors_us),
+        np.maximum(relaxation_time_errors_us, 0.0),
+        0.0,
+    )
+    finite_upper_candidates = upper_candidates[np.isfinite(upper_candidates)]
+    yaxis_upper = (
+        1.05 * float(np.max(finite_upper_candidates))
+        if finite_upper_candidates.size > 0 and np.max(finite_upper_candidates) > 0
+        else 1.0
+    )
+
     fig = viz.make_figure()
     fig.add_trace(
         go.Scatter(
             x=spin_lock_rabi_frequency_range * 1e3,
-            y=relaxation_times * 1e-3,
+            y=relaxation_times_us,
             error_y=dict(
                 type="data",
-                array=relaxation_time_errors * 1e-3,
+                array=relaxation_time_errors_us,
                 visible=True,
             ),
             mode="markers+lines",
@@ -296,12 +718,220 @@ def _make_spin_lock_relaxation_figure(
         ),
         xaxis_title="Spin-lock Rabi frequency (MHz)",
         xaxis_type="log",
-        yaxis_title="Relaxation time (us)",
-        yaxis_rangemode="tozero",
+        yaxis_title="Relaxation time (μs)",
+        yaxis_range=[0, yaxis_upper],
         width=700,
         height=450,
     )
     return fig
+
+
+def _frequency_sort_indices(frequency_range: np.ndarray) -> np.ndarray:
+    if np.any(np.diff(frequency_range) < 0):
+        return np.argsort(frequency_range)
+    return np.arange(frequency_range.size)
+
+
+def _make_fit_summary(
+    *,
+    frequency: float,
+    frequency_index: int,
+    requested_rabi_frequency_range: np.ndarray,
+    effective_frequency_range: np.ndarray,
+    drive_frequencies: np.ndarray,
+    qubit_frequencies: np.ndarray,
+    status: FitStatus | str,
+    message: str,
+    data: dict[str, Any],
+) -> dict[str, Any]:
+    status_value = status.value if isinstance(status, FitStatus) else status
+    return {
+        "frequency": float(frequency),
+        "rabi_frequency": float(frequency),
+        "effective_frequency": float(effective_frequency_range[frequency_index]),
+        "requested_rabi_frequency": float(
+            requested_rabi_frequency_range[frequency_index]
+        ),
+        "drive_frequency": float(drive_frequencies[frequency_index]),
+        "qubit_frequency": float(qubit_frequencies[frequency_index]),
+        "status": status_value,
+        "message": message,
+        "data": data,
+    }
+
+
+def _fit_data_without_figure(fit_result: Any) -> dict[str, Any]:
+    return {key: value for key, value in fit_result.data.items() if key != "fig"}
+
+
+def _analyze_spin_lock_target(
+    *,
+    target: str,
+    sweep_data: Any,
+    durations: np.ndarray,
+    requested_rabi_frequency_range: np.ndarray,
+    rabi_frequency_range: np.ndarray,
+    effective_frequency_range: np.ndarray,
+    drive_frequencies: np.ndarray,
+    qubit_frequencies: np.ndarray,
+) -> _TargetAnalysis:
+    raw = np.asarray(sweep_data.data, dtype=np.complex128).reshape(
+        requested_rabi_frequency_range.size,
+        durations.size,
+    )
+    measured = np.asarray(sweep_data.normalized, dtype=np.float64).reshape(
+        requested_rabi_frequency_range.size,
+        durations.size,
+    )
+    fit_population = 0.5 * (1 + measured)
+
+    relaxation_times = np.full(
+        requested_rabi_frequency_range.shape,
+        np.nan,
+        dtype=np.float64,
+    )
+    relaxation_time_errors = np.full(
+        requested_rabi_frequency_range.shape,
+        np.nan,
+        dtype=np.float64,
+    )
+    r2_values = np.full(
+        requested_rabi_frequency_range.shape,
+        np.nan,
+        dtype=np.float64,
+    )
+    fit_results: list[dict[str, Any]] = []
+    figures: FigureMap = {}
+
+    for frequency_index, frequency in enumerate(rabi_frequency_range):
+        try:
+            fit_result = fitting.fit_exp_decay(
+                target=f"{target}_{frequency * 1e3:.6g}_MHz",
+                x=durations,
+                y=fit_population[frequency_index],
+                plot=False,
+                title="Spin-lock relaxation",
+                xlabel="Duration (μs)",
+                ylabel="Normalized signal",
+                xaxis_type="log",
+                yaxis_type="linear",
+            )
+        except Exception as exc:
+            fit_results.append(
+                _make_fit_summary(
+                    frequency=float(frequency),
+                    frequency_index=frequency_index,
+                    requested_rabi_frequency_range=requested_rabi_frequency_range,
+                    effective_frequency_range=effective_frequency_range,
+                    drive_frequencies=drive_frequencies,
+                    qubit_frequencies=qubit_frequencies,
+                    status=FitStatus.ERROR,
+                    message=str(exc),
+                    data={},
+                )
+            )
+            continue
+
+        if fit_result.status is FitStatus.SUCCESS:
+            relaxation_times[frequency_index] = float(fit_result["tau"])
+            relaxation_time_errors[frequency_index] = float(fit_result["tau_err"])
+            r2_values[frequency_index] = float(fit_result["r2"])
+
+        fit_results.append(
+            _make_fit_summary(
+                frequency=float(frequency),
+                frequency_index=frequency_index,
+                requested_rabi_frequency_range=requested_rabi_frequency_range,
+                effective_frequency_range=effective_frequency_range,
+                drive_frequencies=drive_frequencies,
+                qubit_frequencies=qubit_frequencies,
+                status=fit_result.status,
+                message=fit_result.message or "",
+                data=_fit_data_without_figure(fit_result),
+            )
+        )
+        if fit_result.figure is not None:
+            figures[f"{target}_fit_{frequency_index:03d}_{frequency * 1e3:.6f}_MHz"] = (
+                fit_result.figure
+            )
+
+    sort_indices = _frequency_sort_indices(rabi_frequency_range)
+    figures[f"{target}_heatmap"] = _make_spin_lock_heatmap_figure(
+        target=target,
+        spin_lock_rabi_frequency_range=rabi_frequency_range[sort_indices],
+        duration_range=durations,
+        population=fit_population.T[:, sort_indices],
+    )
+    figures[f"{target}_relaxation"] = _make_spin_lock_relaxation_figure(
+        target=target,
+        spin_lock_rabi_frequency_range=rabi_frequency_range[sort_indices],
+        relaxation_times=relaxation_times[sort_indices],
+        relaxation_time_errors=relaxation_time_errors[sort_indices],
+    )
+
+    return _TargetAnalysis(
+        raw_data=raw,
+        normalized_signal=measured.T,
+        population=fit_population.T,
+        relaxation_times=relaxation_times,
+        relaxation_time_errors=relaxation_time_errors,
+        r2=r2_values,
+        fit_results=fit_results,
+        sort_indices=sort_indices,
+        figures=figures,
+    )
+
+
+def _measure_spin_lock_grid(
+    exp: Experiment,
+    *,
+    targets: list[str],
+    durations: np.ndarray,
+    requested_rabi_frequency_range: np.ndarray,
+    amplitude_map: ArrayMap,
+    frequency_offset_map: ArrayMap,
+    drive_phase: float | None,
+    initial_phase: float | None,
+    final_phase: float | None,
+    n_shots: int,
+    shot_interval: float,
+    enable_tqdm: bool,
+) -> Any:
+    sweep_points = [
+        (frequency_index, duration_index)
+        for frequency_index in range(requested_rabi_frequency_range.size)
+        for duration_index in range(durations.size)
+    ]
+
+    def sequence(point_index: int) -> PulseSchedule:
+        frequency_index, duration_index = sweep_points[int(point_index)]
+        with PulseSchedule(targets) as schedule:
+            for target in targets:
+                _add_spin_lock_pulse(
+                    schedule,
+                    exp,
+                    target=target,
+                    duration=float(durations[duration_index]),
+                    drive_amplitude=float(amplitude_map[target][frequency_index]),
+                    drive_detuning=float(frequency_offset_map[target][frequency_index]),
+                    drive_phase=drive_phase,
+                    initial_phase=initial_phase,
+                    final_phase=final_phase,
+                )
+        return schedule
+
+    with exp.ctx.util.no_output():
+        return exp.measurement_service.sweep_parameter(
+            sequence=sequence,
+            sweep_range=np.arange(len(sweep_points)),
+            n_shots=n_shots,
+            shot_interval=shot_interval,
+            plot=False,
+            enable_tqdm=enable_tqdm,
+            title="Spin-lock spectroscopy",
+            xlabel="Sweep point",
+            ylabel="Measured value",
+        )
 
 
 def spin_lock_spectroscopy(
@@ -310,6 +940,9 @@ def spin_lock_spectroscopy(
     *,
     spin_lock_frequency_range: ArrayLike | None = None,
     duration_range: ArrayLike | None = None,
+    estimate_with_chevron: bool | None = None,
+    chevron_n_shots: int | None = None,
+    return_chevron_figures: bool | None = None,
     drive_detuning: float | None = None,
     drive_phase: float | None = None,
     initial_phase: float | None = None,
@@ -332,8 +965,7 @@ def spin_lock_spectroscopy(
     as ``sqrt(rabi_rate**2 + drive_detuning**2)``.
 
     All ``(spin_lock_frequency, duration)`` points are flattened into one
-    ``sweep_parameter()`` call, following the same pattern as the chevron
-    measurement helpers.
+    ``sweep_parameter()`` call.
 
     Parameters
     ----------
@@ -344,13 +976,28 @@ def spin_lock_spectroscopy(
         are measured.
     spin_lock_frequency_range
         Spin-lock frequencies in GHz. These values are treated as desired Rabi
-        rates. If omitted, ``np.geomspace(0.001, 0.2, 21)`` is used, i.e.
-        1 MHz to 200 MHz.
+        rates. If omitted, ``np.geomspace(0.01, 0.2, 16)`` is used, i.e.
+        10 MHz to 200 MHz.
     duration_range
         Spin-lock drive durations in ns. Values must be positive because the
         heatmap and fit figures use a log time axis. The range is discretized to
         ``exp.ctx.measurement.sampling_period``. If omitted,
         ``np.geomspace(100, 200e3, 31)`` is used.
+    estimate_with_chevron
+        Whether to run ``estimate_qubit_frequency_from_chevron()`` before the
+        spin-lock sweep for each requested spin-lock frequency. When ``True``,
+        the spin-lock pulse frequency is shifted to the AC-Stark-shifted qubit
+        frequency estimated by chevron, and the figure x-axes use the measured
+        Rabi frequencies from chevron. The chevron detuning half-width is scaled
+        from the expected Rabi rate and capped at 200 MHz.
+    chevron_n_shots
+        Number of shots for each pre-measurement chevron sweep point. Used only
+        when ``estimate_with_chevron=True`` and defaults to
+        ``max(1, n_shots // 4)``.
+    return_chevron_figures
+        Whether to include the intermediate chevron measurement and transform
+        figures in ``Result.figures``. Defaults to ``False`` so chevron
+        pre-measurement figures do not enlarge the returned figure payload.
     drive_detuning
         Optional spin-lock drive detuning in GHz.
     drive_phase
@@ -379,12 +1026,23 @@ def spin_lock_spectroscopy(
         Generic result containing measured arrays, fit summaries, and figures.
         Important payload keys are:
 
-        ``spin_lock_rabi_frequency_range``
+        ``requested_spin_lock_rabi_frequency_range``
             Requested spin-lock Rabi-frequency axis in GHz.
+        ``measured_spin_lock_rabi_frequency_range``
+            Per-target Rabi-frequency axis in GHz used for plotting and fit
+            metadata. This matches the requested axis unless
+            ``estimate_with_chevron=True``.
+        ``spin_lock_qubit_frequencies``
+            Per-target qubit frequencies in GHz used as the spin-lock frequency
+            reference before adding ``drive_detuning``.
+        ``spin_lock_drive_frequencies``
+            Per-target microwave drive frequencies in GHz including
+            ``drive_detuning``. When ``estimate_with_chevron=True``, these are
+            AC-Stark-shifted qubit frequencies estimated by chevron plus
+            ``drive_detuning``.
         ``effective_spin_lock_frequency_range``
-            Effective lock-frequency axis in GHz including ``drive_detuning``.
-        ``spin_lock_frequency_range``
-            Alias of ``spin_lock_rabi_frequency_range`` kept for convenience.
+            Per-target effective lock-frequency axis in GHz including
+            ``drive_detuning``.
         ``duration_range``
             Discretized duration axis in ns.
         ``drive_amplitudes``
@@ -392,10 +1050,10 @@ def spin_lock_spectroscopy(
             frequencies.
         ``raw_data``
             Per-target raw IQ data with shape
-            ``(len(spin_lock_frequency_range), len(duration_range))``.
+            ``(len(requested_spin_lock_rabi_frequency_range), len(duration_range))``.
         ``population``
             Per-target heatmap data with shape
-            ``(len(duration_range), len(spin_lock_frequency_range))``.
+            ``(len(duration_range), len(requested_spin_lock_rabi_frequency_range))``.
         ``normalized_signal``
             Per-target normalized signal before converting to population.
         ``relaxation_times``
@@ -406,18 +1064,36 @@ def spin_lock_spectroscopy(
             Per-target fit R² values.
         ``fit_results``
             Per-frequency fit metadata and fit parameters.
+        ``chevron_results``
+            Per-frequency chevron metadata. Empty unless
+            ``estimate_with_chevron=True``.
+        ``return_chevron_figures``
+            Whether intermediate chevron figures were included in
+            ``Result.figures``.
+        ``chevron_n_shots``
+            Number of shots used for each chevron sweep point, or ``None`` when
+            ``estimate_with_chevron=False``.
+        ``spin_lock_rabi_sort_indices``
+            Per-target indices used to sort measured Rabi frequencies for
+            plotting. Measured arrays in the payload keep the acquisition order.
 
         The ``figures`` mapping contains ``"{target}_heatmap"`` and
         ``"{target}_relaxation"`` for each target, plus per-frequency fit figures
-        named ``"{target}_fit_{frequency_mhz}_MHz"``.
+        named ``"{target}_fit_{frequency_index}_{frequency_mhz}_MHz"``.
 
     Notes
     -----
     - ``spin_lock_frequency_range`` is not a detuning sweep; it is the target
-      Rabi rate of the locking drive. The figure x-axis uses this Rabi-rate
-      axis, not the detuning-corrected effective lock frequency.
+      Rabi rate of the locking drive. With ``estimate_with_chevron=True``, the
+      figure x-axis uses the measured Rabi-rate axis from chevron; otherwise it
+      uses this requested Rabi-rate axis.
     - The implementation raises an error if any calculated drive amplitude has
       absolute value larger than 1.
+    - If the active measurement constraint profile defines
+      ``awg_max_frequency_hz``, chevron pre-measurements and the final spin-lock
+      drive frequencies are checked against that AWG modulation limit using the
+      current NCO setting. For current QuEL-1-style strict timing profiles that
+      do not expose such a field, a local 250 MHz contrib fallback is used.
     - The fitted relaxation uses ``0.5 * (1 + normalized_signal)`` and
       ``fitting.fit_exp_decay()``, matching the sign convention used by the T2
       echo analysis path.
@@ -426,171 +1102,137 @@ def spin_lock_spectroscopy(
     if len(target_list) == 0:
         raise ValueError("targets must contain at least one target.")
 
-    if n_shots is None:
-        n_shots = DEFAULT_SHOTS
-    if shot_interval is None:
-        shot_interval = DEFAULT_INTERVAL
-    if plot is None:
-        plot = True
-    if save_image is None:
-        save_image = False
-    if enable_tqdm is None:
-        enable_tqdm = False
+    n_shots = _resolve_positive_integer(
+        n_shots,
+        name="n_shots",
+        default=DEFAULT_SHOTS,
+    )
+    shot_interval = _resolve_nonnegative_finite_float(
+        shot_interval,
+        name="shot_interval",
+        default=DEFAULT_INTERVAL,
+    )
+    plot = _resolve_bool(plot, default=True)
+    save_image = _resolve_bool(save_image, default=False)
+    enable_tqdm = _resolve_bool(enable_tqdm, default=False)
+    estimate_with_chevron = _resolve_bool(estimate_with_chevron, default=False)
+    return_chevron_figures = _resolve_bool(return_chevron_figures, default=False)
 
     exp.pulse.validate_rabi_params(target_list)
 
-    rabi_frequency_range = _resolve_frequency_range(spin_lock_frequency_range)
-    effective_frequency_range = _effective_spin_lock_frequency_range(
-        rabi_frequency_range,
-        drive_detuning=drive_detuning,
+    requested_rabi_frequency_range = _resolve_frequency_range(spin_lock_frequency_range)
+    drive_detuning_value = _resolve_drive_detuning(drive_detuning)
+    drive_phase, initial_phase, final_phase = _resolve_phases(
+        drive_phase=drive_phase,
+        initial_phase=initial_phase,
+        final_phase=final_phase,
     )
     durations = _resolve_duration_range(exp, duration_range)
     amplitude_map = _resolve_spin_lock_amplitudes(
         exp,
         targets=target_list,
-        spin_lock_frequency_range=rabi_frequency_range,
+        spin_lock_frequency_range=requested_rabi_frequency_range,
+    )
+    base_frequencies = _target_base_frequencies(exp, target_list)
+    chevron_results: ChevronMetadataMap = {target: [] for target in target_list}
+    chevron_figures: FigureMap = {}
+    chevron_n_shots_value: int | None = None
+    if estimate_with_chevron:
+        chevron_n_shots_value = _resolve_positive_integer(
+            chevron_n_shots,
+            name="chevron_n_shots",
+            default=max(1, n_shots // 4),
+        )
+        (
+            qubit_frequency_map,
+            measured_rabi_frequency_map,
+            chevron_results,
+            chevron_figures,
+        ) = _estimate_spin_lock_parameters_with_chevron(
+            exp,
+            targets=target_list,
+            requested_rabi_frequency_range=requested_rabi_frequency_range,
+            amplitude_map=amplitude_map,
+            chevron_n_shots=chevron_n_shots_value,
+            shot_interval=shot_interval,
+            return_chevron_figures=return_chevron_figures,
+        )
+    else:
+        qubit_frequency_map = _constant_frequency_map(
+            targets=target_list,
+            values=base_frequencies,
+            shape=requested_rabi_frequency_range.shape,
+        )
+        measured_rabi_frequency_map = {
+            target: requested_rabi_frequency_range.copy() for target in target_list
+        }
+    drive_frequency_map = {
+        target: qubit_frequency_map[target] + drive_detuning_value
+        for target in target_list
+    }
+    _validate_awg_frequency_ranges(
+        exp,
+        targets=target_list,
+        drive_frequency_ranges=drive_frequency_map,
+        description="Spin-lock drive frequencies",
+    )
+    frequency_offset_map = {
+        target: drive_frequency_map[target] - base_frequencies[target]
+        for target in target_list
+    }
+    effective_measured_frequency_map = _effective_frequency_map(
+        rabi_frequency_map=measured_rabi_frequency_map,
+        drive_detuning=drive_detuning_value,
     )
 
-    sweep_points = [
-        (frequency_index, duration_index)
-        for frequency_index in range(rabi_frequency_range.size)
-        for duration_index in range(durations.size)
-    ]
+    sweep_result = _measure_spin_lock_grid(
+        exp,
+        targets=target_list,
+        durations=durations,
+        requested_rabi_frequency_range=requested_rabi_frequency_range,
+        amplitude_map=amplitude_map,
+        frequency_offset_map=frequency_offset_map,
+        drive_phase=drive_phase,
+        initial_phase=initial_phase,
+        final_phase=final_phase,
+        n_shots=n_shots,
+        shot_interval=shot_interval,
+        enable_tqdm=enable_tqdm,
+    )
 
-    def sequence(point_index: int) -> PulseSchedule:
-        frequency_index, duration_index = sweep_points[int(point_index)]
-        with PulseSchedule(target_list) as schedule:
-            for target in target_list:
-                _add_spin_lock_pulse(
-                    schedule,
-                    exp,
-                    target=target,
-                    duration=float(durations[duration_index]),
-                    drive_amplitude=float(amplitude_map[target][frequency_index]),
-                    drive_detuning=drive_detuning,
-                    drive_phase=drive_phase,
-                    initial_phase=initial_phase,
-                    final_phase=final_phase,
-                )
-        return schedule
-
-    with exp.ctx.util.no_output():
-        sweep_result = exp.measurement_service.sweep_parameter(
-            sequence=sequence,
-            sweep_range=np.arange(len(sweep_points)),
-            n_shots=n_shots,
-            shot_interval=shot_interval,
-            plot=False,
-            enable_tqdm=enable_tqdm,
-            title="Spin-lock spectroscopy",
-            xlabel="Sweep point",
-            ylabel="Measured value",
-        )
-
-    normalized_signal: dict[str, np.ndarray] = {}
-    population: dict[str, np.ndarray] = {}
-    raw_data: dict[str, np.ndarray] = {}
-    relaxation_times: dict[str, np.ndarray] = {}
-    relaxation_time_errors: dict[str, np.ndarray] = {}
-    r2_values: dict[str, np.ndarray] = {}
+    normalized_signal: ArrayMap = {}
+    population: ArrayMap = {}
+    raw_data: ArrayMap = {}
+    relaxation_times: ArrayMap = {}
+    relaxation_time_errors: ArrayMap = {}
+    r2_values: ArrayMap = {}
     fit_results: dict[str, list[dict[str, Any]]] = {}
-    figures: dict[str, go.Figure] = {}
+    rabi_sort_indices: ArrayMap = {}
+    figures: FigureMap = dict(chevron_figures)
 
     for target in target_list:
-        sweep_data = sweep_result.data[target]
-        raw = np.asarray(sweep_data.data, dtype=np.complex128).reshape(
-            rabi_frequency_range.size,
-            durations.size,
-        )
-        measured = np.asarray(sweep_data.normalized, dtype=np.float64).reshape(
-            rabi_frequency_range.size,
-            durations.size,
-        )
-        fit_population = 0.5 * (1 + measured)
-        # Plot with duration on the vertical axis and frequency on the horizontal axis.
-        normalized_signal[target] = measured.T
-        population[target] = fit_population.T
-        raw_data[target] = raw
-
-        target_t1rho = np.full(rabi_frequency_range.shape, np.nan, dtype=np.float64)
-        target_t1rho_err = np.full(
-            rabi_frequency_range.shape,
-            np.nan,
-            dtype=np.float64,
-        )
-        target_r2 = np.full(rabi_frequency_range.shape, np.nan, dtype=np.float64)
-        target_fit_results: list[dict[str, Any]] = []
-
-        for frequency_index, frequency in enumerate(rabi_frequency_range):
-            try:
-                fit_result = fitting.fit_exp_decay(
-                    target=f"{target}_{frequency * 1e3:.6g}_MHz",
-                    x=durations,
-                    y=fit_population[frequency_index],
-                    plot=False,
-                    title="Spin-lock relaxation",
-                    xlabel="Duration (us)",
-                    ylabel="Normalized signal",
-                    xaxis_type="log",
-                    yaxis_type="linear",
-                )
-            except Exception as exc:
-                target_fit_results.append(
-                    {
-                        "frequency": float(frequency),
-                        "rabi_frequency": float(frequency),
-                        "effective_frequency": float(
-                            effective_frequency_range[frequency_index]
-                        ),
-                        "status": FitStatus.ERROR.value,
-                        "message": str(exc),
-                        "data": {},
-                    }
-                )
-                continue
-
-            if fit_result.status is FitStatus.SUCCESS:
-                target_t1rho[frequency_index] = float(fit_result["tau"])
-                target_t1rho_err[frequency_index] = float(fit_result["tau_err"])
-                target_r2[frequency_index] = float(fit_result["r2"])
-            target_fit_results.append(
-                {
-                    "frequency": float(frequency),
-                    "rabi_frequency": float(frequency),
-                    "effective_frequency": float(
-                        effective_frequency_range[frequency_index]
-                    ),
-                    "status": fit_result.status.value,
-                    "message": fit_result.message,
-                    "data": {
-                        key: value
-                        for key, value in fit_result.data.items()
-                        if key != "fig"
-                    },
-                }
-            )
-            if fit_result.figure is not None:
-                figures[f"{target}_fit_{frequency * 1e3:.6f}_MHz"] = fit_result.figure
-
-        relaxation_times[target] = target_t1rho
-        relaxation_time_errors[target] = target_t1rho_err
-        r2_values[target] = target_r2
-        fit_results[target] = target_fit_results
-
-        heatmap = _make_spin_lock_heatmap_figure(
+        analysis = _analyze_spin_lock_target(
             target=target,
-            spin_lock_rabi_frequency_range=rabi_frequency_range,
-            duration_range=durations,
-            population=population[target],
+            sweep_data=sweep_result.data[target],
+            durations=durations,
+            requested_rabi_frequency_range=requested_rabi_frequency_range,
+            rabi_frequency_range=measured_rabi_frequency_map[target],
+            effective_frequency_range=effective_measured_frequency_map[target],
+            drive_frequencies=drive_frequency_map[target],
+            qubit_frequencies=qubit_frequency_map[target],
         )
-        relaxation = _make_spin_lock_relaxation_figure(
-            target=target,
-            spin_lock_rabi_frequency_range=rabi_frequency_range,
-            relaxation_times=target_t1rho,
-            relaxation_time_errors=target_t1rho_err,
-        )
-        figures[f"{target}_heatmap"] = heatmap
-        figures[f"{target}_relaxation"] = relaxation
+
+        raw_data[target] = analysis.raw_data
+        normalized_signal[target] = analysis.normalized_signal
+        population[target] = analysis.population
+        relaxation_times[target] = analysis.relaxation_times
+        relaxation_time_errors[target] = analysis.relaxation_time_errors
+        r2_values[target] = analysis.r2
+        fit_results[target] = analysis.fit_results
+        rabi_sort_indices[target] = analysis.sort_indices
+        figures.update(analysis.figures)
+        heatmap = figures[f"{target}_heatmap"]
+        relaxation = figures[f"{target}_relaxation"]
 
         if plot:
             heatmap.show(config=viz.get_config(filename=f"spin_lock_heatmap_{target}"))
@@ -605,11 +1247,19 @@ def spin_lock_spectroscopy(
     return Result(
         data={
             "targets": target_list,
-            "spin_lock_frequency_range": rabi_frequency_range,
-            "spin_lock_rabi_frequency_range": rabi_frequency_range,
-            "effective_spin_lock_frequency_range": effective_frequency_range,
+            "requested_spin_lock_rabi_frequency_range": requested_rabi_frequency_range,
+            "measured_spin_lock_rabi_frequency_range": measured_rabi_frequency_map,
+            "effective_spin_lock_frequency_range": effective_measured_frequency_map,
+            "spin_lock_qubit_frequencies": qubit_frequency_map,
+            "spin_lock_drive_frequencies": drive_frequency_map,
+            "spin_lock_frequency_offsets": frequency_offset_map,
             "duration_range": durations,
             "drive_amplitudes": amplitude_map,
+            "estimate_with_chevron": estimate_with_chevron,
+            "chevron_n_shots": chevron_n_shots_value,
+            "return_chevron_figures": return_chevron_figures,
+            "chevron_results": chevron_results,
+            "spin_lock_rabi_sort_indices": rabi_sort_indices,
             "raw_data": raw_data,
             "normalized_signal": normalized_signal,
             "population": population,

--- a/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
+++ b/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
@@ -1589,7 +1589,9 @@ def spin_lock_spectroscopy(
         is used as the sweep axis when present; otherwise ``rabi_frequencies``
         from the first target is used. All per-target arrays must have the same
         shape and order as the resolved spin-lock frequency sweep. Optional
-        ``chevron_measured`` entries must be bool arrays.
+        ``chevron_measured`` entries must be bool arrays. Rabi parameters are
+        still required for readout normalization even when this calibration is
+        supplied.
     estimate_with_chevron
         Whether to run ``estimate_qubit_frequency_from_chevron()`` before the
         spin-lock sweep for each requested spin-lock frequency. When ``True``,
@@ -1693,6 +1695,7 @@ def spin_lock_spectroscopy(
     if len(target_list) == 0:
         raise ValueError("targets must contain at least one target.")
     _validate_hpi_pulses(exp, target_list)
+    exp.pulse.validate_rabi_params(target_list)
 
     n_shots = _resolve_positive_integer(
         n_shots,
@@ -1708,9 +1711,6 @@ def spin_lock_spectroscopy(
     save_image = _resolve_bool(save_image, default=False)
     estimate_with_chevron = _resolve_bool(estimate_with_chevron, default=True)
     return_chevron_figures = _resolve_bool(return_chevron_figures, default=False)
-
-    if spin_lock_calibration is None:
-        exp.pulse.validate_rabi_params(target_list)
 
     if spin_lock_frequency_range is None and spin_lock_calibration is not None:
         spin_lock_frequency_range = _frequency_axis_from_calibration(

--- a/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
+++ b/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
@@ -191,6 +191,11 @@ def _normalize_targets(
     return list(targets)
 
 
+def _validate_hpi_pulses(exp: Experiment, targets: list[str]) -> None:
+    for target in targets:
+        exp.pulse.get_hpi_pulse(target)
+
+
 def _resolve_frequency_range(
     spin_lock_frequency_range: ArrayLike | None,
 ) -> np.ndarray:
@@ -1275,7 +1280,7 @@ def _analyze_spin_lock_target(
                 y=fit_population[frequency_index],
                 plot=False,
                 title="Spin-lock relaxation",
-                xlabel="Duration (ns)",
+                xlabel="Duration (μs)",
                 ylabel="Normalized signal",
                 xaxis_type="log",
                 yaxis_type="linear",
@@ -1687,6 +1692,7 @@ def spin_lock_spectroscopy(
     target_list = _normalize_targets(exp, targets)
     if len(target_list) == 0:
         raise ValueError("targets must contain at least one target.")
+    _validate_hpi_pulses(exp, target_list)
 
     n_shots = _resolve_positive_integer(
         n_shots,

--- a/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
+++ b/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
@@ -22,9 +22,10 @@ from qubex.pulse import PulseSchedule, Rect
 
 __all__ = ["spin_lock_sequence", "spin_lock_spectroscopy"]
 
-DEFAULT_SPIN_LOCK_FREQUENCY_RANGE = np.geomspace(0.01, 0.2, 16)
+DEFAULT_SPIN_LOCK_FREQUENCY_RANGE = np.geomspace(0.01, 0.15, 16)
 DEFAULT_DURATION_RANGE = np.geomspace(100, 200e3, 31)
 DEFAULT_DRIVE_PHASE = 0.0
+FINAL_PROJECTION_PHASE_CORRECTION_SIGN = -1.0
 CHEVRON_REFERENCE_RABI_FREQUENCY = 0.0125
 CHEVRON_REFERENCE_DETUNING_HALF_WIDTH = 0.05
 CHEVRON_MAX_DETUNING_HALF_WIDTH = 0.2
@@ -95,8 +96,10 @@ def spin_lock_sequence(
         Optional phase for the initial half-pi pulse in radians. Defaults to
         ``drive_phase - pi/2``.
     final_phase
-        Optional phase for the final half-pi pulse in radians. Defaults to
-        ``drive_phase + pi/2``.
+        Optional base phase for the final half-pi pulse in radians. Defaults to
+        ``drive_phase + pi/2``. When ``drive_detuning`` is nonzero, the final
+        projection phase is adjusted by ``-2 * pi * drive_detuning * duration``
+        so the projection tracks the detuned spin-lock drive frame.
 
     Returns
     -------
@@ -500,6 +503,73 @@ def _effective_frequency_map(
     }
 
 
+def _final_projection_phase(
+    *,
+    final_phase: float,
+    drive_detuning: float | None,
+    duration: float,
+) -> float:
+    if drive_detuning is None:
+        return final_phase
+
+    phase_correction = _final_projection_phase_correction(
+        drive_detuning=float(drive_detuning),
+        duration=float(duration),
+    )
+    if not np.isfinite(phase_correction):
+        raise ValueError("final projection phase correction must be finite.")
+    return final_phase + phase_correction
+
+
+def _final_projection_phase_correction(
+    *,
+    drive_detuning: float,
+    duration: float,
+) -> float:
+    return (
+        FINAL_PROJECTION_PHASE_CORRECTION_SIGN * 2.0 * np.pi * drive_detuning * duration
+    )
+
+
+def _final_projection_phase_correction_grid(
+    *,
+    frequency_offsets: np.ndarray,
+    durations: np.ndarray,
+) -> np.ndarray:
+    return (
+        FINAL_PROJECTION_PHASE_CORRECTION_SIGN
+        * 2.0
+        * np.pi
+        * np.asarray(frequency_offsets, dtype=np.float64)[:, None]
+        * np.asarray(durations, dtype=np.float64)[None, :]
+    )
+
+
+def _final_projection_phase_maps(
+    *,
+    targets: list[str],
+    frequency_offset_map: ArrayMap,
+    durations: np.ndarray,
+    final_phase: float,
+) -> tuple[ArrayMap, ArrayMap]:
+    phase_corrections: ArrayMap = {}
+    final_phases: ArrayMap = {}
+
+    for target in targets:
+        correction = _final_projection_phase_correction_grid(
+            frequency_offsets=frequency_offset_map[target],
+            durations=durations,
+        )
+        if not np.all(np.isfinite(correction)):
+            raise ValueError(
+                f"Final projection phase corrections for `{target}` must be finite."
+            )
+        phase_corrections[target] = correction
+        final_phases[target] = final_phase + correction
+
+    return phase_corrections, final_phases
+
+
 def _estimate_spin_lock_parameters_with_chevron(
     exp: Experiment,
     *,
@@ -635,6 +705,12 @@ def _add_spin_lock_pulse(
 
     if drive_detuning is not None:
         spin_lock_drive = spin_lock_drive.detuned(drive_detuning)
+
+    final_phase = _final_projection_phase(
+        final_phase=final_phase,
+        drive_detuning=drive_detuning,
+        duration=duration,
+    )
 
     schedule.add(target, half_pi.shifted(initial_phase))
     schedule.add(target, spin_lock_drive)
@@ -976,8 +1052,8 @@ def spin_lock_spectroscopy(
         are measured.
     spin_lock_frequency_range
         Spin-lock frequencies in GHz. These values are treated as desired Rabi
-        rates. If omitted, ``np.geomspace(0.01, 0.2, 16)`` is used, i.e.
-        10 MHz to 200 MHz.
+        rates. If omitted, ``np.geomspace(0.01, 0.15, 16)`` is used, i.e.
+        10 MHz to 150 MHz.
     duration_range
         Spin-lock drive durations in ns. Values must be positive because the
         heatmap and fit figures use a log time axis. The range is discretized to
@@ -1007,7 +1083,9 @@ def spin_lock_spectroscopy(
         ``drive_phase - pi/2`` is used.
     final_phase
         Final half-pi pulse phase in radians. When omitted,
-        ``drive_phase + pi/2`` is used.
+        ``drive_phase + pi/2`` is used. The actual final projection phase is
+        additionally corrected by the accumulated detuned-drive phase for each
+        spin-lock duration.
     n_shots
         Number of shots per sweep point. Defaults to ``DEFAULT_SHOTS``.
     shot_interval
@@ -1040,6 +1118,16 @@ def spin_lock_spectroscopy(
             ``drive_detuning``. When ``estimate_with_chevron=True``, these are
             AC-Stark-shifted qubit frequencies estimated by chevron plus
             ``drive_detuning``.
+        ``spin_lock_frequency_offsets``
+            Per-target detunings in GHz applied to the spin-lock pulse relative
+            to the calibrated qubit frequencies.
+        ``final_projection_phase_corrections``
+            Per-target phase corrections in radians applied to the final
+            half-pi pulse, with shape
+            ``(len(requested_spin_lock_rabi_frequency_range), len(duration_range))``.
+        ``final_projection_phases``
+            Per-target final half-pi pulse phases in radians after applying
+            ``final_projection_phase_corrections``.
         ``effective_spin_lock_frequency_range``
             Per-target effective lock-frequency axis in GHz including
             ``drive_detuning``.
@@ -1087,6 +1175,10 @@ def spin_lock_spectroscopy(
       Rabi rate of the locking drive. With ``estimate_with_chevron=True``, the
       figure x-axis uses the measured Rabi-rate axis from chevron; otherwise it
       uses this requested Rabi-rate axis.
+    - The initial and final half-pi pulses are left at the calibrated qubit
+      frequency. When the spin-lock drive is detuned from that frequency, the
+      final half-pi pulse phase is shifted by
+      ``-2 * pi * drive_detuning * duration`` to follow the detuned drive frame.
     - The implementation raises an error if any calculated drive amplitude has
       absolute value larger than 1.
     - If the active measurement constraint profile defines
@@ -1180,6 +1272,15 @@ def spin_lock_spectroscopy(
         target: drive_frequency_map[target] - base_frequencies[target]
         for target in target_list
     }
+    (
+        final_projection_phase_corrections,
+        final_projection_phases,
+    ) = _final_projection_phase_maps(
+        targets=target_list,
+        frequency_offset_map=frequency_offset_map,
+        durations=durations,
+        final_phase=final_phase,
+    )
     effective_measured_frequency_map = _effective_frequency_map(
         rabi_frequency_map=measured_rabi_frequency_map,
         drive_detuning=drive_detuning_value,
@@ -1253,6 +1354,8 @@ def spin_lock_spectroscopy(
             "spin_lock_qubit_frequencies": qubit_frequency_map,
             "spin_lock_drive_frequencies": drive_frequency_map,
             "spin_lock_frequency_offsets": frequency_offset_map,
+            "final_projection_phase_corrections": final_projection_phase_corrections,
+            "final_projection_phases": final_projection_phases,
             "duration_range": durations,
             "drive_amplitudes": amplitude_map,
             "estimate_with_chevron": estimate_with_chevron,

--- a/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
+++ b/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
@@ -23,9 +23,9 @@ from qubex.pulse import PulseSchedule, Rect
 
 __all__ = ["spin_lock_sequence", "spin_lock_spectroscopy"]
 
-DEFAULT_SPIN_LOCK_FREQUENCY_RANGE = 0.01 + 0.11 * np.tan(
-    np.pi / 3 * np.linspace(0, 1, 12)
-) / np.sqrt(3)
+DEFAULT_SPIN_LOCK_FREQUENCY_RANGE = (
+    0.12 * np.tan(np.pi / 3 * np.linspace(0, 1, 15)) / np.sqrt(3)
+)
 DEFAULT_DURATION_RANGE = np.geomspace(100, 200e3, 31)
 DEFAULT_DRIVE_PHASE = 0.0
 FINAL_PROJECTION_PHASE_CORRECTION_SIGN = -1.0
@@ -39,7 +39,8 @@ CHEVRON_OMEGA_RABI_POINTS = 128
 MIN_DECAY_FIT_POINTS = 3
 
 ArrayMap = dict[str, np.ndarray]
-ChevronMetadataMap = dict[str, list[dict[str, Any]]]
+ChevronMetadata = dict[str, Any]
+ChevronMetadataMap = dict[str, list[ChevronMetadata]]
 ChevronSource = Literal["measured", "provided", "none"]
 FigureMap = dict[str, go.Figure]
 
@@ -195,8 +196,8 @@ def _resolve_frequency_range(
         raise ValueError("spin_lock_frequency_range must be a non-empty 1D array.")
     if not np.all(np.isfinite(frequencies)):
         raise ValueError("spin_lock_frequency_range must contain finite values.")
-    if np.any(frequencies <= 0):
-        raise ValueError("spin_lock_frequency_range must contain positive values.")
+    if np.any(frequencies < 0):
+        raise ValueError("spin_lock_frequency_range must contain nonnegative values.")
     return frequencies
 
 
@@ -521,6 +522,49 @@ def _validate_matching_chevron_value(
         )
 
 
+def _is_zero_rabi_frequency(frequency: float) -> bool:
+    return bool(np.isclose(float(frequency), 0.0, rtol=0.0, atol=1e-15))
+
+
+def _is_valid_chevron_rabi_frequency(
+    *,
+    requested_rabi_frequency: float,
+    measured_rabi_frequency: float,
+) -> bool:
+    if not np.isfinite(measured_rabi_frequency):
+        return False
+    if measured_rabi_frequency > 0:
+        return True
+    return bool(
+        _is_zero_rabi_frequency(requested_rabi_frequency)
+        and np.isclose(
+            measured_rabi_frequency,
+            0.0,
+            rtol=0.0,
+            atol=1e-15,
+        )
+    )
+
+
+def _zero_rabi_chevron_metadata(
+    *,
+    requested_rabi_frequency: float,
+    drive_amplitude: float,
+    qubit_frequency: float,
+) -> ChevronMetadata:
+    return {
+        "requested_rabi_frequency": float(requested_rabi_frequency),
+        "drive_amplitude": float(drive_amplitude),
+        "qubit_frequency": float(qubit_frequency),
+        "rabi_frequency": 0.0,
+        "peak_background_rms_ratio": np.nan,
+        "detuning_range": np.array([], dtype=np.float64),
+        "time_range": np.array([], dtype=np.float64),
+        "omega_rabi_range": np.array([], dtype=np.float64),
+        "chevron_measured": False,
+    }
+
+
 def _resolve_spin_lock_parameters_from_chevron_results(
     *,
     targets: list[str],
@@ -581,7 +625,12 @@ def _resolve_spin_lock_parameters_from_chevron_results(
                 raise ValueError(
                     f"Chevron qubit frequency for `{target}` must be finite."
                 )
-            if not np.isfinite(rabi_frequency) or rabi_frequency <= 0:
+            if not _is_valid_chevron_rabi_frequency(
+                requested_rabi_frequency=float(
+                    requested_rabi_frequency_range[frequency_index]
+                ),
+                measured_rabi_frequency=rabi_frequency,
+            ):
                 raise ValueError(
                     f"Chevron Rabi frequency for `{target}` must be positive and finite."
                 )
@@ -590,6 +639,30 @@ def _resolve_spin_lock_parameters_from_chevron_results(
             measured_rabi_frequency_map[target][frequency_index] = rabi_frequency
 
     return qubit_frequency_map, measured_rabi_frequency_map, resolved_chevron_results
+
+
+def _record_zero_rabi_chevron_point(
+    *,
+    targets: list[str],
+    frequency_index: int,
+    requested_rabi_frequency: float,
+    amplitude_map: ArrayMap,
+    base_frequencies: dict[str, float],
+    measured_qubit_frequencies: ArrayMap,
+    measured_rabi_frequencies: ArrayMap,
+    chevron_results: ChevronMetadataMap,
+) -> None:
+    for target in targets:
+        base_frequency = float(base_frequencies[target])
+        measured_qubit_frequencies[target][frequency_index] = base_frequency
+        measured_rabi_frequencies[target][frequency_index] = 0.0
+        chevron_results[target].append(
+            _zero_rabi_chevron_metadata(
+                requested_rabi_frequency=requested_rabi_frequency,
+                drive_amplitude=float(amplitude_map[target][frequency_index]),
+                qubit_frequency=base_frequency,
+            )
+        )
 
 
 def _estimate_spin_lock_parameters_with_chevron(
@@ -625,6 +698,19 @@ def _estimate_spin_lock_parameters_with_chevron(
         unit="freq",
     )
     for frequency_index, expected_rabi_frequency in enumerate(progress):
+        if _is_zero_rabi_frequency(float(expected_rabi_frequency)):
+            _record_zero_rabi_chevron_point(
+                targets=targets,
+                frequency_index=frequency_index,
+                requested_rabi_frequency=float(expected_rabi_frequency),
+                amplitude_map=amplitude_map,
+                base_frequencies=base_frequencies,
+                measured_qubit_frequencies=measured_qubit_frequencies,
+                measured_rabi_frequencies=measured_rabi_frequencies,
+                chevron_results=chevron_results,
+            )
+            continue
+
         detuning_range, time_range, omega_rabi_range = _scaled_chevron_ranges(
             exp,
             expected_rabi_frequency=float(expected_rabi_frequency),
@@ -679,6 +765,7 @@ def _estimate_spin_lock_parameters_with_chevron(
                     "detuning_range": detuning_range,
                     "time_range": time_range,
                     "omega_rabi_range": omega_rabi_range,
+                    "chevron_measured": True,
                 }
             )
 
@@ -816,6 +903,16 @@ def _add_spin_lock_pulse(
     schedule.add(target, half_pi.shifted(final_phase))
 
 
+def _frequency_axis_range_mhz(frequency_range: np.ndarray) -> list[float]:
+    frequencies_mhz = np.asarray(frequency_range, dtype=np.float64) * 1e3
+    finite_frequencies_mhz = frequencies_mhz[np.isfinite(frequencies_mhz)]
+    if finite_frequencies_mhz.size == 0:
+        return [0.0, 1.0]
+
+    upper = float(np.max(finite_frequencies_mhz))
+    return [0.0, 1.05 * upper if upper > 0 else 1.0]
+
+
 def _make_spin_lock_heatmap_figure(
     *,
     target: str,
@@ -842,6 +939,7 @@ def _make_spin_lock_heatmap_figure(
         ),
         xaxis_title="Spin-lock Rabi frequency (MHz)",
         xaxis_type="linear",
+        xaxis_range=_frequency_axis_range_mhz(spin_lock_rabi_frequency_range),
         yaxis_title="Duration (ns)",
         yaxis_type="log",
         width=700,
@@ -893,6 +991,7 @@ def _make_spin_lock_relaxation_figure(
         ),
         xaxis_title="Spin-lock Rabi frequency (MHz)",
         xaxis_type="linear",
+        xaxis_range=_frequency_axis_range_mhz(spin_lock_rabi_frequency_range),
         yaxis_title="Relaxation time (μs)",
         yaxis_range=[0, yaxis_upper],
         width=700,
@@ -1232,8 +1331,8 @@ def spin_lock_spectroscopy(
     spin_lock_frequency_range
         Spin-lock frequencies in GHz. These values are treated as desired Rabi
         rates. If omitted,
-        ``0.01 + 0.11 * tan(pi / 3 * linspace(0, 1, 12)) / sqrt(3)`` is used,
-        i.e. 10 MHz to 120 MHz with denser points at low frequencies.
+        ``0.12 * tan(pi / 3 * linspace(0, 1, 15)) / sqrt(3)`` is used,
+        i.e. 0 MHz to 120 MHz with denser points at low frequencies.
     duration_range
         Spin-lock drive durations in ns. Values must be positive because the
         heatmap and fit figures use a log time axis. The range is discretized to
@@ -1252,7 +1351,9 @@ def spin_lock_spectroscopy(
         Rabi frequencies from chevron. The chevron detuning half-width is scaled
         from the expected Rabi rate and capped at 80% of the Nyquist frequency
         implied by ``exp.ctx.measurement.sampling_period``. Defaults to
-        ``True``. Ignored when ``chevron_results`` is supplied.
+        ``True``. The zero-frequency point, if present, is kept in the
+        spin-lock sweep but skipped in chevron pre-measurements. Ignored when
+        ``chevron_results`` is supplied.
     chevron_n_shots
         Number of shots for each pre-measurement chevron sweep point. Used only
         when chevrons are measured in this call and defaults to
@@ -1342,7 +1443,8 @@ def spin_lock_spectroscopy(
             Per-frequency fit metadata and fit parameters.
         ``chevron_results``
             Per-frequency chevron metadata. Empty unless chevron calibration is
-            measured or supplied through ``chevron_results``.
+            measured or supplied through ``chevron_results``. Entries for a
+            zero-frequency point have ``chevron_measured=False``.
         ``chevron_source``
             ``"measured"``, ``"provided"``, or ``"none"`` depending on how the
             chevron calibration values were obtained.
@@ -1373,6 +1475,9 @@ def spin_lock_spectroscopy(
       in this call or supplied through ``chevron_results``, the figure x-axis
       uses the measured Rabi-rate axis from chevron; otherwise it uses this
       requested Rabi-rate axis.
+    - A zero-frequency point is a free-precession reference without a spin-lock
+      drive. It is kept in the final sweep and plots, but chevron calibration is
+      skipped for that point.
     - The initial and final half-pi pulses are left at the calibrated qubit
       frequency. When the spin-lock drive is detuned from that frequency, the
       final half-pi pulse phase is shifted by

--- a/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
+++ b/src/qubex/contrib/experiment/spin_lock_spectroscopy.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Collection, Mapping
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
@@ -28,7 +28,6 @@ DEFAULT_SPIN_LOCK_FREQUENCY_RANGE = (
 )
 DEFAULT_DURATION_RANGE = np.geomspace(100, 200e3, 31)
 DEFAULT_DRIVE_PHASE = 0.0
-FINAL_PROJECTION_PHASE_CORRECTION_SIGN = -1.0
 CHEVRON_REFERENCE_RABI_FREQUENCY = 0.0125
 CHEVRON_REFERENCE_DETUNING_HALF_WIDTH = 0.05
 CHEVRON_NYQUIST_DETUNING_MARGIN = 0.8
@@ -37,11 +36,18 @@ CHEVRON_DETUNING_POINTS = 41
 CHEVRON_TIME_POINTS = 26
 CHEVRON_OMEGA_RABI_POINTS = 128
 MIN_DECAY_FIT_POINTS = 3
+REQUESTED_RABI_FREQUENCIES_KEY = "requested_rabi_frequencies"
+DRIVE_AMPLITUDES_KEY = "drive_amplitudes"
+RABI_FREQUENCIES_KEY = "rabi_frequencies"
+QUBIT_FREQUENCIES_KEY = "qubit_frequencies"
+AC_STARK_SHIFTS_KEY = "ac_stark_shifts"
+PEAK_BACKGROUND_RMS_RATIOS_KEY = "peak_background_rms_ratios"
+CHEVRON_MEASURED_KEY = "chevron_measured"
 
 ArrayMap = dict[str, np.ndarray]
-ChevronMetadata = dict[str, Any]
-ChevronMetadataMap = dict[str, list[ChevronMetadata]]
-ChevronSource = Literal["measured", "provided", "none"]
+SpinLockCalibrationEntry = dict[str, Any]
+SpinLockCalibrationDataset = dict[str, SpinLockCalibrationEntry]
+CalibrationSource = Literal["measured", "provided", "none"]
 FigureMap = dict[str, go.Figure]
 
 
@@ -54,17 +60,17 @@ class _TargetAnalysis:
     relaxation_time_errors: np.ndarray
     r2: np.ndarray
     fit_results: list[dict[str, Any]]
-    sort_indices: np.ndarray
     figures: FigureMap
 
 
 @dataclass(frozen=True)
 class _SpinLockCalibration:
+    drive_amplitude_map: ArrayMap
     qubit_frequency_map: ArrayMap
     rabi_frequency_map: ArrayMap
-    chevron_results: ChevronMetadataMap
+    calibration_dataset: SpinLockCalibrationDataset
     chevron_figures: FigureMap
-    chevron_source: ChevronSource
+    calibration_source: CalibrationSource
     chevron_n_shots: int | None
 
 
@@ -77,7 +83,6 @@ class _SpinLockAnalysis:
     relaxation_time_errors: ArrayMap
     r2: ArrayMap
     fit_results: dict[str, list[dict[str, Any]]]
-    rabi_sort_indices: ArrayMap
     figures: FigureMap
 
 
@@ -126,7 +131,7 @@ def spin_lock_sequence(
 
     Returns
     -------
-        PulseSchedule
+    PulseSchedule
         Pulse schedule containing the spin-lock sequence.
     """
     if not np.isfinite(duration) or duration <= 0:
@@ -437,9 +442,7 @@ def _final_projection_phase_correction(
     drive_detuning: float,
     duration: float,
 ) -> float:
-    return (
-        FINAL_PROJECTION_PHASE_CORRECTION_SIGN * 2.0 * np.pi * drive_detuning * duration
-    )
+    return -2.0 * np.pi * drive_detuning * duration
 
 
 def _final_projection_phase_correction_grid(
@@ -448,8 +451,7 @@ def _final_projection_phase_correction_grid(
     durations: np.ndarray,
 ) -> np.ndarray:
     return (
-        FINAL_PROJECTION_PHASE_CORRECTION_SIGN
-        * 2.0
+        -2.0
         * np.pi
         * np.asarray(frequency_offsets, dtype=np.float64)[:, None]
         * np.asarray(durations, dtype=np.float64)[None, :]
@@ -481,52 +483,107 @@ def _final_projection_phase_maps(
     return phase_corrections, final_phases
 
 
-def _chevron_value(
-    entry: dict[str, Any],
-    *,
-    primary_key: str,
-    fallback_key: str | None,
-    target: str,
-    frequency_index: int,
-) -> float:
-    value = entry.get(primary_key)
-    if value is None and fallback_key is not None:
-        value = entry.get(fallback_key)
-    if value is None:
-        raise ValueError(
-            f"chevron_results for `{target}` at index {frequency_index} "
-            f"must contain `{primary_key}`."
-        )
-    return float(value)
-
-
-def _validate_matching_chevron_value(
-    entry: dict[str, Any],
+def _calibration_array(
+    entry: Mapping[str, Any],
     *,
     key: str,
-    expected: float,
     target: str,
-    frequency_index: int,
-) -> None:
+) -> np.ndarray:
+    value = entry.get(key)
+    if value is None:
+        raise ValueError(f"spin_lock_calibration for `{target}` must contain `{key}`.")
+    return np.asarray(value, dtype=np.float64)
+
+
+def _optional_calibration_array(
+    entry: Mapping[str, Any],
+    *,
+    key: str,
+) -> np.ndarray | None:
     if key not in entry:
+        return None
+    return np.asarray(entry[key], dtype=np.float64)
+
+
+def _optional_calibration_bool_array(
+    entry: Mapping[str, Any],
+    *,
+    key: str,
+    target: str,
+    shape: tuple[int, ...],
+) -> np.ndarray | None:
+    if key not in entry:
+        return None
+
+    values = np.asarray(entry[key])
+    if values.dtype != np.bool_:
+        raise TypeError(f"spin_lock_calibration `{key}` for `{target}` must be bool.")
+
+    _validate_calibration_shape(values, key=key, target=target, shape=shape)
+    return values.astype(bool, copy=False)
+
+
+def _validate_calibration_shape(
+    values: np.ndarray,
+    *,
+    key: str,
+    target: str,
+    shape: tuple[int, ...],
+) -> None:
+    if values.shape != shape:
         raise ValueError(
-            f"chevron_results for `{target}` at index {frequency_index} "
-            f"must contain `{key}`."
+            f"spin_lock_calibration for `{target}` has `{key}` shape "
+            f"{values.shape}, but expected {shape}."
         )
 
-    value = float(entry[key])
-    if not np.isclose(value, expected, rtol=1e-6, atol=1e-12):
+
+def _validate_calibration_array(
+    values: np.ndarray,
+    *,
+    key: str,
+    target: str,
+    shape: tuple[int, ...],
+) -> None:
+    _validate_calibration_shape(values, key=key, target=target, shape=shape)
+    if not np.all(np.isfinite(values)):
         raise ValueError(
-            f"chevron_results for `{target}` at index {frequency_index} "
-            f"has {key}={value:.9g}, but expected {expected:.9g}."
+            f"spin_lock_calibration `{key}` for `{target}` must be finite."
         )
+
+
+def _frequency_axis_from_calibration(
+    *,
+    targets: list[str],
+    spin_lock_calibration: Mapping[str, Mapping[str, Any]],
+) -> np.ndarray:
+    first_target = targets[0]
+    entry = spin_lock_calibration.get(first_target)
+    if entry is None:
+        raise ValueError(f"spin_lock_calibration must contain `{first_target}`.")
+    if REQUESTED_RABI_FREQUENCIES_KEY in entry:
+        return _calibration_array(
+            entry,
+            key=REQUESTED_RABI_FREQUENCIES_KEY,
+            target=first_target,
+        )
+    return _calibration_array(entry, key=RABI_FREQUENCIES_KEY, target=first_target)
 
 
 def _is_zero_rabi_frequency(frequency: float) -> bool:
     return bool(np.isclose(float(frequency), 0.0, rtol=0.0, atol=1e-15))
 
 
-def _is_valid_chevron_rabi_frequency(
+def _chevron_frequency_indices(requested_rabi_frequency_range: np.ndarray) -> list[int]:
+    return [
+        frequency_index
+        for frequency_index, expected_rabi_frequency in enumerate(
+            requested_rabi_frequency_range
+        )
+        if not _is_zero_rabi_frequency(float(expected_rabi_frequency))
+    ]
+
+
+def _is_valid_calibrated_rabi_frequency(
     *,
     requested_rabi_frequency: float,
     measured_rabi_frequency: float,
@@ -546,123 +603,192 @@ def _is_valid_chevron_rabi_frequency(
     )
 
 
-def _zero_rabi_chevron_metadata(
-    *,
-    requested_rabi_frequency: float,
-    drive_amplitude: float,
-    qubit_frequency: float,
-) -> ChevronMetadata:
-    return {
-        "requested_rabi_frequency": float(requested_rabi_frequency),
-        "drive_amplitude": float(drive_amplitude),
-        "qubit_frequency": float(qubit_frequency),
-        "rabi_frequency": 0.0,
-        "peak_background_rms_ratio": np.nan,
-        "detuning_range": np.array([], dtype=np.float64),
-        "time_range": np.array([], dtype=np.float64),
-        "omega_rabi_range": np.array([], dtype=np.float64),
-        "chevron_measured": False,
-    }
-
-
-def _resolve_spin_lock_parameters_from_chevron_results(
+def _make_spin_lock_calibration_dataset(
     *,
     targets: list[str],
     requested_rabi_frequency_range: np.ndarray,
-    amplitude_map: ArrayMap,
-    chevron_results: ChevronMetadataMap,
-) -> tuple[ArrayMap, ArrayMap, ChevronMetadataMap]:
-    qubit_frequency_map = _nan_array_map(
-        targets=targets,
-        shape=requested_rabi_frequency_range.shape,
-    )
-    measured_rabi_frequency_map = _nan_array_map(
-        targets=targets,
-        shape=requested_rabi_frequency_range.shape,
-    )
-    resolved_chevron_results: ChevronMetadataMap = {}
+    drive_amplitude_map: ArrayMap,
+    qubit_frequency_map: ArrayMap,
+    rabi_frequency_map: ArrayMap,
+    base_frequencies: dict[str, float],
+    peak_background_rms_ratio_map: ArrayMap | None = None,
+    chevron_measured_map: dict[str, np.ndarray] | None = None,
+) -> SpinLockCalibrationDataset:
+    dataset: SpinLockCalibrationDataset = {}
+    for target in targets:
+        entry: SpinLockCalibrationEntry = {
+            REQUESTED_RABI_FREQUENCIES_KEY: requested_rabi_frequency_range.copy(),
+            DRIVE_AMPLITUDES_KEY: drive_amplitude_map[target].copy(),
+            RABI_FREQUENCIES_KEY: rabi_frequency_map[target].copy(),
+            QUBIT_FREQUENCIES_KEY: qubit_frequency_map[target].copy(),
+            AC_STARK_SHIFTS_KEY: qubit_frequency_map[target] - base_frequencies[target],
+        }
+        if peak_background_rms_ratio_map is not None:
+            entry[PEAK_BACKGROUND_RMS_RATIOS_KEY] = peak_background_rms_ratio_map[
+                target
+            ].copy()
+        if chevron_measured_map is not None:
+            entry[CHEVRON_MEASURED_KEY] = chevron_measured_map[target].copy()
+        dataset[target] = entry
+    return dataset
+
+
+def _resolve_spin_lock_parameters_from_calibration(
+    *,
+    targets: list[str],
+    requested_rabi_frequency_range: np.ndarray,
+    spin_lock_calibration: Mapping[str, Mapping[str, Any]],
+    base_frequencies: dict[str, float],
+) -> tuple[ArrayMap, ArrayMap, ArrayMap, SpinLockCalibrationDataset]:
+    shape = requested_rabi_frequency_range.shape
+    drive_amplitude_map: ArrayMap = {}
+    qubit_frequency_map: ArrayMap = {}
+    rabi_frequency_map: ArrayMap = {}
+    peak_background_rms_ratio_map: ArrayMap = {}
+    chevron_measured_map: dict[str, np.ndarray] = {}
 
     for target in targets:
-        target_results = list(chevron_results.get(target, []))
-        if len(target_results) != requested_rabi_frequency_range.size:
-            raise ValueError(
-                f"chevron_results for `{target}` must contain "
-                f"{requested_rabi_frequency_range.size} entries."
-            )
-        resolved_chevron_results[target] = target_results
+        entry = spin_lock_calibration.get(target)
+        if entry is None:
+            raise ValueError(f"spin_lock_calibration must contain `{target}`.")
 
-        for frequency_index, entry in enumerate(target_results):
-            _validate_matching_chevron_value(
-                entry,
-                key="requested_rabi_frequency",
-                expected=float(requested_rabi_frequency_range[frequency_index]),
+        requested = _optional_calibration_array(
+            entry,
+            key=REQUESTED_RABI_FREQUENCIES_KEY,
+        )
+        if requested is not None:
+            _validate_calibration_array(
+                requested,
+                key=REQUESTED_RABI_FREQUENCIES_KEY,
                 target=target,
-                frequency_index=frequency_index,
+                shape=shape,
             )
-            _validate_matching_chevron_value(
-                entry,
-                key="drive_amplitude",
-                expected=float(amplitude_map[target][frequency_index]),
-                target=target,
-                frequency_index=frequency_index,
-            )
-
-            qubit_frequency = _chevron_value(
-                entry,
-                primary_key="qubit_frequency",
-                fallback_key="omega_q",
-                target=target,
-                frequency_index=frequency_index,
-            )
-            rabi_frequency = _chevron_value(
-                entry,
-                primary_key="rabi_frequency",
-                fallback_key="omega_rabi",
-                target=target,
-                frequency_index=frequency_index,
-            )
-            if not np.isfinite(qubit_frequency):
+            if not np.allclose(
+                requested,
+                requested_rabi_frequency_range,
+                rtol=1e-6,
+                atol=1e-12,
+            ):
                 raise ValueError(
-                    f"Chevron qubit frequency for `{target}` must be finite."
+                    f"spin_lock_calibration for `{target}` does not match "
+                    "spin_lock_frequency_range."
                 )
-            if not _is_valid_chevron_rabi_frequency(
+
+        drive_amplitudes = _calibration_array(
+            entry,
+            key=DRIVE_AMPLITUDES_KEY,
+            target=target,
+        )
+        rabi_frequencies = _calibration_array(
+            entry,
+            key=RABI_FREQUENCIES_KEY,
+            target=target,
+        )
+        _validate_calibration_array(
+            drive_amplitudes,
+            key=DRIVE_AMPLITUDES_KEY,
+            target=target,
+            shape=shape,
+        )
+        _validate_calibration_array(
+            rabi_frequencies,
+            key=RABI_FREQUENCIES_KEY,
+            target=target,
+            shape=shape,
+        )
+
+        qubit_frequencies = _optional_calibration_array(
+            entry,
+            key=QUBIT_FREQUENCIES_KEY,
+        )
+        if qubit_frequencies is None:
+            ac_stark_shifts = _calibration_array(
+                entry,
+                key=AC_STARK_SHIFTS_KEY,
+                target=target,
+            )
+            _validate_calibration_array(
+                ac_stark_shifts,
+                key=AC_STARK_SHIFTS_KEY,
+                target=target,
+                shape=shape,
+            )
+            qubit_frequencies = ac_stark_shifts + base_frequencies[target]
+        else:
+            _validate_calibration_array(
+                qubit_frequencies,
+                key=QUBIT_FREQUENCIES_KEY,
+                target=target,
+                shape=shape,
+            )
+
+        if np.any(np.abs(drive_amplitudes) > 1):
+            raise ValueError(
+                f"spin_lock_calibration drive amplitudes for `{target}` "
+                "must not exceed 1."
+            )
+        peak_background_rms_ratios = _optional_calibration_array(
+            entry,
+            key=PEAK_BACKGROUND_RMS_RATIOS_KEY,
+        )
+        if peak_background_rms_ratios is not None:
+            _validate_calibration_shape(
+                peak_background_rms_ratios,
+                key=PEAK_BACKGROUND_RMS_RATIOS_KEY,
+                target=target,
+                shape=shape,
+            )
+            peak_background_rms_ratio_map[target] = peak_background_rms_ratios
+
+        chevron_measured = _optional_calibration_bool_array(
+            entry,
+            key=CHEVRON_MEASURED_KEY,
+            target=target,
+            shape=shape,
+        )
+        if chevron_measured is not None:
+            chevron_measured_map[target] = chevron_measured
+
+        for frequency_index, rabi_frequency in enumerate(rabi_frequencies):
+            if not _is_valid_calibrated_rabi_frequency(
                 requested_rabi_frequency=float(
                     requested_rabi_frequency_range[frequency_index]
                 ),
-                measured_rabi_frequency=rabi_frequency,
+                measured_rabi_frequency=float(rabi_frequency),
             ):
                 raise ValueError(
-                    f"Chevron Rabi frequency for `{target}` must be positive and finite."
+                    f"spin_lock_calibration Rabi frequencies for `{target}` "
+                    "must be positive and finite."
                 )
 
-            qubit_frequency_map[target][frequency_index] = qubit_frequency
-            measured_rabi_frequency_map[target][frequency_index] = rabi_frequency
+        drive_amplitude_map[target] = drive_amplitudes
+        qubit_frequency_map[target] = qubit_frequencies
+        rabi_frequency_map[target] = rabi_frequencies
 
-    return qubit_frequency_map, measured_rabi_frequency_map, resolved_chevron_results
-
-
-def _record_zero_rabi_chevron_point(
-    *,
-    targets: list[str],
-    frequency_index: int,
-    requested_rabi_frequency: float,
-    amplitude_map: ArrayMap,
-    base_frequencies: dict[str, float],
-    measured_qubit_frequencies: ArrayMap,
-    measured_rabi_frequencies: ArrayMap,
-    chevron_results: ChevronMetadataMap,
-) -> None:
-    for target in targets:
-        base_frequency = float(base_frequencies[target])
-        measured_qubit_frequencies[target][frequency_index] = base_frequency
-        measured_rabi_frequencies[target][frequency_index] = 0.0
-        chevron_results[target].append(
-            _zero_rabi_chevron_metadata(
-                requested_rabi_frequency=requested_rabi_frequency,
-                drive_amplitude=float(amplitude_map[target][frequency_index]),
-                qubit_frequency=base_frequency,
-            )
-        )
+    optional_peak_background_rms_ratio_map = (
+        peak_background_rms_ratio_map
+        if len(peak_background_rms_ratio_map) == len(targets)
+        else None
+    )
+    optional_chevron_measured_map = (
+        chevron_measured_map if len(chevron_measured_map) == len(targets) else None
+    )
+    calibration_dataset = _make_spin_lock_calibration_dataset(
+        targets=targets,
+        requested_rabi_frequency_range=requested_rabi_frequency_range,
+        drive_amplitude_map=drive_amplitude_map,
+        qubit_frequency_map=qubit_frequency_map,
+        rabi_frequency_map=rabi_frequency_map,
+        base_frequencies=base_frequencies,
+        peak_background_rms_ratio_map=optional_peak_background_rms_ratio_map,
+        chevron_measured_map=optional_chevron_measured_map,
+    )
+    return (
+        drive_amplitude_map,
+        qubit_frequency_map,
+        rabi_frequency_map,
+        calibration_dataset,
+    )
 
 
 def _estimate_spin_lock_parameters_with_chevron(
@@ -678,7 +804,7 @@ def _estimate_spin_lock_parameters_with_chevron(
 ) -> tuple[
     ArrayMap,
     ArrayMap,
-    ChevronMetadataMap,
+    SpinLockCalibrationDataset,
     FigureMap,
 ]:
     measured_qubit_frequencies = _nan_array_map(
@@ -689,28 +815,38 @@ def _estimate_spin_lock_parameters_with_chevron(
         targets=targets,
         shape=requested_rabi_frequency_range.shape,
     )
-    chevron_results: ChevronMetadataMap = {target: [] for target in targets}
+    peak_background_rms_ratios = _nan_array_map(
+        targets=targets,
+        shape=requested_rabi_frequency_range.shape,
+    )
+    chevron_measured = {
+        target: np.full(requested_rabi_frequency_range.shape, False, dtype=bool)
+        for target in targets
+    }
     chevron_figures: FigureMap = {}
 
+    chevron_frequency_indices = _chevron_frequency_indices(
+        requested_rabi_frequency_range
+    )
+    for frequency_index, expected_rabi_frequency in enumerate(
+        requested_rabi_frequency_range
+    ):
+        if not _is_zero_rabi_frequency(float(expected_rabi_frequency)):
+            continue
+
+        for target in targets:
+            measured_qubit_frequencies[target][frequency_index] = float(
+                base_frequencies[target]
+            )
+            measured_rabi_frequencies[target][frequency_index] = 0.0
+
     progress = tqdm(
-        requested_rabi_frequency_range,
+        chevron_frequency_indices,
         desc="Chevron pre-measurements",
         unit="freq",
     )
-    for frequency_index, expected_rabi_frequency in enumerate(progress):
-        if _is_zero_rabi_frequency(float(expected_rabi_frequency)):
-            _record_zero_rabi_chevron_point(
-                targets=targets,
-                frequency_index=frequency_index,
-                requested_rabi_frequency=float(expected_rabi_frequency),
-                amplitude_map=amplitude_map,
-                base_frequencies=base_frequencies,
-                measured_qubit_frequencies=measured_qubit_frequencies,
-                measured_rabi_frequencies=measured_rabi_frequencies,
-                chevron_results=chevron_results,
-            )
-            continue
-
+    for frequency_index in progress:
+        expected_rabi_frequency = requested_rabi_frequency_range[frequency_index]
         detuning_range, time_range, omega_rabi_range = _scaled_chevron_ranges(
             exp,
             expected_rabi_frequency=float(expected_rabi_frequency),
@@ -753,21 +889,10 @@ def _estimate_spin_lock_parameters_with_chevron(
                 raise ValueError(
                     f"Chevron Rabi frequency for `{target}` must be positive and finite."
                 )
-            chevron_results[target].append(
-                {
-                    "requested_rabi_frequency": float(expected_rabi_frequency),
-                    "drive_amplitude": float(amplitude_map[target][frequency_index]),
-                    "qubit_frequency": float(result["omega_q"]),
-                    "rabi_frequency": float(result["omega_rabi"]),
-                    "peak_background_rms_ratio": float(
-                        result["peak_background_rms_ratio"]
-                    ),
-                    "detuning_range": detuning_range,
-                    "time_range": time_range,
-                    "omega_rabi_range": omega_rabi_range,
-                    "chevron_measured": True,
-                }
+            peak_background_rms_ratios[target][frequency_index] = float(
+                result["peak_background_rms_ratio"]
             )
+            chevron_measured[target][frequency_index] = True
 
         if return_chevron_figures and chevron_result.figures is not None:
             for name, figure in chevron_result.figures.items():
@@ -780,8 +905,60 @@ def _estimate_spin_lock_parameters_with_chevron(
     return (
         measured_qubit_frequencies,
         measured_rabi_frequencies,
-        chevron_results,
+        _make_spin_lock_calibration_dataset(
+            targets=targets,
+            requested_rabi_frequency_range=requested_rabi_frequency_range,
+            drive_amplitude_map=amplitude_map,
+            qubit_frequency_map=measured_qubit_frequencies,
+            rabi_frequency_map=measured_rabi_frequencies,
+            base_frequencies=base_frequencies,
+            peak_background_rms_ratio_map=peak_background_rms_ratios,
+            chevron_measured_map=chevron_measured,
+        ),
         chevron_figures,
+    )
+
+
+def _make_nominal_spin_lock_calibration(
+    *,
+    targets: list[str],
+    requested_rabi_frequency_range: np.ndarray,
+    amplitude_map: ArrayMap,
+    base_frequencies: dict[str, float],
+    include_chevron_measured: bool,
+) -> _SpinLockCalibration:
+    qubit_frequency_map = _constant_frequency_map(
+        targets=targets,
+        values=base_frequencies,
+        shape=requested_rabi_frequency_range.shape,
+    )
+    rabi_frequency_map = {
+        target: requested_rabi_frequency_range.copy() for target in targets
+    }
+    chevron_measured_map = (
+        {
+            target: np.full(requested_rabi_frequency_range.shape, False, dtype=bool)
+            for target in targets
+        }
+        if include_chevron_measured
+        else None
+    )
+    return _SpinLockCalibration(
+        drive_amplitude_map=amplitude_map,
+        qubit_frequency_map=qubit_frequency_map,
+        rabi_frequency_map=rabi_frequency_map,
+        calibration_dataset=_make_spin_lock_calibration_dataset(
+            targets=targets,
+            requested_rabi_frequency_range=requested_rabi_frequency_range,
+            drive_amplitude_map=amplitude_map,
+            qubit_frequency_map=qubit_frequency_map,
+            rabi_frequency_map=rabi_frequency_map,
+            base_frequencies=base_frequencies,
+            chevron_measured_map=chevron_measured_map,
+        ),
+        chevron_figures={},
+        calibration_source="none",
+        chevron_n_shots=None,
     )
 
 
@@ -790,36 +967,55 @@ def _resolve_spin_lock_calibration(
     *,
     targets: list[str],
     requested_rabi_frequency_range: np.ndarray,
-    amplitude_map: ArrayMap,
     base_frequencies: dict[str, float],
+    spin_lock_calibration: Mapping[str, Mapping[str, Any]] | None,
     estimate_with_chevron: bool,
-    chevron_results: ChevronMetadataMap | None,
     chevron_n_shots: int | None,
     n_shots: int,
     shot_interval: float,
     return_chevron_figures: bool,
 ) -> _SpinLockCalibration:
-    if chevron_results is not None:
+    if spin_lock_calibration is not None:
         (
+            drive_amplitude_map,
             qubit_frequency_map,
             rabi_frequency_map,
-            resolved_chevron_results,
-        ) = _resolve_spin_lock_parameters_from_chevron_results(
+            calibration_dataset,
+        ) = _resolve_spin_lock_parameters_from_calibration(
             targets=targets,
             requested_rabi_frequency_range=requested_rabi_frequency_range,
-            amplitude_map=amplitude_map,
-            chevron_results=chevron_results,
+            spin_lock_calibration=spin_lock_calibration,
+            base_frequencies=base_frequencies,
         )
         return _SpinLockCalibration(
+            drive_amplitude_map=drive_amplitude_map,
             qubit_frequency_map=qubit_frequency_map,
             rabi_frequency_map=rabi_frequency_map,
-            chevron_results=resolved_chevron_results,
+            calibration_dataset=calibration_dataset,
             chevron_figures={},
-            chevron_source="provided",
+            calibration_source="provided",
             chevron_n_shots=None,
         )
 
+    amplitude_map = _resolve_spin_lock_amplitudes(
+        exp,
+        targets=targets,
+        spin_lock_frequency_range=requested_rabi_frequency_range,
+    )
+
     if estimate_with_chevron:
+        chevron_frequency_indices = _chevron_frequency_indices(
+            requested_rabi_frequency_range
+        )
+        if len(chevron_frequency_indices) == 0:
+            return _make_nominal_spin_lock_calibration(
+                targets=targets,
+                requested_rabi_frequency_range=requested_rabi_frequency_range,
+                amplitude_map=amplitude_map,
+                base_frequencies=base_frequencies,
+                include_chevron_measured=True,
+            )
+
         chevron_n_shots_value = _resolve_positive_integer(
             chevron_n_shots,
             name="chevron_n_shots",
@@ -828,7 +1024,7 @@ def _resolve_spin_lock_calibration(
         (
             qubit_frequency_map,
             rabi_frequency_map,
-            measured_chevron_results,
+            measured_calibration_dataset,
             chevron_figures,
         ) = _estimate_spin_lock_parameters_with_chevron(
             exp,
@@ -841,27 +1037,21 @@ def _resolve_spin_lock_calibration(
             return_chevron_figures=return_chevron_figures,
         )
         return _SpinLockCalibration(
+            drive_amplitude_map=amplitude_map,
             qubit_frequency_map=qubit_frequency_map,
             rabi_frequency_map=rabi_frequency_map,
-            chevron_results=measured_chevron_results,
+            calibration_dataset=measured_calibration_dataset,
             chevron_figures=chevron_figures,
-            chevron_source="measured",
+            calibration_source="measured",
             chevron_n_shots=chevron_n_shots_value,
         )
 
-    return _SpinLockCalibration(
-        qubit_frequency_map=_constant_frequency_map(
-            targets=targets,
-            values=base_frequencies,
-            shape=requested_rabi_frequency_range.shape,
-        ),
-        rabi_frequency_map={
-            target: requested_rabi_frequency_range.copy() for target in targets
-        },
-        chevron_results={target: [] for target in targets},
-        chevron_figures={},
-        chevron_source="none",
-        chevron_n_shots=None,
+    return _make_nominal_spin_lock_calibration(
+        targets=targets,
+        requested_rabi_frequency_range=requested_rabi_frequency_range,
+        amplitude_map=amplitude_map,
+        base_frequencies=base_frequencies,
+        include_chevron_measured=False,
     )
 
 
@@ -1008,7 +1198,7 @@ def _frequency_sort_indices(frequency_range: np.ndarray) -> np.ndarray:
 
 def _make_fit_summary(
     *,
-    frequency: float,
+    rabi_frequency: float,
     frequency_index: int,
     requested_rabi_frequency_range: np.ndarray,
     effective_frequency_range: np.ndarray,
@@ -1020,8 +1210,7 @@ def _make_fit_summary(
 ) -> dict[str, Any]:
     status_value = status.value if isinstance(status, FitStatus) else status
     return {
-        "frequency": float(frequency),
-        "rabi_frequency": float(frequency),
+        "rabi_frequency": float(rabi_frequency),
         "effective_frequency": float(effective_frequency_range[frequency_index]),
         "requested_rabi_frequency": float(
             requested_rabi_frequency_range[frequency_index]
@@ -1094,7 +1283,7 @@ def _analyze_spin_lock_target(
         except Exception as exc:
             fit_results.append(
                 _make_fit_summary(
-                    frequency=float(frequency),
+                    rabi_frequency=float(frequency),
                     frequency_index=frequency_index,
                     requested_rabi_frequency_range=requested_rabi_frequency_range,
                     effective_frequency_range=effective_frequency_range,
@@ -1114,7 +1303,7 @@ def _analyze_spin_lock_target(
 
         fit_results.append(
             _make_fit_summary(
-                frequency=float(frequency),
+                rabi_frequency=float(frequency),
                 frequency_index=frequency_index,
                 requested_rabi_frequency_range=requested_rabi_frequency_range,
                 effective_frequency_range=effective_frequency_range,
@@ -1152,7 +1341,6 @@ def _analyze_spin_lock_target(
         relaxation_time_errors=relaxation_time_errors,
         r2=r2_values,
         fit_results=fit_results,
-        sort_indices=sort_indices,
         figures=figures,
     )
 
@@ -1176,7 +1364,6 @@ def _analyze_spin_lock_targets(
     relaxation_time_errors: ArrayMap = {}
     r2_values: ArrayMap = {}
     fit_results: dict[str, list[dict[str, Any]]] = {}
-    rabi_sort_indices: ArrayMap = {}
     figures: FigureMap = dict(initial_figures)
 
     for target in targets:
@@ -1198,7 +1385,6 @@ def _analyze_spin_lock_targets(
         relaxation_time_errors[target] = analysis.relaxation_time_errors
         r2_values[target] = analysis.r2
         fit_results[target] = analysis.fit_results
-        rabi_sort_indices[target] = analysis.sort_indices
         figures.update(analysis.figures)
 
     return _SpinLockAnalysis(
@@ -1209,7 +1395,6 @@ def _analyze_spin_lock_targets(
         relaxation_time_errors=relaxation_time_errors,
         r2=r2_values,
         fit_results=fit_results,
-        rabi_sort_indices=rabi_sort_indices,
         figures=figures,
     )
 
@@ -1248,7 +1433,6 @@ def _measure_spin_lock_grid(
     final_phase: float | None,
     n_shots: int,
     shot_interval: float,
-    enable_tqdm: bool,
 ) -> Any:
     sweep_points = [
         (frequency_index, duration_index)
@@ -1273,6 +1457,7 @@ def _measure_spin_lock_grid(
                 )
         return schedule
 
+    print(f"Starting spin-lock spectroscopy measurement ({len(sweep_points)} points).")
     with exp.ctx.util.no_output():
         return exp.measurement_service.sweep_parameter(
             sequence=sequence,
@@ -1280,11 +1465,60 @@ def _measure_spin_lock_grid(
             n_shots=n_shots,
             shot_interval=shot_interval,
             plot=False,
-            enable_tqdm=enable_tqdm,
             title="Spin-lock spectroscopy",
             xlabel="Sweep point",
             ylabel="Measured value",
         )
+
+
+def _make_spin_lock_result_data(
+    *,
+    targets: list[str],
+    calibration: _SpinLockCalibration,
+    requested_rabi_frequency_range: np.ndarray,
+    effective_frequency_map: ArrayMap,
+    durations: np.ndarray,
+    drive_detuning: float,
+    drive_frequency_map: ArrayMap,
+    frequency_offset_map: ArrayMap,
+    final_projection_phase_corrections: ArrayMap,
+    final_projection_phases: ArrayMap,
+    analysis: _SpinLockAnalysis,
+) -> dict[str, Any]:
+    return {
+        "targets": targets,
+        "calibration_source": calibration.calibration_source,
+        "spin_lock_calibration": calibration.calibration_dataset,
+        "axes": {
+            "requested_rabi_frequencies": requested_rabi_frequency_range,
+            "measured_rabi_frequencies": calibration.rabi_frequency_map,
+            "effective_spin_lock_frequencies": effective_frequency_map,
+            "duration_range": durations,
+        },
+        "drive": {
+            "drive_detuning": drive_detuning,
+            "drive_frequencies": drive_frequency_map,
+            "frequency_offsets": frequency_offset_map,
+        },
+        "phase": {
+            "final_projection_phase_corrections": final_projection_phase_corrections,
+            "final_projection_phases": final_projection_phases,
+        },
+        "measurement": {
+            "raw_data": analysis.raw_data,
+            "normalized_signal": analysis.normalized_signal,
+            "population": analysis.population,
+        },
+        "fit": {
+            "relaxation_times": analysis.relaxation_times,
+            "relaxation_time_errors": analysis.relaxation_time_errors,
+            "r2": analysis.r2,
+            "fit_results": analysis.fit_results,
+        },
+        "metadata": {
+            "chevron_n_shots": calibration.chevron_n_shots,
+        },
+    }
 
 
 def spin_lock_spectroscopy(
@@ -1293,7 +1527,7 @@ def spin_lock_spectroscopy(
     *,
     spin_lock_frequency_range: ArrayLike | None = None,
     duration_range: ArrayLike | None = None,
-    chevron_results: ChevronMetadataMap | None = None,
+    spin_lock_calibration: Mapping[str, Mapping[str, Any]] | None = None,
     estimate_with_chevron: bool | None = None,
     chevron_n_shots: int | None = None,
     return_chevron_figures: bool | None = None,
@@ -1305,7 +1539,6 @@ def spin_lock_spectroscopy(
     shot_interval: float | None = None,
     plot: bool | None = None,
     save_image: bool | None = None,
-    enable_tqdm: bool | None = None,
 ) -> Result:
     """
     Run a simple spin-lock spectroscopy measurement.
@@ -1313,7 +1546,8 @@ def spin_lock_spectroscopy(
     This experiment prepares each qubit along the spin-lock drive axis, applies
     a continuous drive for each requested duration, and projects the state back
     for readout. The requested spin-lock frequencies are interpreted as Rabi
-    rates in GHz and are converted to hardware amplitudes with
+    rates in GHz. Without ``spin_lock_calibration``, they are converted to
+    hardware amplitudes with
     ``exp.pulse.calc_control_amplitude(target, rabi_rate)``. When
     ``drive_detuning`` is nonzero, the effective lock frequency is also stored
     as ``sqrt(rabi_rate**2 + drive_detuning**2)``.
@@ -1330,19 +1564,27 @@ def spin_lock_spectroscopy(
         are measured.
     spin_lock_frequency_range
         Spin-lock frequencies in GHz. These values are treated as desired Rabi
-        rates. If omitted,
+        rates. If omitted and ``spin_lock_calibration`` is not supplied,
         ``0.12 * tan(pi / 3 * linspace(0, 1, 15)) / sqrt(3)`` is used,
-        i.e. 0 MHz to 120 MHz with denser points at low frequencies.
+        i.e. 0 MHz to 120 MHz with denser points at low frequencies. If omitted
+        and ``spin_lock_calibration`` is supplied, the sweep axis is read from
+        the calibration dataset.
     duration_range
         Spin-lock drive durations in ns. Values must be positive because the
         heatmap and fit figures use a log time axis. The range is discretized to
         ``exp.ctx.measurement.sampling_period``. If omitted,
         ``np.geomspace(100, 200e3, 31)`` is used.
-    chevron_results
-        Previously returned ``Result.data["chevron_results"]``. When supplied,
-        these values are reused and chevron pre-measurements are skipped. The
-        entries must match the requested spin-lock frequency range and
-        calculated drive amplitudes for the current targets.
+    spin_lock_calibration
+        Previously returned ``Result.data["spin_lock_calibration"]`` or a
+        manually prepared calibration dataset. When supplied, these values are
+        reused and chevron pre-measurements are skipped. Each target entry must
+        contain ``drive_amplitudes`` and ``rabi_frequencies``, plus either
+        ``qubit_frequencies`` or ``ac_stark_shifts``. If
+        ``spin_lock_frequency_range`` is omitted, ``requested_rabi_frequencies``
+        is used as the sweep axis when present; otherwise ``rabi_frequencies``
+        from the first target is used. All per-target arrays must have the same
+        shape and order as the resolved spin-lock frequency sweep. Optional
+        ``chevron_measured`` entries must be bool arrays.
     estimate_with_chevron
         Whether to run ``estimate_qubit_frequency_from_chevron()`` before the
         spin-lock sweep for each requested spin-lock frequency. When ``True``,
@@ -1353,7 +1595,9 @@ def spin_lock_spectroscopy(
         implied by ``exp.ctx.measurement.sampling_period``. Defaults to
         ``True``. The zero-frequency point, if present, is kept in the
         spin-lock sweep but skipped in chevron pre-measurements. Ignored when
-        ``chevron_results`` is supplied.
+        ``spin_lock_calibration`` is supplied. If all requested frequencies are
+        zero, no chevron measurement is run and ``calibration_source`` remains
+        ``"none"``.
     chevron_n_shots
         Number of shots for each pre-measurement chevron sweep point. Used only
         when chevrons are measured in this call and defaults to
@@ -1382,87 +1626,32 @@ def spin_lock_spectroscopy(
         Whether to display the heatmap and relaxation-time figures.
     save_image
         Whether to save the heatmap and relaxation-time figures.
-    enable_tqdm
-        Whether to show progress bars inside ``sweep_parameter()``. Defaults to
-        ``False`` to match the measurement service default. Chevron
-        pre-measurement progress is shown separately whenever chevrons are
-        measured.
 
     Returns
     -------
     Result
-        Generic result containing measured arrays, fit summaries, and figures.
-        Important payload keys are:
-
-        ``requested_spin_lock_rabi_frequency_range``
-            Requested spin-lock Rabi-frequency axis in GHz.
-        ``measured_spin_lock_rabi_frequency_range``
-            Per-target Rabi-frequency axis in GHz used for plotting and fit
-            metadata. This matches the requested axis unless chevron
-            calibration is measured or supplied.
-        ``spin_lock_qubit_frequencies``
-            Per-target qubit frequencies in GHz used as the spin-lock frequency
-            reference before adding ``drive_detuning``.
-        ``spin_lock_drive_frequencies``
-            Per-target microwave drive frequencies in GHz including
-            ``drive_detuning``. With chevron calibration, these are
-            AC-Stark-shifted qubit frequencies plus ``drive_detuning``.
-        ``spin_lock_frequency_offsets``
-            Per-target detunings in GHz applied to the spin-lock pulse relative
-            to the calibrated qubit frequencies.
-        ``final_projection_phase_corrections``
-            Per-target phase corrections in radians applied to the final
-            half-pi pulse, with shape
-            ``(len(requested_spin_lock_rabi_frequency_range), len(duration_range))``.
-        ``final_projection_phases``
-            Per-target final half-pi pulse phases in radians after applying
-            ``final_projection_phase_corrections``.
-        ``effective_spin_lock_frequency_range``
-            Per-target effective lock-frequency axis in GHz including
-            ``drive_detuning``.
-        ``duration_range``
-            Discretized duration axis in ns.
-        ``drive_amplitudes``
-            Per-target drive amplitudes calculated from the requested spin-lock
-            frequencies.
-        ``raw_data``
-            Per-target raw IQ data with shape
-            ``(len(requested_spin_lock_rabi_frequency_range), len(duration_range))``.
-        ``population``
-            Per-target heatmap data with shape
-            ``(len(duration_range), len(requested_spin_lock_rabi_frequency_range))``.
-        ``normalized_signal``
-            Per-target normalized signal before converting to population.
-        ``relaxation_times``
-            Per-target fitted spin-lock relaxation times in ns.
-        ``relaxation_time_errors``
-            Per-target one-sigma fit errors for the relaxation times in ns.
-        ``r2``
-            Per-target fit R² values.
-        ``fit_results``
-            Per-frequency fit metadata and fit parameters.
-        ``chevron_results``
-            Per-frequency chevron metadata. Empty unless chevron calibration is
-            measured or supplied through ``chevron_results``. Entries for a
-            zero-frequency point have ``chevron_measured=False``.
-        ``chevron_source``
-            ``"measured"``, ``"provided"``, or ``"none"`` depending on how the
-            chevron calibration values were obtained.
-        ``use_chevron_calibration``
-            Whether chevron-derived qubit and Rabi frequencies were used for the
-            spin-lock sweep.
-        ``estimate_with_chevron``
-            Whether chevrons were measured in this call. ``False`` when
-            ``chevron_results`` was supplied and reused.
-        ``return_chevron_figures``
-            Whether intermediate chevron figures were included in
-            ``Result.figures``.
-        ``chevron_n_shots``
-            Number of shots used for each chevron sweep point, or ``None`` when
-            chevrons were not measured in this call.
-        ``spin_lock_rabi_sort_indices``
-            Per-target indices used to sort measured Rabi frequencies for
-            plotting. Measured arrays in the payload keep the acquisition order.
+        ``spin_lock_calibration``
+            Per-target calibration dataset containing ``drive_amplitudes``,
+            ``rabi_frequencies``, ``qubit_frequencies``, and
+            ``ac_stark_shifts`` in the same order as the sweep axis. This value
+            can be supplied to a later ``spin_lock_spectroscopy()`` call.
+        ``calibration_source``
+            ``"measured"``, ``"provided"``, or ``"none"``.
+        ``axes``
+            Requested, measured, and effective Rabi-frequency axes in GHz, plus
+            the discretized duration axis in ns.
+        ``drive``
+            Per-target spin-lock drive frequencies, offsets, and the common
+            ``drive_detuning`` in GHz.
+        ``phase``
+            Final projection phases and duration-dependent corrections.
+        ``measurement``
+            Raw IQ data, normalized signal, and population heatmap data.
+        ``fit``
+            Relaxation times, fit errors, R² values, and per-frequency fit
+            summaries.
+        ``metadata``
+            Additional measurement metadata such as ``chevron_n_shots``.
 
         The ``figures`` mapping contains ``"{target}_heatmap"`` and
         ``"{target}_relaxation"`` for each target, plus per-frequency fit figures
@@ -1471,10 +1660,10 @@ def spin_lock_spectroscopy(
     Notes
     -----
     - ``spin_lock_frequency_range`` is not a detuning sweep; it is the target
-      Rabi rate of the locking drive. With chevron calibration, either measured
-      in this call or supplied through ``chevron_results``, the figure x-axis
-      uses the measured Rabi-rate axis from chevron; otherwise it uses this
-      requested Rabi-rate axis.
+      Rabi rate of the locking drive. With spin-lock calibration, either
+      measured by chevron in this call or supplied through
+      ``spin_lock_calibration``, the figure x-axis uses the calibrated Rabi-rate
+      axis; otherwise it uses this requested Rabi-rate axis.
     - A zero-frequency point is a free-precession reference without a spin-lock
       drive. It is kept in the final sweep and plots, but chevron calibration is
       skipped for that point.
@@ -1483,8 +1672,8 @@ def spin_lock_spectroscopy(
       final half-pi pulse phase is shifted by
       ``-2 * pi * spin_lock_frequency_offset * duration`` to follow the
       spin-lock drive frame, including AC-Stark-shifted frequency offsets when
-      chevron calibration is used.
-    - The implementation raises an error if any calculated drive amplitude has
+      spin-lock calibration is used.
+    - The implementation raises an error if any drive amplitude has
       absolute value larger than 1.
     - Chevron detuning ranges are capped to stay within 80% of the Nyquist
       frequency implied by the measurement sampling period.
@@ -1511,12 +1700,17 @@ def spin_lock_spectroscopy(
     )
     plot = _resolve_bool(plot, default=True)
     save_image = _resolve_bool(save_image, default=False)
-    enable_tqdm = _resolve_bool(enable_tqdm, default=False)
     estimate_with_chevron = _resolve_bool(estimate_with_chevron, default=True)
     return_chevron_figures = _resolve_bool(return_chevron_figures, default=False)
 
-    exp.pulse.validate_rabi_params(target_list)
+    if spin_lock_calibration is None:
+        exp.pulse.validate_rabi_params(target_list)
 
+    if spin_lock_frequency_range is None and spin_lock_calibration is not None:
+        spin_lock_frequency_range = _frequency_axis_from_calibration(
+            targets=target_list,
+            spin_lock_calibration=spin_lock_calibration,
+        )
     requested_rabi_frequency_range = _resolve_frequency_range(spin_lock_frequency_range)
     drive_detuning_value = _resolve_drive_detuning(drive_detuning)
     drive_phase, initial_phase, final_phase = _resolve_phases(
@@ -1525,20 +1719,14 @@ def spin_lock_spectroscopy(
         final_phase=final_phase,
     )
     durations = _resolve_duration_range(exp, duration_range)
-    amplitude_map = _resolve_spin_lock_amplitudes(
-        exp,
-        targets=target_list,
-        spin_lock_frequency_range=requested_rabi_frequency_range,
-    )
     base_frequencies = _target_base_frequencies(exp, target_list)
     calibration = _resolve_spin_lock_calibration(
         exp,
         targets=target_list,
         requested_rabi_frequency_range=requested_rabi_frequency_range,
-        amplitude_map=amplitude_map,
         base_frequencies=base_frequencies,
+        spin_lock_calibration=spin_lock_calibration,
         estimate_with_chevron=estimate_with_chevron,
-        chevron_results=chevron_results,
         chevron_n_shots=chevron_n_shots,
         n_shots=n_shots,
         shot_interval=shot_interval,
@@ -1572,14 +1760,13 @@ def spin_lock_spectroscopy(
         targets=target_list,
         durations=durations,
         requested_rabi_frequency_range=requested_rabi_frequency_range,
-        amplitude_map=amplitude_map,
+        amplitude_map=calibration.drive_amplitude_map,
         frequency_offset_map=frequency_offset_map,
         drive_phase=drive_phase,
         initial_phase=initial_phase,
         final_phase=final_phase,
         n_shots=n_shots,
         shot_interval=shot_interval,
-        enable_tqdm=enable_tqdm,
     )
 
     analysis = _analyze_spin_lock_targets(
@@ -1601,34 +1788,21 @@ def spin_lock_spectroscopy(
     )
 
     primary_figure = analysis.figures.get(f"{target_list[0]}_relaxation")
+    result_data = _make_spin_lock_result_data(
+        targets=target_list,
+        calibration=calibration,
+        requested_rabi_frequency_range=requested_rabi_frequency_range,
+        effective_frequency_map=effective_measured_frequency_map,
+        durations=durations,
+        drive_detuning=drive_detuning_value,
+        drive_frequency_map=drive_frequency_map,
+        frequency_offset_map=frequency_offset_map,
+        final_projection_phase_corrections=final_projection_phase_corrections,
+        final_projection_phases=final_projection_phases,
+        analysis=analysis,
+    )
     return Result(
-        data={
-            "targets": target_list,
-            "requested_spin_lock_rabi_frequency_range": requested_rabi_frequency_range,
-            "measured_spin_lock_rabi_frequency_range": calibration.rabi_frequency_map,
-            "effective_spin_lock_frequency_range": effective_measured_frequency_map,
-            "spin_lock_qubit_frequencies": calibration.qubit_frequency_map,
-            "spin_lock_drive_frequencies": drive_frequency_map,
-            "spin_lock_frequency_offsets": frequency_offset_map,
-            "final_projection_phase_corrections": final_projection_phase_corrections,
-            "final_projection_phases": final_projection_phases,
-            "duration_range": durations,
-            "drive_amplitudes": amplitude_map,
-            "use_chevron_calibration": calibration.chevron_source != "none",
-            "estimate_with_chevron": calibration.chevron_source == "measured",
-            "chevron_n_shots": calibration.chevron_n_shots,
-            "return_chevron_figures": return_chevron_figures,
-            "chevron_source": calibration.chevron_source,
-            "chevron_results": calibration.chevron_results,
-            "spin_lock_rabi_sort_indices": analysis.rabi_sort_indices,
-            "raw_data": analysis.raw_data,
-            "normalized_signal": analysis.normalized_signal,
-            "population": analysis.population,
-            "relaxation_times": analysis.relaxation_times,
-            "relaxation_time_errors": analysis.relaxation_time_errors,
-            "r2": analysis.r2,
-            "fit_results": analysis.fit_results,
-        },
+        data=result_data,
         figure=primary_figure,
         figures=analysis.figures,
     )

--- a/tests/contrib/spin_lock_spectroscopy/test_function_api.py
+++ b/tests/contrib/spin_lock_spectroscopy/test_function_api.py
@@ -17,6 +17,8 @@ from qubex.contrib.experiment import (
 )
 from qubex.contrib.experiment.spin_lock_spectroscopy import (
     _analyze_spin_lock_target,
+    _final_projection_phase,
+    _final_projection_phase_maps,
     _frequency_sort_indices,
     _make_spin_lock_relaxation_figure,
     _resolve_awg_max_frequency,
@@ -74,12 +76,12 @@ def test_all_spin_lock_spectroscopy_functions_are_exported_from_experiment() -> 
     assert experiment_spin_lock_spectroscopy is spin_lock_spectroscopy
 
 
-def test_default_spin_lock_frequency_range_is_log_spaced_to_200_mhz() -> None:
-    """Given defaults, when inspected, then the Rabi-frequency range reaches 200 MHz."""
+def test_default_spin_lock_frequency_range_is_log_spaced_to_150_mhz() -> None:
+    """Given defaults, when inspected, then the Rabi-frequency range reaches 150 MHz."""
     frequency_range = spin_lock_module.DEFAULT_SPIN_LOCK_FREQUENCY_RANGE
 
     assert frequency_range[0] == pytest.approx(0.01)
-    assert frequency_range[-1] == pytest.approx(0.2)
+    assert frequency_range[-1] == pytest.approx(0.15)
     np.testing.assert_allclose(
         np.diff(np.log(frequency_range)),
         np.diff(np.log(frequency_range))[0],
@@ -341,6 +343,51 @@ def test_frequency_sort_indices_sorts_nonmonotonic_axis() -> None:
     indices = _frequency_sort_indices(frequency_range)
 
     np.testing.assert_allclose(frequency_range[indices], [0.01, 0.02, 0.03])
+
+
+def test_final_projection_phase_tracks_detuned_drive_frame() -> None:
+    """Given detuned spin-lock drive, then final projection tracks accumulated phase."""
+    final_phase = _final_projection_phase(
+        final_phase=np.pi / 2,
+        drive_detuning=0.001,
+        duration=100.0,
+    )
+
+    assert final_phase == pytest.approx(np.pi / 2 - 2.0 * np.pi * 0.001 * 100.0)
+
+
+def test_final_projection_phase_is_unchanged_without_detuning() -> None:
+    """Given no spin-lock detuning, then final projection phase is unchanged."""
+    final_phase = _final_projection_phase(
+        final_phase=np.pi / 2,
+        drive_detuning=None,
+        duration=100.0,
+    )
+
+    assert final_phase == pytest.approx(np.pi / 2)
+
+
+def test_final_projection_phase_maps_return_frequency_duration_grids() -> None:
+    """Given offsets and durations, then final projection metadata matches sweep grid."""
+    corrections, phases = _final_projection_phase_maps(
+        targets=["Q00"],
+        frequency_offset_map={"Q00": np.array([0.001, -0.002])},
+        durations=np.array([100.0, 200.0, 300.0]),
+        final_phase=np.pi / 2,
+    )
+
+    expected_corrections = (
+        -2.0
+        * np.pi
+        * np.array(
+            [
+                [0.001 * 100.0, 0.001 * 200.0, 0.001 * 300.0],
+                [-0.002 * 100.0, -0.002 * 200.0, -0.002 * 300.0],
+            ]
+        )
+    )
+    np.testing.assert_allclose(corrections["Q00"], expected_corrections)
+    np.testing.assert_allclose(phases["Q00"], np.pi / 2 + expected_corrections)
 
 
 def test_spin_lock_relaxation_figure_yaxis_starts_at_zero() -> None:

--- a/tests/contrib/spin_lock_spectroscopy/test_function_api.py
+++ b/tests/contrib/spin_lock_spectroscopy/test_function_api.py
@@ -1,0 +1,71 @@
+"""Tests for functional APIs in `qubex.contrib.experiment.spin_lock_spectroscopy`."""
+
+from __future__ import annotations
+
+import importlib
+
+import numpy as np
+import pytest
+
+from qubex.contrib import spin_lock_sequence, spin_lock_spectroscopy
+from qubex.contrib.experiment import (
+    spin_lock_sequence as experiment_spin_lock_sequence,
+    spin_lock_spectroscopy as experiment_spin_lock_spectroscopy,
+)
+
+spin_lock_module = importlib.import_module(
+    "qubex.contrib.experiment.spin_lock_spectroscopy"
+)
+
+
+def test_all_spin_lock_spectroscopy_functions_are_exported_from_contrib() -> None:
+    """Given contrib package, when imported, then spin-lock helpers are available."""
+    assert callable(spin_lock_sequence)
+    assert callable(spin_lock_spectroscopy)
+
+
+def test_all_spin_lock_spectroscopy_functions_are_exported_from_experiment() -> None:
+    """Given experiment package, when imported, then spin-lock helpers are available."""
+    assert experiment_spin_lock_sequence is spin_lock_sequence
+    assert experiment_spin_lock_spectroscopy is spin_lock_spectroscopy
+
+
+def test_default_spin_lock_frequency_range_is_log_spaced_to_200_mhz() -> None:
+    """Given defaults, when inspected, then the Rabi-frequency range reaches 200 MHz."""
+    frequency_range = spin_lock_module.DEFAULT_SPIN_LOCK_FREQUENCY_RANGE
+
+    assert frequency_range[0] == pytest.approx(0.001)
+    assert frequency_range[-1] == pytest.approx(0.2)
+    np.testing.assert_allclose(
+        np.diff(np.log(frequency_range)),
+        np.diff(np.log(frequency_range))[0],
+    )
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "match"),
+    [
+        ({"duration": 0.0, "drive_amplitude": 0.1}, "duration"),
+        ({"duration": 100.0, "drive_amplitude": np.nan}, "drive_amplitude"),
+        ({"duration": 100.0, "drive_amplitude": 1.1}, "drive_amplitude"),
+        (
+            {
+                "duration": 100.0,
+                "drive_amplitude": 0.1,
+                "drive_detuning": np.nan,
+            },
+            "drive_detuning",
+        ),
+    ],
+)
+def test_spin_lock_sequence_rejects_invalid_scalar_inputs(
+    kwargs: dict[str, float],
+    match: str,
+) -> None:
+    """Given invalid scalar inputs, when building a sequence, then validation fails."""
+    with pytest.raises(ValueError, match=match):
+        spin_lock_sequence(
+            object(),  # type: ignore[arg-type]
+            target="Q00",
+            **kwargs,
+        )

--- a/tests/contrib/spin_lock_spectroscopy/test_function_api.py
+++ b/tests/contrib/spin_lock_spectroscopy/test_function_api.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import importlib
+from contextlib import nullcontext
 from types import SimpleNamespace
 from typing import Any
 
@@ -18,6 +19,7 @@ from qubex.contrib.experiment import (
 from qubex.contrib.experiment.spin_lock_spectroscopy import (
     _analyze_spin_lock_target,
     _chevron_detuning_half_width_limit,
+    _estimate_spin_lock_parameters_with_chevron,
     _final_projection_phase,
     _final_projection_phase_maps,
     _fit_data_without_figure,
@@ -27,6 +29,7 @@ from qubex.contrib.experiment.spin_lock_spectroscopy import (
     _resolve_bool,
     _resolve_drive_detuning,
     _resolve_duration_range,
+    _resolve_frequency_range,
     _resolve_nonnegative_finite_float,
     _resolve_positive_integer,
     _resolve_spin_lock_calibration,
@@ -54,11 +57,19 @@ def test_all_spin_lock_spectroscopy_functions_are_exported_from_experiment() -> 
 def test_default_spin_lock_frequency_range_uses_tangent_spacing_to_120_mhz() -> None:
     """Given defaults, when inspected, then the Rabi-frequency range uses tangent spacing."""
     frequency_range = spin_lock_module.DEFAULT_SPIN_LOCK_FREQUENCY_RANGE
-    expected = 0.01 + 0.11 * np.tan(np.pi / 3 * np.linspace(0, 1, 12)) / np.sqrt(3)
+    expected = 0.12 * np.tan(np.pi / 3 * np.linspace(0, 1, 15)) / np.sqrt(3)
 
     np.testing.assert_allclose(frequency_range, expected)
-    assert frequency_range[0] == pytest.approx(0.01)
+    assert frequency_range[0] == pytest.approx(0.0)
     assert frequency_range[-1] == pytest.approx(0.12)
+
+
+def test_resolve_frequency_range_accepts_zero_and_rejects_negative() -> None:
+    """Given frequency inputs, then zero is allowed but negative values are rejected."""
+    np.testing.assert_allclose(_resolve_frequency_range([0.0, 0.01]), [0.0, 0.01])
+
+    with pytest.raises(ValueError, match="nonnegative"):
+        _resolve_frequency_range([-0.01, 0.01])
 
 
 def test_scaled_chevron_ranges_match_reference_at_12p5_mhz() -> None:
@@ -252,6 +263,100 @@ def test_resolve_spin_lock_parameters_reuses_supplied_chevron_results() -> None:
     assert resolved_results == chevron_results
 
 
+def test_resolve_spin_lock_parameters_reuses_zero_rabi_result() -> None:
+    """Given zero-frequency metadata, then a zero measured Rabi rate is accepted."""
+    chevron_results = {
+        "Q00": [
+            {
+                "requested_rabi_frequency": 0.0,
+                "drive_amplitude": 0.0,
+                "qubit_frequency": 5.0,
+                "rabi_frequency": 0.0,
+            }
+        ]
+    }
+
+    qubit_frequency_map, rabi_frequency_map, _ = (
+        _resolve_spin_lock_parameters_from_chevron_results(
+            targets=["Q00"],
+            requested_rabi_frequency_range=np.array([0.0]),
+            amplitude_map={"Q00": np.array([0.0])},
+            chevron_results=chevron_results,
+        )
+    )
+
+    np.testing.assert_allclose(qubit_frequency_map["Q00"], [5.0])
+    np.testing.assert_allclose(rabi_frequency_map["Q00"], [0.0])
+
+
+def test_estimate_spin_lock_parameters_skips_zero_rabi_chevron(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given a zero-frequency point, then no chevron measurement is taken for it."""
+
+    class _Util:
+        @staticmethod
+        def no_output() -> Any:
+            return nullcontext()
+
+        @staticmethod
+        def discretize_time_range(
+            values: Any,
+            *,
+            sampling_period: float,
+        ) -> np.ndarray:
+            array = np.asarray(values, dtype=np.float64)
+            return np.round(array / sampling_period) * sampling_period
+
+    exp: Any = SimpleNamespace(
+        ctx=SimpleNamespace(
+            util=_Util(),
+            measurement=SimpleNamespace(sampling_period=2.0),
+        )
+    )
+    calls: list[dict[str, Any]] = []
+
+    def _estimate_chevron(*_args: Any, **kwargs: Any) -> SimpleNamespace:
+        calls.append(kwargs)
+        return SimpleNamespace(
+            data={
+                "results": {
+                    "Q00": {
+                        "omega_q": 5.001,
+                        "omega_rabi": 0.012,
+                        "peak_background_rms_ratio": 10.0,
+                    }
+                }
+            },
+            figures=None,
+        )
+
+    monkeypatch.setattr(
+        spin_lock_module,
+        "estimate_qubit_frequency_from_chevron",
+        _estimate_chevron,
+    )
+
+    qubit_frequency_map, rabi_frequency_map, chevron_results, _ = (
+        _estimate_spin_lock_parameters_with_chevron(
+            exp,
+            targets=["Q00"],
+            requested_rabi_frequency_range=np.array([0.0, 0.0125]),
+            amplitude_map={"Q00": np.array([0.0, 0.1])},
+            base_frequencies={"Q00": 5.0},
+            chevron_n_shots=10,
+            shot_interval=0.0,
+            return_chevron_figures=False,
+        )
+    )
+
+    assert len(calls) == 1
+    np.testing.assert_allclose(qubit_frequency_map["Q00"], [5.0, 5.001])
+    np.testing.assert_allclose(rabi_frequency_map["Q00"], [0.0, 0.012])
+    assert chevron_results["Q00"][0]["chevron_measured"] is False
+    assert chevron_results["Q00"][1]["chevron_measured"] is True
+
+
 def test_resolve_spin_lock_parameters_rejects_mismatched_chevron_results() -> None:
     """Given stale chevron metadata, then reuse is rejected before measurement."""
     chevron_results = {
@@ -405,6 +510,7 @@ def test_spin_lock_relaxation_figure_yaxis_starts_at_zero() -> None:
     assert fig.layout.yaxis.range[0] == 0
     assert fig.layout.yaxis.title.text == "Relaxation time (μs)"
     assert fig.layout.xaxis.type == "linear"
+    assert fig.layout.xaxis.range[0] == 0
 
 
 def test_spin_lock_heatmap_figure_uses_linear_frequency_axis() -> None:
@@ -417,6 +523,7 @@ def test_spin_lock_heatmap_figure_uses_linear_frequency_axis() -> None:
     )
 
     assert fig.layout.xaxis.type == "linear"
+    assert fig.layout.xaxis.range[0] == 0
     assert fig.layout.yaxis.type == "log"
     heatmap_trace: Any = fig.data[0]
     assert heatmap_trace.zmin == 0
@@ -468,6 +575,54 @@ def test_analyze_spin_lock_target_returns_expected_shapes_and_figures(
     assert {kwargs["xlabel"] for kwargs in fit_kwargs} == {"Duration (ns)"}
     assert "Q00_heatmap" in analysis.figures
     assert "Q00_relaxation" in analysis.figures
+
+
+def test_analyze_spin_lock_target_fits_zero_rabi_point(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given a zero Rabi point, then decay fitting is still applied."""
+
+    class _FitResult(dict[str, float]):
+        status = FitStatus.SUCCESS
+        message = "ok"
+        figure = None
+
+        def __init__(self, **kwargs: float) -> None:
+            super().__init__(**kwargs)
+            self.data = dict(self)
+
+    fit_kwargs: list[dict[str, Any]] = []
+
+    def _fit_exp_decay(**kwargs: Any) -> _FitResult:
+        fit_kwargs.append(kwargs)
+        return _FitResult(tau=1000.0, tau_err=100.0, r2=0.99)
+
+    monkeypatch.setattr(spin_lock_module.fitting, "fit_exp_decay", _fit_exp_decay)
+    sweep_data = SimpleNamespace(
+        data=np.arange(6, dtype=np.float64),
+        normalized=np.linspace(-1.0, 1.0, 6),
+    )
+
+    analysis = _analyze_spin_lock_target(
+        target="Q00",
+        sweep_data=sweep_data,
+        durations=np.array([100.0, 200.0, 300.0]),
+        requested_rabi_frequency_range=np.array([0.0, 0.01]),
+        rabi_frequency_range=np.array([0.0, 0.01]),
+        effective_frequency_range=np.array([0.0, 0.01]),
+        drive_frequencies=np.array([5.0, 5.0]),
+        qubit_frequencies=np.array([5.0, 5.0]),
+    )
+
+    assert [kwargs["target"] for kwargs in fit_kwargs] == [
+        "Q00_0_MHz",
+        "Q00_10_MHz",
+    ]
+    np.testing.assert_allclose(analysis.relaxation_times, [1000.0, 1000.0])
+    assert [fit_result["status"] for fit_result in analysis.fit_results] == [
+        "success",
+        "success",
+    ]
 
 
 def test_resolve_duration_range_removes_duplicate_discretized_points() -> None:

--- a/tests/contrib/spin_lock_spectroscopy/test_function_api.py
+++ b/tests/contrib/spin_lock_spectroscopy/test_function_api.py
@@ -23,6 +23,7 @@ from qubex.contrib.experiment.spin_lock_spectroscopy import (
     _final_projection_phase,
     _final_projection_phase_maps,
     _fit_data_without_figure,
+    _frequency_axis_from_calibration,
     _frequency_sort_indices,
     _make_spin_lock_heatmap_figure,
     _make_spin_lock_relaxation_figure,
@@ -33,7 +34,7 @@ from qubex.contrib.experiment.spin_lock_spectroscopy import (
     _resolve_nonnegative_finite_float,
     _resolve_positive_integer,
     _resolve_spin_lock_calibration,
-    _resolve_spin_lock_parameters_from_chevron_results,
+    _resolve_spin_lock_parameters_from_calibration,
     _scaled_chevron_ranges,
 )
 
@@ -230,61 +231,109 @@ def test_chevron_detuning_half_width_limit_uses_sampling_period_nyquist() -> Non
     assert _chevron_detuning_half_width_limit(exp) == pytest.approx(0.2)
 
 
-def test_resolve_spin_lock_parameters_reuses_supplied_chevron_results() -> None:
-    """Given previous chevron metadata, then measured axes are recovered from it."""
-    chevron_results = {
-        "Q00": [
-            {
-                "requested_rabi_frequency": 0.01,
-                "drive_amplitude": 0.1,
-                "qubit_frequency": 5.001,
-                "rabi_frequency": 0.011,
-            },
-            {
-                "requested_rabi_frequency": 0.02,
-                "drive_amplitude": 0.2,
-                "qubit_frequency": 5.004,
-                "rabi_frequency": 0.021,
-            },
-        ]
+def test_resolve_spin_lock_parameters_reuses_supplied_calibration() -> None:
+    """Given previous calibration data, then measured axes are recovered from it."""
+    spin_lock_calibration = {
+        "Q00": {
+            "requested_rabi_frequencies": np.array([0.01, 0.02]),
+            "drive_amplitudes": np.array([0.1, 0.2]),
+            "qubit_frequencies": np.array([5.001, 5.004]),
+            "rabi_frequencies": np.array([0.011, 0.021]),
+        }
     }
 
-    qubit_frequency_map, rabi_frequency_map, resolved_results = (
-        _resolve_spin_lock_parameters_from_chevron_results(
+    drive_amplitude_map, qubit_frequency_map, rabi_frequency_map, resolved = (
+        _resolve_spin_lock_parameters_from_calibration(
             targets=["Q00"],
             requested_rabi_frequency_range=np.array([0.01, 0.02]),
-            amplitude_map={"Q00": np.array([0.1, 0.2])},
-            chevron_results=chevron_results,
+            spin_lock_calibration=spin_lock_calibration,
+            base_frequencies={"Q00": 5.0},
+        )
+    )
+
+    np.testing.assert_allclose(drive_amplitude_map["Q00"], [0.1, 0.2])
+    np.testing.assert_allclose(qubit_frequency_map["Q00"], [5.001, 5.004])
+    np.testing.assert_allclose(rabi_frequency_map["Q00"], [0.011, 0.021])
+    np.testing.assert_allclose(resolved["Q00"]["ac_stark_shifts"], [0.001, 0.004])
+
+
+def test_resolve_spin_lock_parameters_accepts_ac_stark_shifts() -> None:
+    """Given AC Stark shifts, then qubit frequencies are reconstructed."""
+    spin_lock_calibration = {
+        "Q00": {
+            "drive_amplitudes": np.array([0.1, 0.2]),
+            "ac_stark_shifts": np.array([0.001, 0.004]),
+            "rabi_frequencies": np.array([0.011, 0.021]),
+        }
+    }
+
+    _, qubit_frequency_map, rabi_frequency_map, _ = (
+        _resolve_spin_lock_parameters_from_calibration(
+            targets=["Q00"],
+            requested_rabi_frequency_range=np.array([0.01, 0.02]),
+            spin_lock_calibration=spin_lock_calibration,
+            base_frequencies={"Q00": 5.0},
         )
     )
 
     np.testing.assert_allclose(qubit_frequency_map["Q00"], [5.001, 5.004])
     np.testing.assert_allclose(rabi_frequency_map["Q00"], [0.011, 0.021])
-    assert resolved_results == chevron_results
+
+
+def test_frequency_axis_from_calibration_prefers_requested_axis() -> None:
+    """Given calibration data, then the stored requested axis is reused if present."""
+    spin_lock_calibration = {
+        "Q00": {
+            "requested_rabi_frequencies": np.array([0.01, 0.02]),
+            "rabi_frequencies": np.array([0.011, 0.021]),
+        }
+    }
+
+    frequency_axis = _frequency_axis_from_calibration(
+        targets=["Q00"],
+        spin_lock_calibration=spin_lock_calibration,
+    )
+
+    np.testing.assert_allclose(frequency_axis, [0.01, 0.02])
+
+
+def test_frequency_axis_from_calibration_falls_back_to_rabi_axis() -> None:
+    """Given manual calibration data, then the Rabi axis can define the sweep."""
+    spin_lock_calibration = {
+        "Q00": {
+            "rabi_frequencies": np.array([0.011, 0.021]),
+        }
+    }
+
+    frequency_axis = _frequency_axis_from_calibration(
+        targets=["Q00"],
+        spin_lock_calibration=spin_lock_calibration,
+    )
+
+    np.testing.assert_allclose(frequency_axis, [0.011, 0.021])
 
 
 def test_resolve_spin_lock_parameters_reuses_zero_rabi_result() -> None:
-    """Given zero-frequency metadata, then a zero measured Rabi rate is accepted."""
-    chevron_results = {
-        "Q00": [
-            {
-                "requested_rabi_frequency": 0.0,
-                "drive_amplitude": 0.0,
-                "qubit_frequency": 5.0,
-                "rabi_frequency": 0.0,
-            }
-        ]
+    """Given zero-frequency calibration, then a zero measured Rabi rate is accepted."""
+    spin_lock_calibration = {
+        "Q00": {
+            "requested_rabi_frequencies": np.array([0.0]),
+            "drive_amplitudes": np.array([0.0]),
+            "qubit_frequencies": np.array([5.0]),
+            "rabi_frequencies": np.array([0.0]),
+        }
     }
 
-    qubit_frequency_map, rabi_frequency_map, _ = (
-        _resolve_spin_lock_parameters_from_chevron_results(
+    drive_amplitude_map, qubit_frequency_map, rabi_frequency_map, _ = (
+        _resolve_spin_lock_parameters_from_calibration(
             targets=["Q00"],
             requested_rabi_frequency_range=np.array([0.0]),
-            amplitude_map={"Q00": np.array([0.0])},
-            chevron_results=chevron_results,
+            spin_lock_calibration=spin_lock_calibration,
+            base_frequencies={"Q00": 5.0},
         )
     )
 
+    np.testing.assert_allclose(drive_amplitude_map["Q00"], [0.0])
     np.testing.assert_allclose(qubit_frequency_map["Q00"], [5.0])
     np.testing.assert_allclose(rabi_frequency_map["Q00"], [0.0])
 
@@ -315,6 +364,7 @@ def test_estimate_spin_lock_parameters_skips_zero_rabi_chevron(
         )
     )
     calls: list[dict[str, Any]] = []
+    progress_iterables: list[list[int]] = []
 
     def _estimate_chevron(*_args: Any, **kwargs: Any) -> SimpleNamespace:
         calls.append(kwargs)
@@ -331,13 +381,19 @@ def test_estimate_spin_lock_parameters_skips_zero_rabi_chevron(
             figures=None,
         )
 
+    def _fake_tqdm(iterable: Any, **_kwargs: Any) -> list[int]:
+        values = list(iterable)
+        progress_iterables.append(values)
+        return values
+
     monkeypatch.setattr(
         spin_lock_module,
         "estimate_qubit_frequency_from_chevron",
         _estimate_chevron,
     )
+    monkeypatch.setattr(spin_lock_module, "tqdm", _fake_tqdm)
 
-    qubit_frequency_map, rabi_frequency_map, chevron_results, _ = (
+    qubit_frequency_map, rabi_frequency_map, spin_lock_calibration, _ = (
         _estimate_spin_lock_parameters_with_chevron(
             exp,
             targets=["Q00"],
@@ -351,59 +407,86 @@ def test_estimate_spin_lock_parameters_skips_zero_rabi_chevron(
     )
 
     assert len(calls) == 1
+    assert progress_iterables == [[1]]
     np.testing.assert_allclose(qubit_frequency_map["Q00"], [5.0, 5.001])
     np.testing.assert_allclose(rabi_frequency_map["Q00"], [0.0, 0.012])
-    assert chevron_results["Q00"][0]["chevron_measured"] is False
-    assert chevron_results["Q00"][1]["chevron_measured"] is True
+    np.testing.assert_allclose(
+        spin_lock_calibration["Q00"]["drive_amplitudes"],
+        [0.0, 0.1],
+    )
+    np.testing.assert_allclose(
+        spin_lock_calibration["Q00"]["rabi_frequencies"],
+        [0.0, 0.012],
+    )
+    np.testing.assert_array_equal(
+        spin_lock_calibration["Q00"]["chevron_measured"],
+        [False, True],
+    )
 
 
-def test_resolve_spin_lock_parameters_rejects_mismatched_chevron_results() -> None:
-    """Given stale chevron metadata, then reuse is rejected before measurement."""
-    chevron_results = {
-        "Q00": [
-            {
-                "requested_rabi_frequency": 0.03,
-                "drive_amplitude": 0.1,
-                "qubit_frequency": 5.001,
-                "rabi_frequency": 0.011,
-            }
-        ]
+def test_resolve_spin_lock_parameters_rejects_mismatched_calibration() -> None:
+    """Given stale calibration metadata, then reuse is rejected before measurement."""
+    spin_lock_calibration = {
+        "Q00": {
+            "requested_rabi_frequencies": np.array([0.03]),
+            "drive_amplitudes": np.array([0.1]),
+            "qubit_frequencies": np.array([5.001]),
+            "rabi_frequencies": np.array([0.011]),
+        }
     }
 
-    with pytest.raises(ValueError, match="requested_rabi_frequency"):
-        _resolve_spin_lock_parameters_from_chevron_results(
+    with pytest.raises(ValueError, match="spin_lock_frequency_range"):
+        _resolve_spin_lock_parameters_from_calibration(
             targets=["Q00"],
             requested_rabi_frequency_range=np.array([0.01]),
-            amplitude_map={"Q00": np.array([0.1])},
-            chevron_results=chevron_results,
+            spin_lock_calibration=spin_lock_calibration,
+            base_frequencies={"Q00": 5.0},
         )
 
 
-def test_resolve_spin_lock_parameters_requires_matching_chevron_metadata() -> None:
-    """Given incomplete previous metadata, then reuse is rejected."""
-    chevron_results = {
-        "Q00": [
-            {
-                "drive_amplitude": 0.1,
-                "qubit_frequency": 5.001,
-                "rabi_frequency": 0.011,
-            }
-        ]
+def test_resolve_spin_lock_parameters_requires_frequency_calibration() -> None:
+    """Given incomplete previous calibration, then reuse is rejected."""
+    spin_lock_calibration = {
+        "Q00": {
+            "drive_amplitudes": np.array([0.1]),
+            "rabi_frequencies": np.array([0.011]),
+        }
     }
 
-    with pytest.raises(ValueError, match="requested_rabi_frequency"):
-        _resolve_spin_lock_parameters_from_chevron_results(
+    with pytest.raises(ValueError, match="ac_stark_shifts"):
+        _resolve_spin_lock_parameters_from_calibration(
             targets=["Q00"],
             requested_rabi_frequency_range=np.array([0.01]),
-            amplitude_map={"Q00": np.array([0.1])},
-            chevron_results=chevron_results,
+            spin_lock_calibration=spin_lock_calibration,
+            base_frequencies={"Q00": 5.0},
         )
 
 
-def test_resolve_spin_lock_calibration_reuses_provided_chevron_without_measuring(
+def test_resolve_spin_lock_parameters_rejects_non_bool_chevron_measured() -> None:
+    """Given non-bool chevron flags, then manual calibration is rejected."""
+    spin_lock_calibration = {
+        "Q00": {
+            "requested_rabi_frequencies": np.array([0.01]),
+            "drive_amplitudes": np.array([0.1]),
+            "qubit_frequencies": np.array([5.001]),
+            "rabi_frequencies": np.array([0.011]),
+            "chevron_measured": np.array([1]),
+        }
+    }
+
+    with pytest.raises(TypeError, match="chevron_measured"):
+        _resolve_spin_lock_parameters_from_calibration(
+            targets=["Q00"],
+            requested_rabi_frequency_range=np.array([0.01]),
+            spin_lock_calibration=spin_lock_calibration,
+            base_frequencies={"Q00": 5.0},
+        )
+
+
+def test_resolve_spin_lock_calibration_reuses_provided_dataset_without_measuring(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Given previous chevron metadata, then calibration skips new chevron sweeps."""
+    """Given previous calibration data, then calibration skips new chevron sweeps."""
 
     def _unexpected_chevron_measurement(**_kwargs: Any) -> None:
         raise AssertionError("Chevron measurement should not be called.")
@@ -418,30 +501,72 @@ def test_resolve_spin_lock_calibration_reuses_provided_chevron_without_measuring
         object(),  # type: ignore[arg-type]
         targets=["Q00"],
         requested_rabi_frequency_range=np.array([0.01]),
-        amplitude_map={"Q00": np.array([0.1])},
         base_frequencies={"Q00": 5.0},
-        estimate_with_chevron=True,
-        chevron_results={
-            "Q00": [
-                {
-                    "requested_rabi_frequency": 0.01,
-                    "drive_amplitude": 0.1,
-                    "qubit_frequency": 5.001,
-                    "rabi_frequency": 0.011,
-                }
-            ]
+        spin_lock_calibration={
+            "Q00": {
+                "requested_rabi_frequencies": np.array([0.01]),
+                "drive_amplitudes": np.array([0.1]),
+                "qubit_frequencies": np.array([5.001]),
+                "rabi_frequencies": np.array([0.011]),
+            }
         },
+        estimate_with_chevron=True,
         chevron_n_shots=10,
         n_shots=100,
         shot_interval=0.0,
         return_chevron_figures=True,
     )
 
-    assert calibration.chevron_source == "provided"
+    assert calibration.calibration_source == "provided"
     assert calibration.chevron_n_shots is None
     assert calibration.chevron_figures == {}
+    np.testing.assert_allclose(calibration.drive_amplitude_map["Q00"], [0.1])
     np.testing.assert_allclose(calibration.qubit_frequency_map["Q00"], [5.001])
     np.testing.assert_allclose(calibration.rabi_frequency_map["Q00"], [0.011])
+
+
+def test_resolve_spin_lock_calibration_marks_zero_only_axis_as_not_measured(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given only zero Rabi points, then chevron calibration is not marked measured."""
+
+    def _unexpected_chevron_measurement(**_kwargs: Any) -> None:
+        raise AssertionError("Chevron measurement should not be called.")
+
+    exp: Any = SimpleNamespace(
+        pulse=SimpleNamespace(
+            calc_control_amplitude=lambda _target, _frequency: 0.0,
+        )
+    )
+    monkeypatch.setattr(
+        spin_lock_module,
+        "_estimate_spin_lock_parameters_with_chevron",
+        _unexpected_chevron_measurement,
+    )
+
+    calibration = _resolve_spin_lock_calibration(
+        exp,
+        targets=["Q00"],
+        requested_rabi_frequency_range=np.array([0.0]),
+        base_frequencies={"Q00": 5.0},
+        spin_lock_calibration=None,
+        estimate_with_chevron=True,
+        chevron_n_shots=0,
+        n_shots=100,
+        shot_interval=0.0,
+        return_chevron_figures=True,
+    )
+
+    assert calibration.calibration_source == "none"
+    assert calibration.chevron_n_shots is None
+    assert calibration.chevron_figures == {}
+    np.testing.assert_allclose(calibration.drive_amplitude_map["Q00"], [0.0])
+    np.testing.assert_allclose(calibration.qubit_frequency_map["Q00"], [5.0])
+    np.testing.assert_allclose(calibration.rabi_frequency_map["Q00"], [0.0])
+    np.testing.assert_array_equal(
+        calibration.calibration_dataset["Q00"]["chevron_measured"],
+        [False],
+    )
 
 
 def test_frequency_sort_indices_sorts_nonmonotonic_axis() -> None:
@@ -571,10 +696,12 @@ def test_analyze_spin_lock_target_returns_expected_shapes_and_figures(
     assert analysis.normalized_signal.shape == (3, 2)
     assert analysis.population.shape == (3, 2)
     np.testing.assert_allclose(analysis.relaxation_times, [1000.0, 1000.0])
-    np.testing.assert_allclose(analysis.sort_indices, [1, 0])
     assert {kwargs["xlabel"] for kwargs in fit_kwargs} == {"Duration (ns)"}
     assert "Q00_heatmap" in analysis.figures
     assert "Q00_relaxation" in analysis.figures
+    heatmap_figure: Any = analysis.figures["Q00_heatmap"]
+    heatmap_trace: Any = heatmap_figure.data[0]
+    np.testing.assert_allclose(heatmap_trace.x, [10.0, 20.0])
 
 
 def test_analyze_spin_lock_target_fits_zero_rabi_point(
@@ -623,6 +750,8 @@ def test_analyze_spin_lock_target_fits_zero_rabi_point(
         "success",
         "success",
     ]
+    assert "rabi_frequency" in analysis.fit_results[0]
+    assert "frequency" not in analysis.fit_results[0]
 
 
 def test_resolve_duration_range_removes_duplicate_discretized_points() -> None:

--- a/tests/contrib/spin_lock_spectroscopy/test_function_api.py
+++ b/tests/contrib/spin_lock_spectroscopy/test_function_api.py
@@ -3,19 +3,63 @@
 from __future__ import annotations
 
 import importlib
+from types import SimpleNamespace
+from typing import Any
 
 import numpy as np
 import pytest
 
+from qubex.analysis import FitStatus
 from qubex.contrib import spin_lock_sequence, spin_lock_spectroscopy
 from qubex.contrib.experiment import (
     spin_lock_sequence as experiment_spin_lock_sequence,
     spin_lock_spectroscopy as experiment_spin_lock_spectroscopy,
 )
+from qubex.contrib.experiment.spin_lock_spectroscopy import (
+    _analyze_spin_lock_target,
+    _frequency_sort_indices,
+    _make_spin_lock_relaxation_figure,
+    _resolve_awg_max_frequency,
+    _resolve_bool,
+    _resolve_drive_detuning,
+    _resolve_duration_range,
+    _resolve_nonnegative_finite_float,
+    _resolve_positive_integer,
+    _scaled_chevron_ranges,
+    _validate_awg_frequency_ranges,
+    _validate_chevron_awg_frequency_range,
+)
 
 spin_lock_module = importlib.import_module(
     "qubex.contrib.experiment.spin_lock_spectroscopy"
 )
+
+
+def _make_awg_validation_exp(
+    *,
+    sideband: str,
+    nco_frequency: float,
+    awg_max_frequency_hz: float | None = 250_000_000,
+) -> Any:
+    class _ExperimentSystem:
+        @staticmethod
+        def get_target(_target: str) -> SimpleNamespace:
+            return SimpleNamespace(sideband=sideband)
+
+        @staticmethod
+        def get_nco_frequency(_target: str) -> float:
+            return nco_frequency
+
+    return SimpleNamespace(
+        ctx=SimpleNamespace(
+            experiment_system=_ExperimentSystem(),
+            measurement=SimpleNamespace(
+                constraint_profile=SimpleNamespace(
+                    awg_max_frequency_hz=awg_max_frequency_hz
+                )
+            ),
+        )
+    )
 
 
 def test_all_spin_lock_spectroscopy_functions_are_exported_from_contrib() -> None:
@@ -34,7 +78,7 @@ def test_default_spin_lock_frequency_range_is_log_spaced_to_200_mhz() -> None:
     """Given defaults, when inspected, then the Rabi-frequency range reaches 200 MHz."""
     frequency_range = spin_lock_module.DEFAULT_SPIN_LOCK_FREQUENCY_RANGE
 
-    assert frequency_range[0] == pytest.approx(0.001)
+    assert frequency_range[0] == pytest.approx(0.01)
     assert frequency_range[-1] == pytest.approx(0.2)
     np.testing.assert_allclose(
         np.diff(np.log(frequency_range)),
@@ -42,10 +86,411 @@ def test_default_spin_lock_frequency_range_is_log_spaced_to_200_mhz() -> None:
     )
 
 
+def test_scaled_chevron_ranges_match_reference_at_12p5_mhz() -> None:
+    """Given 12.5 MHz expected Rabi rate, then chevron ranges use reference spans."""
+
+    class _Util:
+        @staticmethod
+        def discretize_time_range(
+            values: Any,
+            *,
+            sampling_period: float,
+        ) -> np.ndarray:
+            array = np.asarray(values, dtype=np.float64)
+            return np.round(array / sampling_period) * sampling_period
+
+    exp: Any = SimpleNamespace(
+        ctx=SimpleNamespace(
+            util=_Util(),
+            measurement=SimpleNamespace(sampling_period=10.0),
+        )
+    )
+
+    detuning_range, time_range, omega_rabi_range = _scaled_chevron_ranges(
+        exp,
+        expected_rabi_frequency=0.0125,
+    )
+
+    np.testing.assert_allclose(detuning_range, np.linspace(-0.05, 0.05, 41))
+    np.testing.assert_allclose(time_range, np.linspace(0, 250, 26))
+    assert omega_rabi_range[-1] == pytest.approx(0.025)
+
+
+def test_scaled_chevron_ranges_shorten_time_for_larger_rabi_rate() -> None:
+    """Given larger drive, then chevron time span is shortened."""
+
+    class _Util:
+        @staticmethod
+        def discretize_time_range(
+            values: Any,
+            *,
+            sampling_period: float,
+        ) -> np.ndarray:
+            return np.asarray(values, dtype=np.float64)
+
+    exp: Any = SimpleNamespace(
+        ctx=SimpleNamespace(
+            util=_Util(),
+            measurement=SimpleNamespace(sampling_period=1.0),
+        )
+    )
+
+    detuning_range, time_range, omega_rabi_range = _scaled_chevron_ranges(
+        exp,
+        expected_rabi_frequency=0.025,
+    )
+
+    assert detuning_range[0] == pytest.approx(-0.1)
+    assert detuning_range[-1] == pytest.approx(0.1)
+    assert time_range[-1] == pytest.approx(125.0)
+    assert omega_rabi_range[-1] == pytest.approx(0.05)
+
+
+def test_scaled_chevron_ranges_caps_detuning_span_at_200_mhz() -> None:
+    """Given strong drive, then chevron detuning span is capped at +/-200 MHz."""
+
+    class _Util:
+        @staticmethod
+        def discretize_time_range(
+            values: Any,
+            *,
+            sampling_period: float,
+        ) -> np.ndarray:
+            return np.asarray(values, dtype=np.float64)
+
+    exp: Any = SimpleNamespace(
+        ctx=SimpleNamespace(
+            util=_Util(),
+            measurement=SimpleNamespace(sampling_period=1.0),
+        )
+    )
+
+    detuning_range, time_range, omega_rabi_range = _scaled_chevron_ranges(
+        exp,
+        expected_rabi_frequency=0.2,
+    )
+
+    assert detuning_range[0] == pytest.approx(-0.2)
+    assert detuning_range[-1] == pytest.approx(0.2)
+    assert time_range[-1] == pytest.approx(15.625)
+    assert omega_rabi_range[-1] == pytest.approx(0.4)
+
+
+def test_scaled_chevron_ranges_rounds_time_to_sampling_grid() -> None:
+    """Given a coarse sampling grid, then only chevron time points are rounded."""
+
+    class _Util:
+        @staticmethod
+        def discretize_time_range(
+            values: Any,
+            *,
+            sampling_period: float,
+        ) -> np.ndarray:
+            array = np.asarray(values, dtype=np.float64)
+            return np.round(array / sampling_period) * sampling_period
+
+    exp: Any = SimpleNamespace(
+        ctx=SimpleNamespace(
+            util=_Util(),
+            measurement=SimpleNamespace(sampling_period=7.0),
+        )
+    )
+
+    detuning_range, time_range, _ = _scaled_chevron_ranges(
+        exp,
+        expected_rabi_frequency=0.0125,
+    )
+
+    np.testing.assert_allclose(detuning_range, np.linspace(-0.05, 0.05, 41))
+    np.testing.assert_allclose(time_range / 7.0, np.round(time_range / 7.0))
+
+
+def test_scaled_chevron_ranges_rejects_too_few_time_points() -> None:
+    """Given a coarse sampling grid, then an unusable chevron time range is rejected."""
+
+    class _Util:
+        @staticmethod
+        def discretize_time_range(
+            values: Any,
+            *,
+            sampling_period: float,
+        ) -> np.ndarray:
+            array = np.asarray(values, dtype=np.float64)
+            return np.round(array / sampling_period) * sampling_period
+
+    exp: Any = SimpleNamespace(
+        ctx=SimpleNamespace(
+            util=_Util(),
+            measurement=SimpleNamespace(sampling_period=1000.0),
+        )
+    )
+
+    with pytest.raises(ValueError, match="chevron time_range"):
+        _scaled_chevron_ranges(
+            exp,
+            expected_rabi_frequency=0.2,
+        )
+
+
+def test_validate_chevron_awg_frequency_range_accepts_reachable_span() -> None:
+    """Given reachable drive frequencies, then current NCO validation passes."""
+    exp = _make_awg_validation_exp(sideband="U", nco_frequency=5.0)
+
+    _validate_chevron_awg_frequency_range(
+        exp,
+        targets=["Q00"],
+        base_frequencies={"Q00": 5.0},
+        detuning_range=np.array([-0.2, 0.0, 0.2]),
+    )
+
+
+def test_validate_chevron_awg_frequency_range_rejects_unreachable_span() -> None:
+    """Given unreachable drive frequencies, then current NCO validation fails."""
+    exp = _make_awg_validation_exp(sideband="U", nco_frequency=5.0)
+
+    with pytest.raises(ValueError, match="AWG modulation"):
+        _validate_chevron_awg_frequency_range(
+            exp,
+            targets=["Q00"],
+            base_frequencies={"Q00": 5.1},
+            detuning_range=np.array([-0.2, 0.0, 0.2]),
+        )
+
+
+def test_validate_awg_frequency_range_accepts_lower_sideband_span() -> None:
+    """Given lower sideband, then AWG validation uses NCO minus drive frequency."""
+    exp = _make_awg_validation_exp(sideband="L", nco_frequency=5.0)
+
+    _validate_awg_frequency_ranges(
+        exp,
+        targets=["Q00"],
+        drive_frequency_ranges={"Q00": np.array([4.8, 4.9, 5.0])},
+        description="test frequencies",
+    )
+
+
+def test_validate_awg_frequency_range_skips_unknown_backend_limit() -> None:
+    """Given no AWG limit in profile, then validation is left to the backend."""
+    exp = _make_awg_validation_exp(
+        sideband="U",
+        nco_frequency=5.0,
+        awg_max_frequency_hz=None,
+    )
+
+    _validate_awg_frequency_ranges(
+        exp,
+        targets=["Q00"],
+        drive_frequency_ranges={"Q00": np.array([5.0, 6.0])},
+        description="test frequencies",
+    )
+
+
+def test_resolve_awg_max_frequency_skips_legacy_context_without_profile() -> None:
+    """Given old fake measurement context, then AWG validation is skipped."""
+    exp: Any = SimpleNamespace(ctx=SimpleNamespace(measurement=SimpleNamespace()))
+
+    assert _resolve_awg_max_frequency(exp) is None
+
+
+def test_resolve_awg_max_frequency_uses_quel1_like_profile() -> None:
+    """Given QuEL-1-like constraints, then the contrib fallback uses QuEL-1 AWG limit."""
+    exp: Any = SimpleNamespace(
+        ctx=SimpleNamespace(
+            measurement=SimpleNamespace(
+                constraint_profile=SimpleNamespace(
+                    sampling_period_ns=2.0,
+                    word_length_samples=4,
+                    block_length_samples=64,
+                    require_workaround_capture=True,
+                    enforce_word_alignment=True,
+                    enforce_block_alignment=True,
+                    enforce_capture_spacing=True,
+                )
+            )
+        )
+    )
+
+    assert _resolve_awg_max_frequency(exp) == pytest.approx(0.25)
+
+
+def test_resolve_awg_max_frequency_skips_non_quel1_strict_profile() -> None:
+    """Given strict non-QuEL-1 constraints, then no QuEL-1 AWG limit is assumed."""
+    exp: Any = SimpleNamespace(
+        ctx=SimpleNamespace(
+            measurement=SimpleNamespace(
+                constraint_profile=SimpleNamespace(
+                    sampling_period_ns=0.4,
+                    word_length_samples=4,
+                    block_length_samples=64,
+                    require_workaround_capture=True,
+                    enforce_word_alignment=True,
+                    enforce_block_alignment=True,
+                    enforce_capture_spacing=True,
+                )
+            )
+        )
+    )
+
+    assert _resolve_awg_max_frequency(exp) is None
+
+
+def test_frequency_sort_indices_sorts_nonmonotonic_axis() -> None:
+    """Given a nonmonotonic measured Rabi axis, then sort indices reorder it."""
+    frequency_range = np.array([0.02, 0.01, 0.03])
+
+    indices = _frequency_sort_indices(frequency_range)
+
+    np.testing.assert_allclose(frequency_range[indices], [0.01, 0.02, 0.03])
+
+
+def test_spin_lock_relaxation_figure_yaxis_starts_at_zero() -> None:
+    """Given relaxation data, then the summary figure lower y-axis bound is zero."""
+    fig = _make_spin_lock_relaxation_figure(
+        target="Q00",
+        spin_lock_rabi_frequency_range=np.array([0.01, 0.02]),
+        relaxation_times=np.array([1000.0, 2000.0]),
+        relaxation_time_errors=np.array([500.0, 800.0]),
+    )
+
+    assert fig.layout.yaxis.range[0] == 0
+    assert fig.layout.yaxis.title.text == "Relaxation time (μs)"
+
+
+def test_analyze_spin_lock_target_returns_expected_shapes_and_figures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given sweep data, then per-target analysis returns arrays and figures."""
+
+    class _FitResult(dict[str, float]):
+        status = FitStatus.SUCCESS
+        message = "ok"
+        figure = None
+
+        def __init__(self, **kwargs: float) -> None:
+            super().__init__(**kwargs)
+            self.data = dict(self)
+
+    def _fit_exp_decay(**_kwargs: Any) -> _FitResult:
+        return _FitResult(tau=1000.0, tau_err=100.0, r2=0.99)
+
+    monkeypatch.setattr(spin_lock_module.fitting, "fit_exp_decay", _fit_exp_decay)
+    sweep_data = SimpleNamespace(
+        data=np.arange(6, dtype=np.float64),
+        normalized=np.linspace(-1.0, 1.0, 6),
+    )
+
+    analysis = _analyze_spin_lock_target(
+        target="Q00",
+        sweep_data=sweep_data,
+        durations=np.array([100.0, 200.0, 300.0]),
+        requested_rabi_frequency_range=np.array([0.02, 0.01]),
+        rabi_frequency_range=np.array([0.02, 0.01]),
+        effective_frequency_range=np.array([0.02, 0.01]),
+        drive_frequencies=np.array([5.0, 5.0]),
+        qubit_frequencies=np.array([5.0, 5.0]),
+    )
+
+    assert analysis.raw_data.shape == (2, 3)
+    assert analysis.normalized_signal.shape == (3, 2)
+    assert analysis.population.shape == (3, 2)
+    np.testing.assert_allclose(analysis.relaxation_times, [1000.0, 1000.0])
+    np.testing.assert_allclose(analysis.sort_indices, [1, 0])
+    assert "Q00_heatmap" in analysis.figures
+    assert "Q00_relaxation" in analysis.figures
+
+
+def test_resolve_duration_range_removes_duplicate_discretized_points() -> None:
+    """Given close durations, then discretization removes duplicate time points."""
+
+    class _Util:
+        @staticmethod
+        def discretize_time_range(
+            values: Any,
+            *,
+            sampling_period: float,
+        ) -> np.ndarray:
+            array = np.asarray(values, dtype=np.float64)
+            return np.round(array / sampling_period) * sampling_period
+
+    exp: Any = SimpleNamespace(
+        ctx=SimpleNamespace(
+            util=_Util(),
+            measurement=SimpleNamespace(sampling_period=10.0),
+        )
+    )
+
+    durations = _resolve_duration_range(exp, [9.0, 11.0, 21.0, 31.0])
+
+    np.testing.assert_allclose(durations, [10.0, 20.0, 30.0])
+
+
+def test_resolve_duration_range_rejects_too_few_fit_points() -> None:
+    """Given too few unique durations, then decay fitting is rejected early."""
+
+    class _Util:
+        @staticmethod
+        def discretize_time_range(
+            values: Any,
+            *,
+            sampling_period: float,
+        ) -> np.ndarray:
+            array = np.asarray(values, dtype=np.float64)
+            return np.round(array / sampling_period) * sampling_period
+
+    exp: Any = SimpleNamespace(
+        ctx=SimpleNamespace(
+            util=_Util(),
+            measurement=SimpleNamespace(sampling_period=10.0),
+        )
+    )
+
+    with pytest.raises(ValueError, match="duration_range"):
+        _resolve_duration_range(exp, [9.0, 11.0, 21.0])
+
+
+def test_resolve_drive_detuning_rejects_nonfinite_values() -> None:
+    """Given invalid detuning, then validation rejects it before measurement."""
+    with pytest.raises(ValueError, match="drive_detuning"):
+        _resolve_drive_detuning(np.nan)
+
+
+def test_resolve_positive_integer_rejects_invalid_values() -> None:
+    """Given invalid shot counts, then validation rejects them early."""
+    with pytest.raises(ValueError, match="n_shots"):
+        _resolve_positive_integer(0, name="n_shots", default=1024)
+
+    with pytest.raises(TypeError, match="n_shots"):
+        _resolve_positive_integer(np.nan, name="n_shots", default=1024)  # type: ignore[arg-type]
+
+
+def test_resolve_nonnegative_finite_float_rejects_invalid_values() -> None:
+    """Given invalid shot intervals, then validation rejects them early."""
+    with pytest.raises(ValueError, match="shot_interval"):
+        _resolve_nonnegative_finite_float(
+            np.nan,
+            name="shot_interval",
+            default=0.0,
+        )
+
+    with pytest.raises(ValueError, match="shot_interval"):
+        _resolve_nonnegative_finite_float(
+            -1.0,
+            name="shot_interval",
+            default=0.0,
+        )
+
+
+def test_resolve_bool_rejects_non_bool_values() -> None:
+    """Given non-bool value, then boolean option validation rejects it."""
+    with pytest.raises(TypeError, match="Boolean options"):
+        _resolve_bool("False", default=False)  # type: ignore[arg-type]
+
+
 @pytest.mark.parametrize(
     ("kwargs", "match"),
     [
         ({"duration": 0.0, "drive_amplitude": 0.1}, "duration"),
+        ({"duration": np.nan, "drive_amplitude": 0.1}, "duration"),
         ({"duration": 100.0, "drive_amplitude": np.nan}, "drive_amplitude"),
         ({"duration": 100.0, "drive_amplitude": 1.1}, "drive_amplitude"),
         (
@@ -55,6 +500,14 @@ def test_default_spin_lock_frequency_range_is_log_spaced_to_200_mhz() -> None:
                 "drive_detuning": np.nan,
             },
             "drive_detuning",
+        ),
+        (
+            {
+                "duration": 100.0,
+                "drive_amplitude": 0.1,
+                "drive_phase": np.nan,
+            },
+            "phase",
         ),
     ],
 )

--- a/tests/contrib/spin_lock_spectroscopy/test_function_api.py
+++ b/tests/contrib/spin_lock_spectroscopy/test_function_api.py
@@ -82,6 +82,34 @@ def test_spin_lock_spectroscopy_checks_hpi_pulse_before_measurement() -> None:
         )
 
 
+def test_spin_lock_spectroscopy_requires_rabi_params_with_calibration() -> None:
+    """Given reusable calibration, then Rabi params are still checked for normalization."""
+
+    class _Pulse:
+        @staticmethod
+        def get_hpi_pulse(_target: str) -> object:
+            return object()
+
+        @staticmethod
+        def validate_rabi_params(_targets: list[str]) -> None:
+            raise ValueError("Rabi parameters are not stored.")
+
+    exp: Any = SimpleNamespace(pulse=_Pulse())
+
+    with pytest.raises(ValueError, match="Rabi parameters"):
+        spin_lock_spectroscopy(
+            exp,
+            targets=["Q00"],
+            spin_lock_calibration={
+                "Q00": {
+                    "drive_amplitudes": np.array([0.0]),
+                    "qubit_frequencies": np.array([5.0]),
+                    "rabi_frequencies": np.array([0.0]),
+                }
+            },
+        )
+
+
 def test_validate_hpi_pulses_checks_each_target() -> None:
     """Given multiple targets, then half-pi pulse availability is checked for all."""
 

--- a/tests/contrib/spin_lock_spectroscopy/test_function_api.py
+++ b/tests/contrib/spin_lock_spectroscopy/test_function_api.py
@@ -17,51 +17,26 @@ from qubex.contrib.experiment import (
 )
 from qubex.contrib.experiment.spin_lock_spectroscopy import (
     _analyze_spin_lock_target,
+    _chevron_detuning_half_width_limit,
     _final_projection_phase,
     _final_projection_phase_maps,
+    _fit_data_without_figure,
     _frequency_sort_indices,
+    _make_spin_lock_heatmap_figure,
     _make_spin_lock_relaxation_figure,
-    _resolve_awg_max_frequency,
     _resolve_bool,
     _resolve_drive_detuning,
     _resolve_duration_range,
     _resolve_nonnegative_finite_float,
     _resolve_positive_integer,
+    _resolve_spin_lock_calibration,
+    _resolve_spin_lock_parameters_from_chevron_results,
     _scaled_chevron_ranges,
-    _validate_awg_frequency_ranges,
-    _validate_chevron_awg_frequency_range,
 )
 
 spin_lock_module = importlib.import_module(
     "qubex.contrib.experiment.spin_lock_spectroscopy"
 )
-
-
-def _make_awg_validation_exp(
-    *,
-    sideband: str,
-    nco_frequency: float,
-    awg_max_frequency_hz: float | None = 250_000_000,
-) -> Any:
-    class _ExperimentSystem:
-        @staticmethod
-        def get_target(_target: str) -> SimpleNamespace:
-            return SimpleNamespace(sideband=sideband)
-
-        @staticmethod
-        def get_nco_frequency(_target: str) -> float:
-            return nco_frequency
-
-    return SimpleNamespace(
-        ctx=SimpleNamespace(
-            experiment_system=_ExperimentSystem(),
-            measurement=SimpleNamespace(
-                constraint_profile=SimpleNamespace(
-                    awg_max_frequency_hz=awg_max_frequency_hz
-                )
-            ),
-        )
-    )
 
 
 def test_all_spin_lock_spectroscopy_functions_are_exported_from_contrib() -> None:
@@ -76,16 +51,14 @@ def test_all_spin_lock_spectroscopy_functions_are_exported_from_experiment() -> 
     assert experiment_spin_lock_spectroscopy is spin_lock_spectroscopy
 
 
-def test_default_spin_lock_frequency_range_is_log_spaced_to_150_mhz() -> None:
-    """Given defaults, when inspected, then the Rabi-frequency range reaches 150 MHz."""
+def test_default_spin_lock_frequency_range_uses_tangent_spacing_to_120_mhz() -> None:
+    """Given defaults, when inspected, then the Rabi-frequency range uses tangent spacing."""
     frequency_range = spin_lock_module.DEFAULT_SPIN_LOCK_FREQUENCY_RANGE
+    expected = 0.01 + 0.11 * np.tan(np.pi / 3 * np.linspace(0, 1, 12)) / np.sqrt(3)
 
+    np.testing.assert_allclose(frequency_range, expected)
     assert frequency_range[0] == pytest.approx(0.01)
-    assert frequency_range[-1] == pytest.approx(0.15)
-    np.testing.assert_allclose(
-        np.diff(np.log(frequency_range)),
-        np.diff(np.log(frequency_range))[0],
-    )
+    assert frequency_range[-1] == pytest.approx(0.12)
 
 
 def test_scaled_chevron_ranges_match_reference_at_12p5_mhz() -> None:
@@ -104,7 +77,7 @@ def test_scaled_chevron_ranges_match_reference_at_12p5_mhz() -> None:
     exp: Any = SimpleNamespace(
         ctx=SimpleNamespace(
             util=_Util(),
-            measurement=SimpleNamespace(sampling_period=10.0),
+            measurement=SimpleNamespace(sampling_period=2.0),
         )
     )
 
@@ -148,8 +121,8 @@ def test_scaled_chevron_ranges_shorten_time_for_larger_rabi_rate() -> None:
     assert omega_rabi_range[-1] == pytest.approx(0.05)
 
 
-def test_scaled_chevron_ranges_caps_detuning_span_at_200_mhz() -> None:
-    """Given strong drive, then chevron detuning span is capped at +/-200 MHz."""
+def test_scaled_chevron_ranges_caps_detuning_span_by_sampling_nyquist() -> None:
+    """Given strong drive, then chevron detuning span is capped by sampling Nyquist."""
 
     class _Util:
         @staticmethod
@@ -172,9 +145,10 @@ def test_scaled_chevron_ranges_caps_detuning_span_at_200_mhz() -> None:
         expected_rabi_frequency=0.2,
     )
 
-    assert detuning_range[0] == pytest.approx(-0.2)
-    assert detuning_range[-1] == pytest.approx(0.2)
-    assert time_range[-1] == pytest.approx(15.625)
+    assert detuning_range[0] == pytest.approx(-0.4)
+    assert detuning_range[-1] == pytest.approx(0.4)
+    assert time_range.size == spin_lock_module.CHEVRON_TIME_POINTS
+    assert time_range[-1] == pytest.approx(25.0)
     assert omega_rabi_range[-1] == pytest.approx(0.4)
 
 
@@ -207,8 +181,8 @@ def test_scaled_chevron_ranges_rounds_time_to_sampling_grid() -> None:
     np.testing.assert_allclose(time_range / 7.0, np.round(time_range / 7.0))
 
 
-def test_scaled_chevron_ranges_rejects_too_few_time_points() -> None:
-    """Given a coarse sampling grid, then an unusable chevron time range is rejected."""
+def test_scaled_chevron_ranges_keeps_time_point_count_on_coarse_grid() -> None:
+    """Given a coarse sampling grid, then chevron time point count is preserved."""
 
     class _Util:
         @staticmethod
@@ -227,113 +201,142 @@ def test_scaled_chevron_ranges_rejects_too_few_time_points() -> None:
         )
     )
 
-    with pytest.raises(ValueError, match="chevron time_range"):
-        _scaled_chevron_ranges(
-            exp,
-            expected_rabi_frequency=0.2,
-        )
-
-
-def test_validate_chevron_awg_frequency_range_accepts_reachable_span() -> None:
-    """Given reachable drive frequencies, then current NCO validation passes."""
-    exp = _make_awg_validation_exp(sideband="U", nco_frequency=5.0)
-
-    _validate_chevron_awg_frequency_range(
+    _, time_range, _ = _scaled_chevron_ranges(
         exp,
-        targets=["Q00"],
-        base_frequencies={"Q00": 5.0},
-        detuning_range=np.array([-0.2, 0.0, 0.2]),
+        expected_rabi_frequency=0.2,
     )
 
+    assert time_range.size == spin_lock_module.CHEVRON_TIME_POINTS
+    np.testing.assert_allclose(np.diff(time_range), 1000.0)
 
-def test_validate_chevron_awg_frequency_range_rejects_unreachable_span() -> None:
-    """Given unreachable drive frequencies, then current NCO validation fails."""
-    exp = _make_awg_validation_exp(sideband="U", nco_frequency=5.0)
 
-    with pytest.raises(ValueError, match="AWG modulation"):
-        _validate_chevron_awg_frequency_range(
-            exp,
+def test_chevron_detuning_half_width_limit_uses_sampling_period_nyquist() -> None:
+    """Given a sampling grid, then the detuning cap is 80% of Nyquist."""
+    exp: Any = SimpleNamespace(
+        ctx=SimpleNamespace(measurement=SimpleNamespace(sampling_period=2.0))
+    )
+
+    assert _chevron_detuning_half_width_limit(exp) == pytest.approx(0.2)
+
+
+def test_resolve_spin_lock_parameters_reuses_supplied_chevron_results() -> None:
+    """Given previous chevron metadata, then measured axes are recovered from it."""
+    chevron_results = {
+        "Q00": [
+            {
+                "requested_rabi_frequency": 0.01,
+                "drive_amplitude": 0.1,
+                "qubit_frequency": 5.001,
+                "rabi_frequency": 0.011,
+            },
+            {
+                "requested_rabi_frequency": 0.02,
+                "drive_amplitude": 0.2,
+                "qubit_frequency": 5.004,
+                "rabi_frequency": 0.021,
+            },
+        ]
+    }
+
+    qubit_frequency_map, rabi_frequency_map, resolved_results = (
+        _resolve_spin_lock_parameters_from_chevron_results(
             targets=["Q00"],
-            base_frequencies={"Q00": 5.1},
-            detuning_range=np.array([-0.2, 0.0, 0.2]),
+            requested_rabi_frequency_range=np.array([0.01, 0.02]),
+            amplitude_map={"Q00": np.array([0.1, 0.2])},
+            chevron_results=chevron_results,
+        )
+    )
+
+    np.testing.assert_allclose(qubit_frequency_map["Q00"], [5.001, 5.004])
+    np.testing.assert_allclose(rabi_frequency_map["Q00"], [0.011, 0.021])
+    assert resolved_results == chevron_results
+
+
+def test_resolve_spin_lock_parameters_rejects_mismatched_chevron_results() -> None:
+    """Given stale chevron metadata, then reuse is rejected before measurement."""
+    chevron_results = {
+        "Q00": [
+            {
+                "requested_rabi_frequency": 0.03,
+                "drive_amplitude": 0.1,
+                "qubit_frequency": 5.001,
+                "rabi_frequency": 0.011,
+            }
+        ]
+    }
+
+    with pytest.raises(ValueError, match="requested_rabi_frequency"):
+        _resolve_spin_lock_parameters_from_chevron_results(
+            targets=["Q00"],
+            requested_rabi_frequency_range=np.array([0.01]),
+            amplitude_map={"Q00": np.array([0.1])},
+            chevron_results=chevron_results,
         )
 
 
-def test_validate_awg_frequency_range_accepts_lower_sideband_span() -> None:
-    """Given lower sideband, then AWG validation uses NCO minus drive frequency."""
-    exp = _make_awg_validation_exp(sideband="L", nco_frequency=5.0)
+def test_resolve_spin_lock_parameters_requires_matching_chevron_metadata() -> None:
+    """Given incomplete previous metadata, then reuse is rejected."""
+    chevron_results = {
+        "Q00": [
+            {
+                "drive_amplitude": 0.1,
+                "qubit_frequency": 5.001,
+                "rabi_frequency": 0.011,
+            }
+        ]
+    }
 
-    _validate_awg_frequency_ranges(
-        exp,
+    with pytest.raises(ValueError, match="requested_rabi_frequency"):
+        _resolve_spin_lock_parameters_from_chevron_results(
+            targets=["Q00"],
+            requested_rabi_frequency_range=np.array([0.01]),
+            amplitude_map={"Q00": np.array([0.1])},
+            chevron_results=chevron_results,
+        )
+
+
+def test_resolve_spin_lock_calibration_reuses_provided_chevron_without_measuring(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given previous chevron metadata, then calibration skips new chevron sweeps."""
+
+    def _unexpected_chevron_measurement(**_kwargs: Any) -> None:
+        raise AssertionError("Chevron measurement should not be called.")
+
+    monkeypatch.setattr(
+        spin_lock_module,
+        "_estimate_spin_lock_parameters_with_chevron",
+        _unexpected_chevron_measurement,
+    )
+
+    calibration = _resolve_spin_lock_calibration(
+        object(),  # type: ignore[arg-type]
         targets=["Q00"],
-        drive_frequency_ranges={"Q00": np.array([4.8, 4.9, 5.0])},
-        description="test frequencies",
+        requested_rabi_frequency_range=np.array([0.01]),
+        amplitude_map={"Q00": np.array([0.1])},
+        base_frequencies={"Q00": 5.0},
+        estimate_with_chevron=True,
+        chevron_results={
+            "Q00": [
+                {
+                    "requested_rabi_frequency": 0.01,
+                    "drive_amplitude": 0.1,
+                    "qubit_frequency": 5.001,
+                    "rabi_frequency": 0.011,
+                }
+            ]
+        },
+        chevron_n_shots=10,
+        n_shots=100,
+        shot_interval=0.0,
+        return_chevron_figures=True,
     )
 
-
-def test_validate_awg_frequency_range_skips_unknown_backend_limit() -> None:
-    """Given no AWG limit in profile, then validation is left to the backend."""
-    exp = _make_awg_validation_exp(
-        sideband="U",
-        nco_frequency=5.0,
-        awg_max_frequency_hz=None,
-    )
-
-    _validate_awg_frequency_ranges(
-        exp,
-        targets=["Q00"],
-        drive_frequency_ranges={"Q00": np.array([5.0, 6.0])},
-        description="test frequencies",
-    )
-
-
-def test_resolve_awg_max_frequency_skips_legacy_context_without_profile() -> None:
-    """Given old fake measurement context, then AWG validation is skipped."""
-    exp: Any = SimpleNamespace(ctx=SimpleNamespace(measurement=SimpleNamespace()))
-
-    assert _resolve_awg_max_frequency(exp) is None
-
-
-def test_resolve_awg_max_frequency_uses_quel1_like_profile() -> None:
-    """Given QuEL-1-like constraints, then the contrib fallback uses QuEL-1 AWG limit."""
-    exp: Any = SimpleNamespace(
-        ctx=SimpleNamespace(
-            measurement=SimpleNamespace(
-                constraint_profile=SimpleNamespace(
-                    sampling_period_ns=2.0,
-                    word_length_samples=4,
-                    block_length_samples=64,
-                    require_workaround_capture=True,
-                    enforce_word_alignment=True,
-                    enforce_block_alignment=True,
-                    enforce_capture_spacing=True,
-                )
-            )
-        )
-    )
-
-    assert _resolve_awg_max_frequency(exp) == pytest.approx(0.25)
-
-
-def test_resolve_awg_max_frequency_skips_non_quel1_strict_profile() -> None:
-    """Given strict non-QuEL-1 constraints, then no QuEL-1 AWG limit is assumed."""
-    exp: Any = SimpleNamespace(
-        ctx=SimpleNamespace(
-            measurement=SimpleNamespace(
-                constraint_profile=SimpleNamespace(
-                    sampling_period_ns=0.4,
-                    word_length_samples=4,
-                    block_length_samples=64,
-                    require_workaround_capture=True,
-                    enforce_word_alignment=True,
-                    enforce_block_alignment=True,
-                    enforce_capture_spacing=True,
-                )
-            )
-        )
-    )
-
-    assert _resolve_awg_max_frequency(exp) is None
+    assert calibration.chevron_source == "provided"
+    assert calibration.chevron_n_shots is None
+    assert calibration.chevron_figures == {}
+    np.testing.assert_allclose(calibration.qubit_frequency_map["Q00"], [5.001])
+    np.testing.assert_allclose(calibration.rabi_frequency_map["Q00"], [0.011])
 
 
 def test_frequency_sort_indices_sorts_nonmonotonic_axis() -> None:
@@ -401,6 +404,23 @@ def test_spin_lock_relaxation_figure_yaxis_starts_at_zero() -> None:
 
     assert fig.layout.yaxis.range[0] == 0
     assert fig.layout.yaxis.title.text == "Relaxation time (μs)"
+    assert fig.layout.xaxis.type == "linear"
+
+
+def test_spin_lock_heatmap_figure_uses_linear_frequency_axis() -> None:
+    """Given heatmap data, then the spin-lock frequency axis is linear."""
+    fig = _make_spin_lock_heatmap_figure(
+        target="Q00",
+        spin_lock_rabi_frequency_range=np.array([0.01, 0.02]),
+        duration_range=np.array([100.0, 200.0, 300.0]),
+        population=np.ones((3, 2)),
+    )
+
+    assert fig.layout.xaxis.type == "linear"
+    assert fig.layout.yaxis.type == "log"
+    heatmap_trace: Any = fig.data[0]
+    assert heatmap_trace.zmin == 0
+    assert heatmap_trace.zmax == 1
 
 
 def test_analyze_spin_lock_target_returns_expected_shapes_and_figures(
@@ -417,7 +437,10 @@ def test_analyze_spin_lock_target_returns_expected_shapes_and_figures(
             super().__init__(**kwargs)
             self.data = dict(self)
 
-    def _fit_exp_decay(**_kwargs: Any) -> _FitResult:
+    fit_kwargs: list[dict[str, Any]] = []
+
+    def _fit_exp_decay(**kwargs: Any) -> _FitResult:
+        fit_kwargs.append(kwargs)
         return _FitResult(tau=1000.0, tau_err=100.0, r2=0.99)
 
     monkeypatch.setattr(spin_lock_module.fitting, "fit_exp_decay", _fit_exp_decay)
@@ -442,6 +465,7 @@ def test_analyze_spin_lock_target_returns_expected_shapes_and_figures(
     assert analysis.population.shape == (3, 2)
     np.testing.assert_allclose(analysis.relaxation_times, [1000.0, 1000.0])
     np.testing.assert_allclose(analysis.sort_indices, [1, 0])
+    assert {kwargs["xlabel"] for kwargs in fit_kwargs} == {"Duration (ns)"}
     assert "Q00_heatmap" in analysis.figures
     assert "Q00_relaxation" in analysis.figures
 
@@ -493,6 +517,31 @@ def test_resolve_duration_range_rejects_too_few_fit_points() -> None:
 
     with pytest.raises(ValueError, match="duration_range"):
         _resolve_duration_range(exp, [9.0, 11.0, 21.0])
+
+
+def test_resolve_duration_range_rejects_invalid_sampling_period() -> None:
+    """Given an invalid sampling period, then duration discretization is rejected."""
+    exp: Any = SimpleNamespace(
+        ctx=SimpleNamespace(
+            util=SimpleNamespace(),
+            measurement=SimpleNamespace(sampling_period=0.0),
+        )
+    )
+
+    with pytest.raises(ValueError, match="sampling_period"):
+        _resolve_duration_range(exp, [10.0, 20.0, 30.0])
+
+
+def test_fit_data_without_figure_tolerates_missing_data_attribute() -> None:
+    """Given a nonstandard fit result, then no figure payload is returned."""
+    assert _fit_data_without_figure(SimpleNamespace()) == {}
+
+
+def test_fit_data_without_figure_drops_embedded_figure() -> None:
+    """Given fit result data, then embedded figure payload is omitted."""
+    fit_result = SimpleNamespace(data={"tau": 100.0, "fig": object()})
+
+    assert _fit_data_without_figure(fit_result) == {"tau": 100.0}
 
 
 def test_resolve_drive_detuning_rejects_nonfinite_values() -> None:

--- a/tests/contrib/spin_lock_spectroscopy/test_function_api.py
+++ b/tests/contrib/spin_lock_spectroscopy/test_function_api.py
@@ -36,6 +36,7 @@ from qubex.contrib.experiment.spin_lock_spectroscopy import (
     _resolve_spin_lock_calibration,
     _resolve_spin_lock_parameters_from_calibration,
     _scaled_chevron_ranges,
+    _validate_hpi_pulses,
 )
 
 spin_lock_module = importlib.import_module(
@@ -53,6 +54,51 @@ def test_all_spin_lock_spectroscopy_functions_are_exported_from_experiment() -> 
     """Given experiment package, when imported, then spin-lock helpers are available."""
     assert experiment_spin_lock_sequence is spin_lock_sequence
     assert experiment_spin_lock_spectroscopy is spin_lock_spectroscopy
+
+
+def test_spin_lock_spectroscopy_checks_hpi_pulse_before_measurement() -> None:
+    """Given unavailable half-pi pulse, then spectroscopy fails before calibration."""
+
+    class _Pulse:
+        def get_hpi_pulse(self, target: str) -> None:
+            raise ValueError(f"hpi pulse for {target} is unavailable.")
+
+        def validate_rabi_params(self, _targets: list[str]) -> None:
+            raise AssertionError("Rabi validation should not run after hpi failure.")
+
+    exp: Any = SimpleNamespace(pulse=_Pulse())
+
+    with pytest.raises(ValueError, match="hpi pulse"):
+        spin_lock_spectroscopy(
+            exp,
+            targets=["Q00"],
+            spin_lock_calibration={
+                "Q00": {
+                    "drive_amplitudes": np.array([0.0]),
+                    "qubit_frequencies": np.array([5.0]),
+                    "rabi_frequencies": np.array([0.0]),
+                }
+            },
+        )
+
+
+def test_validate_hpi_pulses_checks_each_target() -> None:
+    """Given multiple targets, then half-pi pulse availability is checked for all."""
+
+    class _Pulse:
+        def __init__(self) -> None:
+            self.targets: list[str] = []
+
+        def get_hpi_pulse(self, target: str) -> object:
+            self.targets.append(target)
+            return object()
+
+    pulse = _Pulse()
+    exp: Any = SimpleNamespace(pulse=pulse)
+
+    _validate_hpi_pulses(exp, ["Q00", "Q01"])
+
+    assert pulse.targets == ["Q00", "Q01"]
 
 
 def test_default_spin_lock_frequency_range_uses_tangent_spacing_to_120_mhz() -> None:
@@ -696,7 +742,7 @@ def test_analyze_spin_lock_target_returns_expected_shapes_and_figures(
     assert analysis.normalized_signal.shape == (3, 2)
     assert analysis.population.shape == (3, 2)
     np.testing.assert_allclose(analysis.relaxation_times, [1000.0, 1000.0])
-    assert {kwargs["xlabel"] for kwargs in fit_kwargs} == {"Duration (ns)"}
+    assert {kwargs["xlabel"] for kwargs in fit_kwargs} == {"Duration (μs)"}
     assert "Q00_heatmap" in analysis.figures
     assert "Q00_relaxation" in analysis.figures
     heatmap_figure: Any = analysis.figures["Q00_heatmap"]


### PR DESCRIPTION
## Summary

- Add `spin_lock_sequence()` and `spin_lock_spectroscopy()` contrib APIs
- Measure spin-lock decay over Rabi-frequency and duration sweeps in a single `sweep_parameter()` call
- Optionally run chevron pre-calibration to determine drive amplitudes, AC-Stark-shifted qubit frequencies, and measured Rabi frequencies
- Store reusable `spin_lock_calibration` data for later runs
- Add heatmap, relaxation-time plots, fit summaries, and API coverage

## Test

- `make check`