### PR TITLE
fix: cap NumPy below 2.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,7 +22,7 @@ dependencies = [
     "kaleido == 0.2.1",
     "networkx >= 2.7",
     "nbformat >= 5.0",
-    "numpy >= 1.22",
+    "numpy >= 1.22, <2.4",
     # Plotly v6 FigureWidget uses anywidget and can persist a multi-MB _esm bundle
     # per widget in notebook metadata.widgets, making saved .ipynb files very large.
     "plotly >= 5.23, <6",

--- a/uv.lock
+++ b/uv.lock
@@ -3488,7 +3488,7 @@ requires-dist = [
     { name = "kaleido", specifier = "==0.2.1" },
     { name = "nbformat", specifier = ">=5.0" },
     { name = "networkx", specifier = ">=2.7" },
-    { name = "numpy", specifier = ">=1.22" },
+    { name = "numpy", specifier = ">=1.22,<2.4" },
     { name = "plotly", specifier = ">=5.23,<6" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyserial", specifier = ">=3.5" },


### PR DESCRIPTION
## Background

NumPy 2.4 expires deprecations that Qubex currently relies on, including removal of `np.trapz` and rejection of converting non-zero-dimensional arrays to Python scalars. These changes cause calibration workflows such as chevron analysis and Bell-state tomography to fail at runtime.

## Summary

- constrain the Qubex runtime dependency to `numpy >=1.22,<2.4`
- refresh `uv.lock` with the matching package metadata

## Compatibility

This is a temporary compatibility boundary. Existing NumPy 1.x through 2.3 environments remain supported. NumPy 2.4 support should be restored after the affected runtime code is updated and validated against NumPy 2.4.

No public API or result format changes are included. No documentation changes are required because installation steps remain unchanged and the dependency policy already permits upper bounds for known incompatibilities.

## Verification

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright` — 0 errors
- `make check-release-version` — synchronized at 1.5.0rc2
- `uv run pytest` — 1152 passed

## Follow-up

- replace removed/deprecated NumPy APIs and explicit array-to-scalar conversions
- add NumPy 2.4 coverage before removing the upper bound

## Related
- https://github.com/numpy/numpy/pull/29841
- https://github.com/numpy/numpy/pull/29997