### PR TITLE
docs: propose experiment task API design

### DIFF
--- a/docs/developer-notes/experiment-task-api-design.md
+++ b/docs/developer-notes/experiment-task-api-design.md
@@ -4,7 +4,7 @@
 
 - State: `PROPOSED`
 - Created: `2026-08-24`
-- Updated: `2026-08-27`
+- Updated: `2026-08-31`
 - Scope: task-based experiment execution below the `Experiment` facade
 - Discussion:
   - [Qubex issue #357](https://github.com/amachino/qubex/issues/357)
@@ -398,19 +398,28 @@ The Service preserves the existing interactive contract around the Task:
 
 ```python
 class CharacterizationService:
-    async def _execute_qubit_spectroscopy(...) -> Result:
+    def qubit_spectroscopy(self, ...) -> Result:
         task = QubitSpectroscopyTask.from_context(self.ctx, ...)
-        task_result = await task.run(self._runtime)
+        task_result = self.async_bridge.run(
+            lambda: task.run(self.runtime)
+        )
 
-        figure = self._make_qubit_spectroscopy_figure(task_result)
-        self._show_or_save_figure(figure, ...)
-
-        return self._to_result(task_result, figure)
+        # Create a figure from task_result and display or save it
+        # according to the existing settings.
+        # Adapt task_result to the existing Result contract.
+        return Result(...)
 ```
 
-An existing synchronous facade method can call this canonical async path
-through a compatibility adapter, while an async facade method can await it
-directly.
+The existing synchronous `qubit_spectroscopy(...) -> Result` API remains
+unchanged. The Service delegates execution to the asynchronous Task through a
+compatibility bridge, without introducing a private execution method. The
+`Experiment.qubit_spectroscopy(...)` facade continues to delegate to this
+Service method, so existing callers do not need to use `await`.
+
+This schematic example omits the existing arguments and their forwarding,
+figure and result construction, and bridge initialization and lifecycle
+management. Existing argument defaults, result semantics, and display and
+save behavior remain part of the compatibility contract.
 
 ## Compatibility and migration
 

--- a/docs/developer-notes/experiment-task-api-design.md
+++ b/docs/developer-notes/experiment-task-api-design.md
@@ -22,9 +22,9 @@ Introduce a common task-based execution layer below the human-facing
 
 An experiment Task contains the fully resolved parameters and
 experiment-specific execution flow. It exposes the effective parameters before
-execution and runs against an `ExperimentRuntime` that provides only the
-capabilities needed by that Task. It does not read or update `CalibrationNote`
-during execution.
+execution and runs asynchronously against an `ExperimentRuntime` that provides
+only the capabilities needed by that Task. It does not read or update
+`CalibrationNote` during execution.
 
 `Experiment` remains a concise entry point for interactive use. A Service
 constructs a Task from the current context, runs it, and owns optional policy
@@ -74,6 +74,8 @@ re-execution harder to reason about.
   coupling them to the complete `ExperimentContext`.
 - Support the temporary hardware-control operations required within experiment
   flows through narrowly scoped runtime capabilities.
+- Use one async-first Task execution path while keeping synchronous
+  compatibility adapters outside the Task layer.
 - Allow the Task and runtime contracts to be distributed independently of a
   concrete backend execution engine.
 - Keep backend-specific operations available through explicit capabilities
@@ -101,7 +103,7 @@ re-execution harder to reason about.
 ### Resolve before execution
 
 A Task must contain all values that affect its measurement conditions,
-sweeps, search initial values, and analysis behavior before `run()` starts.
+sweeps, search initial values, and analysis behavior before execution begins.
 Required values that remain unresolved must produce an error before hardware
 execution.
 
@@ -153,6 +155,23 @@ The runtime may therefore expose narrowly scoped measurement and temporary
 system-control capabilities. It must not expose the complete
 `ExperimentContext`, `CalibrationNote`, visualization, or persistence services.
 
+### Keep Task execution async-first
+
+The canonical Task API is asynchronous because measurement and temporary
+system-control operations are asynchronous. Calling `run(runtime)` returns an
+awaitable; `await task.run(runtime)` produces the ordinary task-specific
+`ResultT`. The result object itself is not an asynchronous result or job handle.
+
+If an existing `Experiment` or Service API must remain synchronous for backward
+compatibility, its adapter may bridge to the canonical asynchronous path. That
+bridge belongs outside the Task and must not create a second Task execution
+implementation.
+
+A backend that queues remote work may additionally need a submission API that
+returns a job handle for status, cancellation, and later result retrieval. That
+distributed job model is separate from the Task result contract and remains an
+open design question.
+
 ### Invert the dependency at the Task-runtime boundary
 
 The client-facing Task contract owns the `ExperimentRuntime` capability
@@ -168,10 +187,10 @@ Experiment -> Task -> ExperimentRuntime interface <- runtime implementation
 
 This boundary permits the client-facing library and backend execution engine to
 live in separate distributions or repositories. It does not require that they
-do so immediately, and it does not decide whether `Task.run()` executes in the
-client process against a remote runtime proxy or in the backend process against
-a direct runtime implementation. Both deployment models should preserve the
-same Task and capability contracts.
+do so immediately, and it does not decide whether `await Task.run()` executes
+in the client process against a remote runtime proxy or in the backend process
+against a direct runtime implementation. Both deployment models should
+preserve the same Task and capability contracts.
 
 If execution crosses a process or network boundary, the in-process
 `ExperimentRuntime` interface and the serialized transport contract are
@@ -258,12 +277,12 @@ There are two supported construction paths:
 ```text
 Interactive use
 
-Experiment -> Service -> Task.from_context(...) -> Task.run(runtime)
+Experiment -> Service -> Task.from_context(...) -> await Task.run(runtime)
                        -> Service-side adaptation and optional state update
 
 System-facing use
 
-External workflow -> Task(explicit parameters) -> Task.run(runtime)
+External workflow -> Task(explicit parameters) -> await Task.run(runtime)
                   -> workflow-owned validation and persistence
 ```
 
@@ -303,8 +322,8 @@ grouped models, explicit fields, or a combination is not decided here.
 ### Execution
 
 After construction, the Task's effective parameters are stable and available
-through `task.parameters`. `run(runtime)` uses only those parameters and the
-narrow capabilities supplied by the runtime.
+through `task.parameters`. `await task.run(runtime)` uses only those parameters
+and the narrow capabilities supplied by the runtime.
 
 The implementation must define cleanup semantics for temporary system changes.
 An execution failure must not leave an LO, NCO, or other temporary setting in
@@ -324,7 +343,7 @@ calibration state merely because the Task ran.
 ## Illustrative API shape
 
 The following examples explain the responsibility boundary. They do not freeze
-names, signatures, inheritance, synchronization style, or package layout.
+names, exact signatures, inheritance, or package layout.
 
 ```python
 class ExperimentTask[ParametersT, ResultT]:
@@ -332,7 +351,7 @@ class ExperimentTask[ParametersT, ResultT]:
     def parameters(self) -> ParametersT:
         ...
 
-    def run(self, runtime: ExperimentRuntime) -> ResultT:
+    async def run(self, runtime: ExperimentRuntime) -> ResultT:
         ...
 ```
 
@@ -353,7 +372,7 @@ task = QubitSpectroscopyTask.from_context(
 # Inspect every realized value before execution.
 task.parameters
 
-task_result = task.run(runtime)
+task_result = await task.run(runtime)
 ```
 
 An external workflow supplies the complete input set directly:
@@ -372,22 +391,26 @@ task = QubitSpectroscopyTask(
 )
 
 task.parameters
-task_result = task.run(runtime)
+task_result = await task.run(runtime)
 ```
 
 The Service preserves the existing interactive contract around the Task:
 
 ```python
 class CharacterizationService:
-    def qubit_spectroscopy(...) -> Result:
+    async def _execute_qubit_spectroscopy(...) -> Result:
         task = QubitSpectroscopyTask.from_context(self.ctx, ...)
-        task_result = task.run(self._runtime)
+        task_result = await task.run(self._runtime)
 
         figure = self._make_qubit_spectroscopy_figure(task_result)
         self._show_or_save_figure(figure, ...)
 
         return self._to_result(task_result, figure)
 ```
+
+An existing synchronous facade method can call this canonical async path
+through a compatibility adapter, while an async facade method can await it
+directly.
 
 ## Compatibility and migration
 
@@ -481,8 +504,8 @@ backend-specific work.
 - How should parameter source provenance be represented and inspected?
 - Which result data and execution metadata must be serializable for replay and
   audit?
-- Should Task execution be synchronous, asynchronous, or support both through
-  one canonical implementation?
+- If a remote backend queues execution, should `await task.run(runtime)` wait
+  for the final result, or should a separate submission API return a job handle?
 - Which temporary system-control capabilities belong in
   `ExperimentRuntime`, and what cleanup contract should each capability have?
 - Which capabilities are common, which are optional extensions, and how should
@@ -504,6 +527,8 @@ This proposal is ready to move to `ACCEPTED` when the team agrees that:
 - direct system-facing Task construction has no implicit calibration-state
   fallback;
 - Task execution cannot access or mutate `CalibrationNote`;
+- canonical Task execution is async-first, with any synchronous compatibility
+  adapter outside the Task layer;
 - visualization, persistence, result adaptation, and calibration-state updates
   remain outside the Task;
 - `ExperimentRuntime` exposes restricted execution capabilities instead of the
@@ -527,7 +552,7 @@ This proposal is ready to move to `ACCEPTED` when the team agrees that:
 2. Define the minimum `ExperimentRuntime` capability protocols required by the
    reference experiment and map them to lower-level measurement schemas.
 3. Add contract tests for construction, pre-execution validation, state
-   isolation, and cleanup on failure.
+   isolation, cancellation, and cleanup on failure.
 4. Implement Service delegation while preserving the current facade and
    `Result` behavior.
 5. Validate the explicit construction path with an external workflow consumer,

--- a/docs/developer-notes/experiment-task-api-design.md
+++ b/docs/developer-notes/experiment-task-api-design.md
@@ -1,0 +1,403 @@
+# Experiment task API design proposal
+
+## Status
+
+- State: `PROPOSED`
+- Created: `2026-08-24`
+- Updated: `2026-08-24`
+- Scope: task-based experiment execution below the `Experiment` facade
+- Discussion:
+  - [Qubex issue #357](https://github.com/amachino/qubex/issues/357)
+  - [QDash pull request #1363](https://github.com/oqtopus-team/qdash/pull/1363)
+
+This document is a design proposal for team discussion. It does not introduce
+a public API or change the compatibility contract. If the proposal is
+accepted, change the state to `ACCEPTED` before merging it.
+
+## Summary
+
+Introduce a common task-based execution layer below the human-facing
+`Experiment` facade.
+
+An experiment Task contains the fully resolved parameters and
+experiment-specific execution flow. It exposes the effective parameters before
+execution and runs against an `ExperimentRuntime` that provides only the
+capabilities needed by that Task. It does not read or update `CalibrationNote`
+during execution.
+
+`Experiment` remains a concise entry point for interactive use. A Service
+constructs a Task from the current context, runs it, and owns optional policy
+such as applying calibrated values to `CalibrationNote`, creating figures, and
+adapting a task-specific result to the current `Result` contract. External
+workflow systems can construct the same Task with explicit parameters and
+consume its result without mutating Qubex session state.
+
+## Motivation
+
+Some experiment and calibration paths resolve inputs from `CalibrationNote`,
+configuration, defaults, or other mutable context late in the execution path.
+This is convenient for consecutive interactive work, but it creates two
+problems.
+
+First, external workflow systems cannot reliably reproduce an execution from
+their recorded task inputs alone. The values used by Qubex may depend on the
+current session state, and restoring that state requires the caller to know
+Qubex internals.
+
+Second, interactive users cannot easily inspect the complete realized
+parameter set or identify where each value came from before starting an
+experiment.
+
+QDash currently works around this by restoring selected calibration inputs
+into the Qubex context before dependent experiments. That compatibility layer
+duplicates parts of Qubex parameter resolution and makes snapshot-based
+re-execution harder to reason about.
+
+## Goals
+
+- Make experiment execution reproducible from explicit, inspectable inputs.
+- Resolve all execution parameters before measurement starts.
+- Keep one canonical owner for each default value.
+- Allow interactive callers to use context-based convenience without making
+  context access part of Task execution.
+- Separate experiment execution from visualization, persistence, and
+  `CalibrationNote` mutation.
+- Give external workflow systems a supported API below `Experiment` without
+  coupling them to the complete `ExperimentContext`.
+- Support the temporary hardware-control operations required within experiment
+  flows through narrowly scoped runtime capabilities.
+
+## Non-goals
+
+- Finalize class names, package paths, or every field in this proposal.
+- Add every lower-level parameter as a flat argument to every `Experiment`
+  method.
+- Replace or break the current `Experiment` or `Result` public contracts.
+- Define the serialization format for tasks, parameters, or results.
+- Implement the task layer in this documentation change.
+- Require one migration of all calibration, characterization, and benchmarking
+  methods at once.
+
+## Design principles
+
+### Resolve before execution
+
+A Task must contain all values that affect its measurement conditions,
+sweeps, search initial values, and analysis behavior before `run()` starts.
+Required values that remain unresolved must produce an error before hardware
+execution.
+
+The complete effective parameter set must be inspectable through
+`task.parameters`. The resolution API should also make parameter provenance
+inspectable so callers can distinguish explicit overrides, calibration state,
+configuration, and canonical defaults. The exact provenance model remains an
+open question.
+
+### Keep the facade concise
+
+`Experiment` is the human-facing facade and index of available experiment
+methods. Its signatures should expose the main parameters that users commonly
+need to understand or control. They should not flatten every control, readout,
+pulse-shape, acquisition, analysis, and backend detail into hundreds of
+arguments.
+
+This does not imply that the current facade signatures are complete. Meaningful
+experiment parameters should be added when they improve interactive use. Full
+control belongs to the corresponding Task API.
+
+### Keep execution free from calibration state
+
+Task execution must not read from or write to `CalibrationNote`. It must not
+receive the complete `ExperimentContext`, because doing so would make hidden
+mutable-state access possible again.
+
+Using calibrated values as inputs, producing new calibration estimates, and
+committing accepted estimates to calibration state are separate operations.
+
+### Keep side-effect policy outside the Task
+
+A Task produces a task-specific result. It does not create or display figures,
+save images, convert to the current generic `Result`, or decide whether to
+update `CalibrationNote`.
+
+The Service owns those policies for the existing interactive workflow. An
+external workflow system may instead validate and persist the task-specific
+result using its own policy.
+
+### Restrict runtime capabilities
+
+`ExperimentRuntime` provides the minimum capabilities needed during execution.
+Measurement alone is insufficient because some experiments temporarily change
+system settings while running. For example, qubit spectroscopy may change an
+LO or NCO frequency while scanning different frequency ranges.
+
+The runtime may therefore expose narrowly scoped measurement and temporary
+system-control capabilities. It must not expose the complete
+`ExperimentContext`, `CalibrationNote`, visualization, or persistence services.
+
+## Proposed responsibility split
+
+```text
+Experiment
+  - Human-facing entry point and method index
+  - Keeps concise signatures focused on the main experiment parameters
+  - Delegates processing to the owning Service
+
+Service
+  - Resolves context-dependent inputs and constructs a Task
+  - Runs the Task with an ExperimentRuntime
+  - Optionally applies accepted results to CalibrationNote
+  - Creates and saves figures according to interactive policy
+  - Adapts the task-specific result to the current Result contract
+
+Task
+  - Holds fully resolved experiment parameters
+  - Implements the experiment-specific execution flow
+  - Produces a task-specific result
+  - Does not access or update CalibrationNote
+  - Does not own visualization or persistence policy
+
+ExperimentRuntime
+  - Provides only the measurement and temporary system-control capabilities
+    required to run a Task
+```
+
+There are two supported construction paths:
+
+```text
+Interactive use
+
+Experiment -> Service -> Task.from_context(...) -> Task.run(runtime)
+                       -> Service-side adaptation and optional state update
+
+System-facing use
+
+External workflow -> Task(explicit parameters) -> Task.run(runtime)
+                  -> workflow-owned validation and persistence
+```
+
+Both paths must execute the same Task implementation after construction.
+
+## Parameter lifecycle
+
+### Context-based construction
+
+For interactive use, a factory such as `Task.from_context(...)` resolves all
+parameters immediately. The intended precedence is:
+
+1. Explicit overrides passed to the factory.
+2. Values owned by the current experiment or calibration context.
+3. Canonical defaults owned by the appropriate Qubex layer.
+
+Resolution must finish before the Task is returned. It must not pass unresolved
+`None` values through the execution chain merely so a deeper layer can consult
+mutable state later.
+
+Keeping one owner for each default remains important. Immediate resolution does
+not mean duplicating the same default across the facade, Service, and Task.
+
+### Explicit construction
+
+For system-facing use, direct Task construction accepts every required
+execution parameter explicitly. It does not implicitly fall back to
+`CalibrationNote` or other session state. Missing required parameters fail
+validation before execution.
+
+Grouped parameter models may be appropriate when they preserve domain
+structure and make validation clearer. Whether individual Tasks should use
+grouped models, explicit fields, or a combination is not decided here.
+
+### Execution
+
+After construction, the Task's effective parameters are stable and available
+through `task.parameters`. `run(runtime)` uses only those parameters and the
+narrow capabilities supplied by the runtime.
+
+The implementation must define cleanup semantics for temporary system changes.
+An execution failure must not leave an LO, NCO, or other temporary setting in
+an unintended state.
+
+### Result handling
+
+The task-specific result contains experiment output and newly estimated values
+needed by its consumers. The effective input parameters remain available from
+the Task and may also be included in a serializable execution record in a
+future design.
+
+Applying estimates to `CalibrationNote` is an explicit Service or caller
+operation after validation. A failed or rejected result must not update shared
+calibration state merely because the Task ran.
+
+## Illustrative API shape
+
+The following examples explain the responsibility boundary. They do not freeze
+names, signatures, inheritance, synchronization style, or package layout.
+
+```python
+class ExperimentTask[ParametersT, ResultT]:
+    @property
+    def parameters(self) -> ParametersT:
+        ...
+
+    def run(self, runtime: ExperimentRuntime) -> ResultT:
+        ...
+```
+
+Interactive construction resolves context-dependent values before execution:
+
+```python
+task = QubitSpectroscopyTask.from_context(
+    ctx,
+    target="Q01",
+    frequency_range=frequency_range,
+    power_range=power_range,
+    readout_amplitude=readout_amplitude,
+    readout_frequency=readout_frequency,
+    n_shots=n_shots,
+    shot_interval=shot_interval,
+)
+
+# Inspect every realized value before execution.
+task.parameters
+
+task_result = task.run(runtime)
+```
+
+An external workflow supplies the complete input set directly:
+
+```python
+task = QubitSpectroscopyTask(
+    target="Q01",
+    frequency_range=frequency_range,
+    power_range=power_range,
+    readout_amplitude=0.2,
+    readout_frequency=6.1,
+    control_pulse_duration=200.0,
+    readout_pulse_duration=1000.0,
+    n_shots=2048,
+    shot_interval=1024.0,
+)
+
+task.parameters
+task_result = task.run(runtime)
+```
+
+The Service preserves the existing interactive contract around the Task:
+
+```python
+class CharacterizationService:
+    def qubit_spectroscopy(...) -> Result:
+        task = QubitSpectroscopyTask.from_context(self.ctx, ...)
+        task_result = task.run(self._runtime)
+
+        figure = self._make_qubit_spectroscopy_figure(task_result)
+        self._show_or_save_figure(figure, ...)
+
+        return self._to_result(task_result, figure)
+```
+
+## Compatibility and migration
+
+The task API described here is new and unreleased. The removed legacy
+`ExperimentTask`, `ExperimentTaskResult`, and `Experiment.run(task)` contracts
+must not be used as its compatibility foundation.
+
+The existing `Experiment` facade and generic `Result` contract remain the
+compatibility surface during incremental migration. A Service can delegate to
+a new Task internally without requiring existing interactive callers to adopt
+the lower-level API.
+
+Migration should proceed one coherent experiment path at a time. Qubit
+spectroscopy is a useful candidate reference slice because it exercises both
+parameter resolution and temporary LO or NCO control. The first implemented
+slice should establish reusable runtime and validation patterns before broader
+calibration, characterization, and benchmarking migration.
+
+Each implementation pull request must separately decide:
+
+- whether any affected public behavior has already been released;
+- which existing defaults and result semantics must remain compatible;
+- which parameter and result types are ready to become supported contracts;
+- what unit, integration, and hardware validation is required.
+
+## Alternatives considered
+
+### Add every parameter to every Experiment method
+
+This would make all values discoverable from the facade signature, but the
+signature would mix main experiment controls with lower-level control,
+readout, acquisition, analysis, and backend details. It would also tightly
+couple the human-facing facade to implementation changes.
+
+The proposal instead improves facade signatures selectively and provides the
+Task API for complete control.
+
+### Pass ExperimentContext to Task.run
+
+This is convenient because all current capabilities and state are available,
+but it preserves the possibility of late reads and writes to hidden mutable
+state. It also makes Task dependencies difficult to inspect and test.
+
+The proposal passes a restricted `ExperimentRuntime` instead.
+
+### Keep resolving parameters at the deepest owning layer
+
+This avoids duplicating defaults, but the complete effective input set remains
+unknown until late in execution. The proposal keeps one owner per default while
+moving resolution to Task construction.
+
+### Let the Task update CalibrationNote and create figures
+
+This preserves current all-in-one interactive behavior, but it prevents
+external callers from validating results before committing them and mixes
+execution with presentation and persistence policy.
+
+The proposal keeps these responsibilities in the Service or external caller.
+
+## Open questions
+
+- Where should the common Task, parameter, result, and runtime contracts live?
+- Should `ParametersT` use one structured model, explicit Task fields, or a
+  combination of domain-specific submodels?
+- How should parameter source provenance be represented and inspected?
+- Which result data and execution metadata must be serializable for replay and
+  audit?
+- Should Task execution be synchronous, asynchronous, or support both through
+  one canonical implementation?
+- Which temporary system-control capabilities belong in
+  `ExperimentRuntime`, and what cleanup contract should each capability have?
+- What API should validate and atomically apply accepted task results to
+  `CalibrationNote`?
+- Which Task types and fields are stable public contracts for external systems,
+  and which remain internal during the first migration?
+
+## Acceptance criteria
+
+This proposal is ready to move to `ACCEPTED` when the team agrees that:
+
+- `Experiment` remains the concise human-facing facade;
+- complete parameter resolution occurs before Task execution;
+- direct system-facing Task construction has no implicit calibration-state
+  fallback;
+- Task execution cannot access or mutate `CalibrationNote`;
+- visualization, persistence, result adaptation, and calibration-state updates
+  remain outside the Task;
+- `ExperimentRuntime` exposes restricted execution capabilities instead of the
+  complete `ExperimentContext`;
+- the same Task implementation serves interactive and external workflows; and
+- unresolved API details can be decided incrementally without weakening these
+  boundaries.
+
+## Follow-up work after acceptance
+
+1. Select one reference experiment and define its exact parameter and result
+   models.
+2. Define the minimum `ExperimentRuntime` capability protocols required by the
+   reference experiment.
+3. Add contract tests for construction, pre-execution validation, state
+   isolation, and cleanup on failure.
+4. Implement Service delegation while preserving the current facade and
+   `Result` behavior.
+5. Validate the explicit construction path with an external workflow consumer.
+6. Use the reference slice to refine the common contracts before migrating
+   additional experiments.

--- a/docs/developer-notes/experiment-task-api-design.md
+++ b/docs/developer-notes/experiment-task-api-design.md
@@ -4,11 +4,12 @@
 
 - State: `PROPOSED`
 - Created: `2026-08-24`
-- Updated: `2026-08-24`
+- Updated: `2026-08-27`
 - Scope: task-based experiment execution below the `Experiment` facade
 - Discussion:
   - [Qubex issue #357](https://github.com/amachino/qubex/issues/357)
   - [QDash pull request #1363](https://github.com/oqtopus-team/qdash/pull/1363)
+  - [Runtime and backend boundary discussion](https://quantummiddleware.slack.com/archives/C070D6DDH6D/p1787803320352839)
 
 This document is a design proposal for team discussion. It does not introduce
 a public API or change the compatibility contract. If the proposal is
@@ -31,6 +32,13 @@ such as applying calibrated values to `CalibrationNote`, creating figures, and
 adapting a task-specific result to the current `Result` contract. External
 workflow systems can construct the same Task with explicit parameters and
 consume its result without mutating Qubex session state.
+
+The Task and runtime contracts should also support a client-side library that
+can be installed independently of the backend execution engine. A Task depends
+on an `ExperimentRuntime` capability interface, not on a concrete backend,
+hardware driver, or transport. A backend implementation or remote adapter
+provides those capabilities. Exact repository, package, and deployment
+boundaries remain open.
 
 ## Motivation
 
@@ -66,6 +74,12 @@ re-execution harder to reason about.
   coupling them to the complete `ExperimentContext`.
 - Support the temporary hardware-control operations required within experiment
   flows through narrowly scoped runtime capabilities.
+- Allow the Task and runtime contracts to be distributed independently of a
+  concrete backend execution engine.
+- Keep backend-specific operations available through explicit capabilities
+  without coupling portable Tasks to backend implementations.
+- Distinguish experiment-protocol Tasks from lower-level sweep-measurement
+  request and result schemas.
 
 ## Non-goals
 
@@ -74,6 +88,10 @@ re-execution harder to reason about.
   method.
 - Replace or break the current `Experiment` or `Result` public contracts.
 - Define the serialization format for tasks, parameters, or results.
+- Choose the final repository, distribution-package, transport, or process
+  boundary between a client library and backend engine.
+- Reduce every backend to one lowest-common-denominator capability set or hide
+  all meaningful backend differences from Task authors.
 - Implement the task layer in this documentation change.
 - Require one migration of all calibration, characterization, and benchmarking
   methods at once.
@@ -135,6 +153,72 @@ The runtime may therefore expose narrowly scoped measurement and temporary
 system-control capabilities. It must not expose the complete
 `ExperimentContext`, `CalibrationNote`, visualization, or persistence services.
 
+### Invert the dependency at the Task-runtime boundary
+
+The client-facing Task contract owns the `ExperimentRuntime` capability
+interface that Tasks consume. A Task must not import a concrete measurement
+implementation, hardware driver, backend service object, or transport client.
+A backend runtime or remote adapter provides the required capabilities.
+
+Conceptually, the dependency direction is:
+
+```text
+Experiment -> Task -> ExperimentRuntime interface <- runtime implementation
+```
+
+This boundary permits the client-facing library and backend execution engine to
+live in separate distributions or repositories. It does not require that they
+do so immediately, and it does not decide whether `Task.run()` executes in the
+client process against a remote runtime proxy or in the backend process against
+a direct runtime implementation. Both deployment models should preserve the
+same Task and capability contracts.
+
+If execution crosses a process or network boundary, the in-process
+`ExperimentRuntime` interface and the serialized transport contract are
+separate concerns. A client-side proxy may implement `ExperimentRuntime` while
+using a backend API internally. Tasks must remain unaware of that transport.
+
+### Make backend capabilities explicit
+
+Backend independence means that a Task does not know a backend's implementation
+details. It does not mean that the client must be unaware of every capability
+that a backend provides.
+
+Common experiment flows should depend on small, stable capability interfaces.
+Optional or backend-specific operations should use explicit extension
+capabilities. A specialized Task declares the capabilities it requires, and
+runtime compatibility must be checked before measurement starts. This avoids
+both a single oversized runtime interface and a lowest-common-denominator API.
+
+Operations that are intentionally backend-specific and cannot support a stable
+experiment-level contract may remain available through a clearly identified
+low-level escape hatch. Such operations must not become hidden dependencies of
+otherwise portable Tasks.
+
+### Keep Tasks above sweep-measurement schemas
+
+An experiment Task represents a physical experiment protocol. Its parameters
+are protocol-specific, such as Ramsey detuning, delay times, and whether an
+echo is used, or the amplitude range of a Rabi experiment. Its result is also
+protocol-specific, such as an estimated frequency or coherence time.
+
+[`SweepMeasurementConfig`](https://github.com/amachino/qubex/blob/develop/packages/qxschema/src/qxschema/sweep_measurement_config.py)
+is a lower-level measurement schema. It describes a parametric pulse sequence,
+frequencies, sweep axes, and data-acquisition conditions. Its corresponding
+result carries generic measurement data and metadata. The schema does not
+itself execute a measurement or define a physical experiment protocol.
+
+A single Task may issue one or more lower-level sweep measurements through its
+runtime:
+
+```text
+ExperimentTask
+  -> ExperimentRuntime measurement capability
+  -> SweepMeasurementConfig / SweepMeasurementResult
+  -> backend execution engine
+  -> control hardware
+```
+
 ## Proposed responsibility split
 
 ```text
@@ -158,8 +242,15 @@ Task
   - Does not own visualization or persistence policy
 
 ExperimentRuntime
+  - Is the client-facing capability interface consumed by Tasks
   - Provides only the measurement and temporary system-control capabilities
     required to run a Task
+  - Makes optional backend capabilities explicit and preflightable
+
+Runtime implementation
+  - Implements the capabilities for a concrete backend or remote adapter
+  - Performs or delegates measurement and temporary system control
+  - Keeps hardware drivers, transport, and backend internals outside Tasks
 ```
 
 There are two supported construction paths:
@@ -177,6 +268,8 @@ External workflow -> Task(explicit parameters) -> Task.run(runtime)
 ```
 
 Both paths must execute the same Task implementation after construction.
+The supplied runtime may be a direct backend implementation or a remote proxy;
+the Task must not depend on which deployment is used.
 
 ## Parameter lifecycle
 
@@ -354,9 +447,35 @@ execution with presentation and persistence policy.
 
 The proposal keeps these responsibilities in the Service or external caller.
 
+### Let Tasks import concrete backend implementations
+
+This makes backend-specific operations immediately available, but it couples
+Task definitions, tests, and distribution to one execution engine. It also
+makes a client-side installation or alternate backend require conditional
+imports throughout the Task library.
+
+The proposal instead makes required backend capabilities explicit through the
+`ExperimentRuntime` boundary. Concrete implementations remain behind that
+interface.
+
+### Hide all backend differences from Tasks
+
+This maximizes superficial portability, but it either limits every backend to
+the smallest shared feature set or pushes backend-specific behavior into hidden
+conditionals. Both outcomes make experiment requirements harder to inspect.
+
+The proposal standardizes common capabilities while allowing explicit optional
+capability interfaces and a separate low-level escape hatch for intentionally
+backend-specific work.
+
 ## Open questions
 
-- Where should the common Task, parameter, result, and runtime contracts live?
+- Which repository and distribution package should own the common Task,
+  parameter, result, and runtime contracts?
+- Should canonical Task execution occur in the client process against a remote
+  runtime proxy, in the backend process after serialization, or support both?
+- Which schemas define the transport boundary when client and backend run in
+  separate processes?
 - Should `ParametersT` use one structured model, explicit Task fields, or a
   combination of domain-specific submodels?
 - How should parameter source provenance be represented and inspected?
@@ -366,6 +485,11 @@ The proposal keeps these responsibilities in the Service or external caller.
   one canonical implementation?
 - Which temporary system-control capabilities belong in
   `ExperimentRuntime`, and what cleanup contract should each capability have?
+- Which capabilities are common, which are optional extensions, and how should
+  a Task declare and preflight its requirements?
+- Which operations should remain in a backend-specific low-level escape hatch?
+- How should `SweepMeasurementConfig` and related result schemas evolve as the
+  lower-level measurement boundary used by Tasks?
 - What API should validate and atomically apply accepted task results to
   `CalibrationNote`?
 - Which Task types and fields are stable public contracts for external systems,
@@ -384,6 +508,14 @@ This proposal is ready to move to `ACCEPTED` when the team agrees that:
   remain outside the Task;
 - `ExperimentRuntime` exposes restricted execution capabilities instead of the
   complete `ExperimentContext`;
+- Tasks depend on runtime capability interfaces rather than concrete backend,
+  transport, or hardware implementations;
+- backend-specific capabilities are explicit and can be validated before
+  measurement starts;
+- experiment-protocol Tasks remain distinct from lower-level
+  `SweepMeasurementConfig` request and result schemas;
+- the dependency boundary permits independent client and backend deployment
+  without requiring the package layout to be finalized in this proposal;
 - the same Task implementation serves interactive and external workflows; and
 - unresolved API details can be decided incrementally without weakening these
   boundaries.
@@ -393,11 +525,13 @@ This proposal is ready to move to `ACCEPTED` when the team agrees that:
 1. Select one reference experiment and define its exact parameter and result
    models.
 2. Define the minimum `ExperimentRuntime` capability protocols required by the
-   reference experiment.
+   reference experiment and map them to lower-level measurement schemas.
 3. Add contract tests for construction, pre-execution validation, state
    isolation, and cleanup on failure.
 4. Implement Service delegation while preserving the current facade and
    `Result` behavior.
-5. Validate the explicit construction path with an external workflow consumer.
+5. Validate the explicit construction path with an external workflow consumer,
+   including capability preflight and at least one client/backend deployment
+   boundary.
 6. Use the reference slice to refine the common contracts before migrating
    additional experiments.

--- a/docs/developer-notes/index.md
+++ b/docs/developer-notes/index.md
@@ -19,6 +19,7 @@ Manage development notes and operational documents.
 - [QuEL-3 Control-System Model Design](quel3-control-system-model-design.md)
 - [Target label metadata roadmap](target-label-metadata-roadmap.md)
 - [Experiment system logical/hardware configuration split design](experiment-system-logical-hardware-split-design.md)
+- [Experiment task API design proposal](experiment-task-api-design.md)
 - [QuEL-3 Wiring And Binding Policy](quel3-wiring-binding-policy.md)
 - [QuEL-3 Demo Readiness (2026-03-19)](quel3-demo-readiness-2026-03-19.md)
 - [System Package QuEL-1/QuEL-3 Boundary](system-package-quel1-quel3-boundary.md)


### PR DESCRIPTION
## Background

External workflow systems such as QDash need to reproduce experiment and
calibration execution from recorded inputs without depending on hidden mutable
state in a Qubex session. Interactive users also need to inspect the realized
parameter values and their sources before execution.

The problem statement and prior team discussion converged on a task-based
execution layer below the human-facing `Experiment` facade rather than
flattening every lower-level parameter into every facade method.

Relates to #357.

- [QDash PR #1363](https://github.com/oqtopus-team/qdash/pull/1363)

## Summary

- Add a `PROPOSED` design document for a common experiment Task API.
- Define the intended responsibility split between `Experiment`, Service,
  Task, and `ExperimentRuntime`.
- Require complete parameter resolution before Task execution and expose the
  effective values through `task.parameters`.
- Keep `CalibrationNote` access, visualization, persistence, and generic
  `Result` adaptation outside Task execution.
- Describe separate context-based and fully explicit construction paths that
  execute the same Task implementation.
- Record alternatives, compatibility boundaries, open questions, acceptance
  criteria, and an incremental follow-up plan.
- Add the proposal to the developer-notes index.

## API and compatibility impact

This is a documentation-only proposal. It does not add a public API or change
runtime behavior.

The existing `Experiment` facade and `Result` contract remain the compatibility
surface. The removed legacy `ExperimentTask` API is explicitly excluded as a
compatibility foundation for the future design.

## Review focus

Please review whether the proposed boundaries are appropriate:

- `Experiment` remains a concise human-facing facade.
- Services resolve context-dependent inputs and own optional side effects.
- Tasks hold fully resolved parameters and cannot access or mutate
  `CalibrationNote`.
- `ExperimentRuntime` exposes only narrowly scoped execution capabilities.
- External workflows can construct the same Tasks from explicit inputs.

Names, package paths, exact parameter grouping, result serialization, and
sync/async execution remain open for follow-up design.

If the responsibility boundaries reach consensus, this document should be
changed from `PROPOSED` to `ACCEPTED` before merge.

## Validation

- `uv run mkdocs build`
- `git diff --check`

The documentation build passed. It reported only existing navigation and
docstring warnings unrelated to this change.
