### PR TITLE
fix: support NumPy 2.4 without a dependency cap

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -140,6 +140,7 @@ select = [
     "PT",   # flake8-pytest-style
     "TID",  # flake8-tidy-imports
     "I",    # isort
+    "NPY201", # NumPy 2.0 removed APIs
     "PERF", # Perflint
     "E",    # pycodestyle
     "D",    # pydocstyle

--- a/src/qubex/analysis/fitting.py
+++ b/src/qubex/analysis/fitting.py
@@ -1661,8 +1661,8 @@ def fit_sqrt_lorentzian(
 def fit_rabi(
     *,
     target: str,
-    times: NDArray,
-    data: NDArray,
+    times: NDArray[np.float64],
+    data: NDArray[np.complex64],
     tau_est: float | None = None,
     reference_point: complex | None = None,
     plot: bool = True,

--- a/src/qubex/analysis/state_tomography.py
+++ b/src/qubex/analysis/state_tomography.py
@@ -126,7 +126,7 @@ def mle_fit_density_matrix(
 
 
 def plot_ghz_state_tomography(
-    rho: NDArray,
+    rho: NDArray[np.complex64],
     qubits: list[str],
     fidelity: float,
     width: int,

--- a/src/qubex/compat/numpy_compat.py
+++ b/src/qubex/compat/numpy_compat.py
@@ -1,0 +1,8 @@
+"""Compatibility helpers for NumPy API changes."""
+
+import numpy as np
+
+try:
+    trapezoid = np.trapezoid  # pyright: ignore[reportAttributeAccessIssue]
+except AttributeError:
+    trapezoid = np.trapz  # pyright: ignore[reportAttributeAccessIssue]

--- a/src/qubex/contrib/experiment/chevron_matched_transform.py
+++ b/src/qubex/contrib/experiment/chevron_matched_transform.py
@@ -10,6 +10,7 @@ from numpy.typing import ArrayLike
 from qxpulse import Rect, get_sampling_period
 
 import qubex.visualization as viz
+from qubex.compat.numpy_compat import trapezoid
 from qubex.experiment import Experiment
 from qubex.experiment.experiment_constants import (
     DEFAULT_INTERVAL,
@@ -749,8 +750,8 @@ def _measure_and_analyze_chevron(
     # The matched-transform resonance search intentionally spans about twice
     # the measured detuning interval so a peak near the edge is still captured.
     omega_q_range = np.linspace(
-        frequency + 2 * np.min(detuning_range),
-        frequency + 2 * np.max(detuning_range),
+        frequency + 2 * np.min(np.asarray(detuning_range)),
+        frequency + 2 * np.max(np.asarray(detuning_range)),
         1024,
     )
 
@@ -1242,13 +1243,13 @@ def analyze_chevron_matched_transform(
 
         integrand = f_expanded * kernel
 
-        tmp = np.trapz(
+        tmp = trapezoid(
             integrand,
             x=time_range,
             axis=0,
         )
 
-        transform[i] = np.trapz(
+        transform[i] = trapezoid(
             tmp,
             x=omega_d,
             axis=0,

--- a/src/qubex/contrib/experiment/ckp_characterization.py
+++ b/src/qubex/contrib/experiment/ckp_characterization.py
@@ -45,6 +45,7 @@ from tqdm import tqdm
 
 import qubex.visualization as viz
 from qubex.analysis import fitting
+from qubex.compat.numpy_compat import trapezoid
 from qubex.experiment import Experiment
 from qubex.experiment.experiment_constants import DEFAULT_SHOTS
 from qubex.experiment.models import Result
@@ -1410,9 +1411,9 @@ def estimate_filtered_ckp_initial_params(
     x = x[order]
     delta = delta[order]
 
-    M0 = np.trapz(delta, x)
-    M1 = np.trapz(x * delta, x)
-    M2 = np.trapz((x**2) * delta, x)
+    M0 = trapezoid(delta, x)
+    M1 = trapezoid(x * delta, x)
+    M2 = trapezoid((x**2) * delta, x)
 
     if np.abs(M0) < 1e-18:
         raise ValueError("Moment M0 is too small.")

--- a/src/qubex/contrib/experiment/measure_efh_chevron_pattern.py
+++ b/src/qubex/contrib/experiment/measure_efh_chevron_pattern.py
@@ -1126,8 +1126,8 @@ def _measure_and_analyze_fh_chevron(
     )
 
     omega_q_range = np.linspace(
-        frequency + 2 * np.min(detuning_range),
-        frequency + 2 * np.max(detuning_range),
+        frequency + 2 * np.min(np.asarray(detuning_range)),
+        frequency + 2 * np.max(np.asarray(detuning_range)),
         1024,
     )
 
@@ -1177,8 +1177,8 @@ def _measure_and_analyze_ef_chevron(
     )
 
     omega_q_range = np.linspace(
-        frequency + 2 * np.min(detuning_range),
-        frequency + 2 * np.max(detuning_range),
+        frequency + 2 * np.min(np.asarray(detuning_range)),
+        frequency + 2 * np.max(np.asarray(detuning_range)),
         1024,
     )
 

--- a/src/qubex/contrib/experiment/purity_benchmarking.py
+++ b/src/qubex/contrib/experiment/purity_benchmarking.py
@@ -383,7 +383,7 @@ def pb_experiment_1q(
             sweep_range.append(n_clifford)
 
             trial_data = defaultdict(list)
-            for seed in seeds:
+            for seed in np.asarray(seeds):
                 seed = int(seed)
                 result = exp.measurement_service.measure(
                     sequence=pb_sequence(
@@ -609,7 +609,7 @@ def pb_experiment_2q(
             sweep_range.append(n_clifford)
 
             trial_data = defaultdict(list)
-            for seed in seeds:
+            for seed in np.asarray(seeds):
                 seed = int(seed)
                 result = exp.measurement_service.measure(
                     sequence=pb_sequence(

--- a/src/qubex/experiment/models/experiment_result.py
+++ b/src/qubex/experiment/models/experiment_result.py
@@ -131,6 +131,8 @@ class RabiData(TargetData):
         Centers of the states.
     """
 
+    data: NDArray[np.complexfloating[Any, Any]]
+
     time_range: NDArray
     rabi_param: RabiParam
     state_centers: dict[int, complex] | None = None
@@ -298,6 +300,8 @@ class SweepData(TargetData):
     yaxis_type : str, optional
         Type of the y-axis.
     """
+
+    data: NDArray[np.complexfloating[Any, Any]]
 
     sweep_range: NDArray
     rabi_param: RabiParam | None = None

--- a/src/qubex/experiment/services/benchmarking_service.py
+++ b/src/qubex/experiment/services/benchmarking_service.py
@@ -404,7 +404,7 @@ class BenchmarkingService:
                 sweep_range.append(n_clifford)
 
                 trial_data = defaultdict(list)
-                for seed in seeds:
+                for seed in np.asarray(seeds):
                     seed = int(seed)  # Ensure seed is an integer
                     result = self.measurement_service.measure(
                         sequence=rb_sequence(
@@ -633,7 +633,7 @@ class BenchmarkingService:
                 sweep_range.append(n_clifford)
 
                 trial_data = defaultdict(list)
-                for seed in seeds:
+                for seed in np.asarray(seeds):
                     seed = int(seed)  # Ensure seed is an integer
                     result = self.measurement_service.measure(
                         sequence=rb_sequence(

--- a/src/qubex/experiment/services/measurement_service.py
+++ b/src/qubex/experiment/services/measurement_service.py
@@ -2756,7 +2756,7 @@ class MeasurementService:
 
         sequences = [
             {
-                target: self.partial_waveform(pulse, i)
+                target: self.partial_waveform(pulse, int(i))
                 for target, pulse in flattened_pulses.items()
             }
             for i in indices
@@ -3265,10 +3265,10 @@ class MeasurementService:
         bell_state = np.zeros((dim, 1), dtype=np.complex128)
         bell_state[0, 0] = 1 / np.sqrt(2)
         bell_state[-1, 0] = 1 / np.sqrt(2)
-        fidelity = float(np.real(bell_state.T.conj() @ rho @ bell_state))
+        fidelity = np.real(bell_state.T.conj() @ rho @ bell_state).item()
 
         fig = plot_ghz_state_tomography(
-            rho=rho,
+            rho=np.asarray(rho, dtype=np.complex64),
             qubits=[control_qubit, target_qubit],
             fidelity=fidelity,
             plot=plot,

--- a/src/qubex/measurement/models/measure_result.py
+++ b/src/qubex/measurement/models/measure_result.py
@@ -153,7 +153,7 @@ class MeasureData:
     def times(self) -> NDArray[np.float64]:
         """Return capture times for the measurement mode."""
         if self.mode in (MeasureMode.SINGLE, MeasureMode.AVG):
-            return np.arange(self.length) * self.sampling_period
+            return np.arange(self.length, dtype=np.float64) * self.sampling_period
         raise ValueError(f"Invalid mode: {self.mode}")
 
     @cached_property

--- a/src/qubex/measurement/services/measurement_classification_service.py
+++ b/src/qubex/measurement/services/measurement_classification_service.py
@@ -57,12 +57,16 @@ class MeasurementClassificationService:
         npt.NDArray
             Kronecker-product confusion matrix.
         """
+        if len(targets) == 0:
+            return np.array([[1.0]], dtype=np.float64)
+
         target_list = list(targets)
-        confusion_matrices = []
+        confusion_matrices: list[NDArray[np.float64]] = []
         for target in target_list:
             cm = self.classifiers[target].confusion_matrix
             confusion_matrices.append(_normalize_confusion_matrix_rows(cm))
-        return reduce(np.kron, confusion_matrices)
+
+        return np.asarray(reduce(np.kron, confusion_matrices), np.float64)
 
     def get_inverse_confusion_matrix(
         self,


### PR DESCRIPTION
## Background

NumPy 2.4 surfaces API and typing incompatibilities in the current codebase. PR #354 avoids them by capping NumPy below 2.4; this PR keeps the existing `numpy >= 1.22` contract and fixes the incompatibilities instead.

## Changes

- add a compatibility helper that uses `numpy.trapezoid` when available and falls back to `numpy.trapz`
- normalize ArrayLike ranges, seeds, indices, and scalar results at NumPy/service boundaries
- make complex array and measurement dtypes explicit
- define the empty confusion-matrix Kronecker product as a 1x1 identity matrix

## Impact

No migration is required. Existing inputs remain accepted, older NumPy releases remain supported, and NumPy 2.4 no longer needs a dependency cap.

Calling `get_confusion_matrix([])` now returns `[[1.0]]` instead of failing during reduction.

## Validation

- `uv run ruff check --fix`
- `uv run ruff format`
- `uv run pyright`
- focused pytest selection: 24 passed
- `uv run --isolated --python 3.12 --frozen --extra backend --with 'numpy>=2.4' python -m pyright src/`
- `uv run --isolated --python 3.13 --frozen --extra backend --with 'numpy>=2.4' python -m pyright src/`

The full pytest suite was not completed locally.