### PR TITLE
feat(quel3): fan out transmitter instruments

### DIFF
--- a/src/qubex/backend/quel3/instrument_groups.py
+++ b/src/qubex/backend/quel3/instrument_groups.py
@@ -1,0 +1,32 @@
+"""Internal alias conventions for grouped QuEL-3 transmitter instruments."""
+
+from __future__ import annotations
+
+from typing import Final
+
+TRANSMITTER_INSTRUMENT_MULTIPLICITY: Final = 4
+_TRANSMITTER_SUFFIXES: Final = frozenset(range(TRANSMITTER_INSTRUMENT_MULTIPLICITY))
+
+
+def build_transmitter_aliases(alias: str) -> tuple[str, ...]:
+    """Return the four physical transmitter aliases for one logical alias."""
+    return tuple(
+        f"{alias}-{index}" for index in range(TRANSMITTER_INSTRUMENT_MULTIPLICITY)
+    )
+
+
+def split_transmitter_alias(alias: str) -> tuple[str, int | None]:
+    """Split one terminal transmitter-group suffix from an alias."""
+    base_alias, separator, raw_index = alias.rpartition("-")
+    if not separator or not base_alias or not raw_index.isdigit():
+        return alias, None
+    index = int(raw_index)
+    if index not in _TRANSMITTER_SUFFIXES:
+        return alias, None
+    return base_alias, index
+
+
+def is_transmitter_role(role: object) -> bool:
+    """Return whether an enum-like role value identifies a transmitter."""
+    role_name = getattr(role, "name", role)
+    return str(role_name).rsplit(".", maxsplit=1)[-1].upper() == "TRANSMITTER"

--- a/src/qubex/backend/quel3/managers/configuration_manager.py
+++ b/src/qubex/backend/quel3/managers/configuration_manager.py
@@ -11,6 +11,11 @@ from dataclasses import dataclass
 from typing import TypeVar
 
 from qubex.backend.quel3.infra.quelware_imports import Quel3ClientMode
+from qubex.backend.quel3.instrument_groups import (
+    build_transmitter_aliases,
+    is_transmitter_role,
+    split_transmitter_alias,
+)
 from qubex.backend.quel3.interfaces.client import (
     FixedTimelineProfileFactory,
     InstrumentDefinitionFactory,
@@ -205,8 +210,7 @@ class Quel3ConfigurationManager:
         backend_settings: Mapping[str, dict],
     ) -> None:
         """Restore instrument alias caches from normalized backend settings."""
-        deployed: dict[str, tuple[InstrumentInfoProtocol, ...]] = {}
-        target_alias_map: dict[TargetAliasKey, str] = {}
+        entries: list[tuple[str | None, str, str, InstrumentInfoProtocol]] = []
 
         for box_id, box_config in backend_settings.items():
             instruments = box_config.get("instruments")
@@ -231,15 +235,14 @@ class Quel3ConfigurationManager:
                     alias=definition.alias,
                     port_id=port_id,
                 )
-                deployed[alias] = (
-                    _CachedInstrumentInfo(
-                        id=resource_id,
-                        port_id=port_id,
-                        definition=definition,
-                    ),
+                instrument_info = _CachedInstrumentInfo(
+                    id=resource_id,
+                    port_id=port_id,
+                    definition=definition,
                 )
-                target_alias_map[(box_id, local_alias)] = runtime_alias
+                entries.append((box_id, local_alias, runtime_alias, instrument_info))
 
+        deployed, target_alias_map = self._group_instrument_cache_entries(entries)
         self._last_deployed_instrument_infos = deployed
         self._target_alias_map = target_alias_map
 
@@ -377,18 +380,27 @@ class Quel3ConfigurationManager:
     ) -> _PortDeployResult:
         """Deploy one port batch through the active quelware session."""
         definitions: list[InstrumentDefinitionProtocol] = []
+        alias_groups: list[tuple[InstrumentDeployRequest, tuple[str, ...]]] = []
         for request in port_requests:
+            aliases = (
+                build_transmitter_aliases(request.alias)
+                if request.role == "TRANSMITTER"
+                else (request.alias,)
+            )
+            alias_groups.append((request, aliases))
             profile = instrument_entities.fixed_timeline_profile_factory(
                 frequency_range_min=request.frequency_range_min_hz,
                 frequency_range_max=request.frequency_range_max_hz,
             )
-            definitions.append(
+            role = instrument_entities.role_value(request.role)
+            definitions.extend(
                 instrument_entities.instrument_definition_factory(
-                    alias=request.alias,
+                    alias=alias,
                     mode=instrument_entities.instrument_mode_namespace.FIXED_TIMELINE,
-                    role=instrument_entities.role_value(request.role),
+                    role=role,
                     profile=profile,
                 )
+                for alias in aliases
             )
 
         instrument_infos = await session.deploy_instruments(
@@ -398,30 +410,24 @@ class Quel3ConfigurationManager:
             # truth for this port's selected instruments.
             append=False,
         )
-        instrument_infos_by_alias: dict[str, list[InstrumentInfoProtocol]] = (
-            defaultdict(list)
-        )
+        instrument_infos_by_alias: dict[str, InstrumentInfoProtocol] = {}
         for instrument_info in instrument_infos:
             local_alias, _runtime_alias = self._split_alias_for_port(
                 alias=instrument_info.definition.alias,
                 port_id=instrument_info.port_id,
             )
-            instrument_infos_by_alias[local_alias].append(instrument_info)
+            instrument_infos_by_alias[local_alias] = instrument_info
 
         deployed: dict[str, tuple[InstrumentInfoProtocol, ...]] = {}
         target_alias_map: dict[TargetAliasKey, str] = {}
-        for request in port_requests:
+        for request, aliases in alias_groups:
             matched_instrument_infos = tuple(
-                instrument_infos_by_alias.get(request.alias, ())
+                instrument_infos_by_alias[alias] for alias in aliases
             )
-            if len(matched_instrument_infos) != 1:
-                raise ValueError(
-                    "quelware did not return the deployed instrument info for one request."
-                )
             deployed[request.alias] = matched_instrument_infos
             runtime_alias = self._runtime_alias_from_instrument_info(
                 instrument_info=matched_instrument_infos[0],
-                fallback_alias=request.alias,
+                fallback_alias=aliases[0],
             )
             for target_label in request.target_labels:
                 target_alias_map[(request.box_id, target_label)] = runtime_alias
@@ -445,20 +451,53 @@ class Quel3ConfigurationManager:
                 unit_labels=None,
             )
 
-        deployed: dict[str, tuple[InstrumentInfoProtocol, ...]] = {}
+        entries: list[tuple[str | None, str, str, InstrumentInfoProtocol]] = []
         for instrument_info in instrument_infos:
             alias = instrument_info.definition.alias
             if len(alias.strip()) == 0:
                 continue
-            local_alias, _runtime_alias = self._split_alias_for_port(
+            local_alias, runtime_alias = self._split_alias_for_port(
                 alias=alias,
                 port_id=instrument_info.port_id,
             )
-            deployed[local_alias] = (instrument_info,)
+            entries.append((None, local_alias, runtime_alias, instrument_info))
 
+        deployed, _target_alias_map = self._group_instrument_cache_entries(entries)
         self._last_deployed_instrument_infos = deployed
         self._target_alias_map = {}
         return dict(deployed)
+
+    @classmethod
+    def _group_instrument_cache_entries(
+        cls,
+        entries: Sequence[tuple[str | None, str, str, InstrumentInfoProtocol]],
+    ) -> tuple[
+        dict[str, tuple[InstrumentInfoProtocol, ...]],
+        dict[TargetAliasKey, str],
+    ]:
+        """Group suffixed transmitter cache entries under logical aliases."""
+        grouped_infos: dict[str, list[InstrumentInfoProtocol]] = defaultdict(list)
+        target_alias_map: dict[TargetAliasKey, str] = {}
+        for box_id, local_alias, runtime_alias, instrument_info in entries:
+            logical_alias = local_alias
+            base_alias, suffix_index = split_transmitter_alias(local_alias)
+            if is_transmitter_role(
+                getattr(instrument_info.definition, "role", None)
+            ) and (suffix_index is not None):
+                logical_alias = base_alias
+                runtime_alias = cls._runtime_alias_for_port(
+                    alias=build_transmitter_aliases(base_alias)[0],
+                    port_id=str(instrument_info.port_id),
+                )
+            grouped_infos[logical_alias].append(instrument_info)
+            if box_id is not None:
+                target_alias_map[(box_id, logical_alias)] = runtime_alias
+
+        deployed = {
+            alias: tuple(sorted(infos, key=lambda info: info.definition.alias))
+            for alias, infos in grouped_infos.items()
+        }
+        return deployed, target_alias_map
 
     def _load_quelware_client_factory(self) -> QuelwareClientFactory:
         """Import quelware client factory lazily."""

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -14,6 +14,11 @@ import numpy as np
 
 from qubex.backend.quel3.builders.sequencer_builder import Quel3SequencerBuilder
 from qubex.backend.quel3.infra.quelware_imports import Quel3ClientMode
+from qubex.backend.quel3.instrument_groups import (
+    build_transmitter_aliases,
+    is_transmitter_role,
+    split_transmitter_alias,
+)
 from qubex.backend.quel3.interfaces import (
     CaptureModeNamespaceProtocol,
     CaptureModeProtocol,
@@ -86,8 +91,6 @@ class _PayloadExecutionPlan:
     """Resolved payload and runtime aliases required for one execution."""
 
     resolved_payload: Quel3ExecutionPayload
-    aliases: tuple[str, ...]
-    aliases_with_captures: frozenset[str]
 
 
 @dataclass(frozen=True)
@@ -339,21 +342,26 @@ class Quel3ExecutionManager:
                     quelware_api=quelware_api,
                     force_resolver_refresh=attempt > 0,
                 )
-                alias_to_instrument_info = {
-                    alias: self._find_instrument_info_by_alias(
+                resolved_payload, alias_to_instrument_info = (
+                    self._resolve_payload_instruments(
+                        payload=payload_plan.resolved_payload,
                         resolver=resolver,
-                        alias=alias,
                     )
-                    for alias in payload_plan.aliases
-                }
+                )
+                aliases = tuple(sorted(resolved_payload.fixed_timelines))
+                aliases_with_captures = frozenset(
+                    alias
+                    for alias, timeline in resolved_payload.fixed_timelines.items()
+                    if len(timeline.capture_windows) > 0
+                )
                 session_state = await self._open_payload_execution_session(
                     alias_to_instrument_info=alias_to_instrument_info,
-                    aliases=payload_plan.aliases,
-                    aliases_with_captures=payload_plan.aliases_with_captures,
+                    aliases=aliases,
+                    aliases_with_captures=aliases_with_captures,
                     quelware_api=quelware_api,
                 )
                 return await self._execute_resolved_payload(
-                    payload=payload_plan.resolved_payload,
+                    payload=resolved_payload,
                     session_state=session_state,
                     quelware_api=quelware_api,
                     parallel=parallel,
@@ -608,13 +616,63 @@ class Quel3ExecutionManager:
         resolved_payload = cls._resolve_payload(payload=runnable_payload)
         return _PayloadExecutionPlan(
             resolved_payload=resolved_payload,
-            aliases=tuple(sorted(resolved_payload.fixed_timelines)),
-            aliases_with_captures=frozenset(
-                alias
-                for alias, timeline in resolved_payload.fixed_timelines.items()
-                if len(timeline.capture_windows) > 0
-            ),
         )
+
+    @classmethod
+    def _resolve_payload_instruments(
+        cls,
+        *,
+        payload: Quel3ExecutionPayload,
+        resolver: InstrumentResolverProtocol,
+    ) -> tuple[Quel3ExecutionPayload, dict[str, InstrumentInfoProtocol]]:
+        """Expand resolved transmitter timelines to four physical aliases."""
+        physical_timelines: dict[str, Quel3FixedTimeline] = {}
+        alias_to_instrument_info: dict[str, InstrumentInfoProtocol] = {}
+        for requested_alias, timeline in payload.fixed_timelines.items():
+            resolved_group = cls._resolve_instrument_group(
+                resolver=resolver,
+                requested_alias=requested_alias,
+            )
+            for physical_alias, instrument_info in resolved_group.items():
+                physical_timelines[physical_alias] = timeline
+                alias_to_instrument_info[physical_alias] = instrument_info
+        return (
+            replace(payload, fixed_timelines=physical_timelines),
+            alias_to_instrument_info,
+        )
+
+    @classmethod
+    def _resolve_instrument_group(
+        cls,
+        *,
+        resolver: InstrumentResolverProtocol,
+        requested_alias: str,
+    ) -> dict[str, InstrumentInfoProtocol]:
+        """Resolve one binding to a transmitter quartet or one other instrument."""
+        instrument_info = cls._find_instrument_info_by_alias(
+            resolver=resolver,
+            alias=requested_alias,
+        )
+        if not is_transmitter_role(instrument_info.definition.role):
+            return {requested_alias: instrument_info}
+
+        base_alias, suffix_index = split_transmitter_alias(requested_alias)
+        if suffix_index is None:
+            raise ValueError(
+                "QuEL-3 transmitter must use aliases ending in `-0` through `-3`."
+            )
+
+        return {
+            alias: (
+                instrument_info
+                if alias == requested_alias
+                else cls._find_instrument_info_by_alias(
+                    resolver=resolver,
+                    alias=alias,
+                )
+            )
+            for alias in build_transmitter_aliases(base_alias)
+        }
 
     @classmethod
     def _resolve_payload(

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -49,6 +49,8 @@ class _FakeCaptureMode(Enum):
 class _FakeInstrumentDefinition:
     role: str
     alias: str = ""
+    mode: None = None
+    profile: None = None
 
 
 @dataclass(frozen=True)
@@ -92,7 +94,13 @@ class _FakeInstrumentResolver:
     def resolve(self, aliases: list[str]) -> list[str]:
         return aliases
 
-    def find_inst_info_by_alias(self, alias: str) -> _FakeInstrumentInfo:
+    def find_inst_info_by_alias(
+        self,
+        alias: str,
+        *,
+        unit: str | None = None,
+    ) -> _FakeInstrumentInfo:
+        del unit
         if alias not in self._alias_to_info:
             raise ValueError(alias)
         return self._alias_to_info[alias]
@@ -966,12 +974,22 @@ def test_resolve_payload_rejects_unqualified_alias_binding() -> None:
 def test_execute_resolves_unit_prefixed_alias_binding(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
-    """Given unit-prefixed alias binding, execute should resolve with the unit label."""
+    """A transmitter binding should drive four suffixed instruments identically."""
     payload = _make_payload()
+    timeline = payload.fixed_timelines["alias-rq00"]
     payload = replace(
         payload,
-        fixed_timelines={"Q00": payload.fixed_timelines["alias-rq00"]},
-        instrument_bindings={"Q00": "alias:quel3-02-a01:Q00"},
+        fixed_timelines={
+            "Q00": replace(
+                timeline,
+                events=(
+                    replace(timeline.events[0], gain=0.375, phase_offset_deg=12.0),
+                ),
+                capture_windows=(),
+                frequency_hz=4.25e9,
+            )
+        },
+        instrument_bindings={"Q00": "alias:quel3-02-a01:Q00-0"},
     )
     manager = Quel3ExecutionManager(
         runtime_config=Quel3RuntimeConfig(),
@@ -1007,19 +1025,38 @@ def test_execute_resolves_unit_prefixed_alias_binding(
             unit: str | None = None,
         ) -> _InstrumentInfo:
             self.find_calls.append((alias, unit))
-            if (alias, unit) != ("Q00", "quel3-02-a01"):
+            if unit != "quel3-02-a01" or alias not in {
+                "Q00-0",
+                "Q00-1",
+                "Q00-2",
+                "Q00-3",
+            }:
                 raise ValueError(alias)
             return _InstrumentInfo(
-                id="inst-q00",
+                id=f"inst-{alias.lower()}",
                 port_id="quel3-02-a01:tx_p04",
                 definition=_Definition(
-                    alias="Q00",
+                    alias=alias,
                     role="TRANSMITTER",
                 ),
             )
 
     resolver = _UnitAwareResolver()
-    driver = _FakeInstrumentDriver()
+    drivers = {f"Q00-{index}": _FakeInstrumentDriver() for index in range(4)}
+    sequencer_events: list[tuple[str, float, float]] = []
+
+    class _RecordingSequencer(_FakeSequencer):
+        def add_event(
+            self,
+            instrument_alias: str,
+            waveform_name: str,
+            start_offset_ns: float,
+            gain: float = 1.0,
+            phase_offset_deg: float = 0.0,
+        ) -> None:
+            del waveform_name, start_offset_ns
+            sequencer_events.append((instrument_alias, gain, phase_offset_deg))
+
     session = _FakeSession()
     client = _FakeClient(session)
 
@@ -1029,7 +1066,10 @@ def test_execute_resolves_unit_prefixed_alias_binding(
         lambda: _make_fake_execution_api(
             client_factory=lambda endpoint, port: client,
             instrument_resolver_factory=lambda: resolver,
-            fixed_timeline_driver_factory=lambda _session, _instrument_info: driver,
+            fixed_timeline_driver_factory=lambda _session, instrument_info: drivers[
+                instrument_info.definition.alias
+            ],
+            sequencer_factory=_RecordingSequencer,
         ),
     )
 
@@ -1037,15 +1077,21 @@ def test_execute_resolves_unit_prefixed_alias_binding(
         manager.execute_async(request=BackendExecutionRequest(payload=payload))
     )
 
-    assert resolver.find_calls == [("Q00", "quel3-02-a01")]
-    assert driver.apply_calls == [
-        [
-            ("capture_mode", _FakeCaptureMode.AVERAGED_VALUE),
-            ("timeline", "quel3-02-a01:Q00"),
+    physical_aliases = [f"quel3-02-a01:Q00-{index}" for index in range(4)]
+    assert set(resolver.find_calls) >= {
+        (f"Q00-{index}", "quel3-02-a01") for index in range(4)
+    }
+    assert sequencer_events == [(alias, 0.375, -12.0) for alias in physical_aliases]
+    for index, physical_alias in enumerate(physical_aliases):
+        assert drivers[f"Q00-{index}"].apply_calls == [
+            [
+                ("frequency", 4.25e9),
+                ("capture_mode", _FakeCaptureMode.AVERAGED_VALUE),
+                ("timeline", physical_alias),
+            ]
         ]
-    ]
-    assert session.trigger_calls == [["inst-q00"]]
-    assert "quel3-02-a01:Q00" in result.data
+    assert session.trigger_calls == [[f"inst-q00-{index}" for index in range(4)]]
+    assert result.data == {}
 
 
 def test_execute_rejects_invalid_payload_before_opening_session(

--- a/tests/backend/test_quel3_configuration_manager.py
+++ b/tests/backend/test_quel3_configuration_manager.py
@@ -121,10 +121,11 @@ def test_deploy_instruments_calls_session_api(
             deploy_calls.append((port_id, definitions))
             return [
                 _InstrumentInfo(
-                    id=f"id:{port_id}",
+                    id=f"id:{port_id}:{index}",
                     port_id=port_id,
-                    definition=definitions[0],
+                    definition=definition,
                 )
+                for index, definition in enumerate(definitions)
             ]
 
     class _FakeClient:
@@ -171,14 +172,30 @@ def test_deploy_instruments_calls_session_api(
     assert len(deploy_calls) == 1
     port_id, definitions = deploy_calls[0]
     assert port_id == "quel3-02-a01:tx_p02"
-    definition = definitions[0]
-    assert definition.mode == "fixed_timeline"
-    assert definition.role == "transmitter"
-    assert definition.profile.frequency_range_min == pytest.approx(4.1e9)
-    assert definition.profile.frequency_range_max == pytest.approx(4.3e9)
-    assert definition.alias == "Q00"
-    assert manager.target_alias_map == {("BOX1", "Q00"): "quel3-02-a01:Q00"}
-    assert definition.alias in deployed
+    assert [definition.alias for definition in definitions] == [
+        "Q00-0",
+        "Q00-1",
+        "Q00-2",
+        "Q00-3",
+    ]
+    assert all(definition.mode == "fixed_timeline" for definition in definitions)
+    assert all(definition.role == "transmitter" for definition in definitions)
+    assert all(
+        definition.profile.frequency_range_min == pytest.approx(4.1e9)
+        for definition in definitions
+    )
+    assert all(
+        definition.profile.frequency_range_max == pytest.approx(4.3e9)
+        for definition in definitions
+    )
+    assert manager.target_alias_map == {("BOX1", "Q00"): "quel3-02-a01:Q00-0"}
+    assert set(deployed) == {"Q00"}
+    assert [info.definition.alias for info in deployed["Q00"]] == [
+        "Q00-0",
+        "Q00-1",
+        "Q00-2",
+        "Q00-3",
+    ]
 
 
 def test_deploy_instruments_recreates_session_after_transient_request_failure(
@@ -258,10 +275,11 @@ def test_deploy_instruments_recreates_session_after_transient_request_failure(
                 raise RuntimeError("quelware request failed")
             return [
                 _InstrumentInfo(
-                    id=f"id:{port_id}",
+                    id=f"id:{port_id}:{definition.alias}",
                     port_id=port_id,
-                    definition=definitions[0],
+                    definition=definition,
                 )
+                for definition in definitions
             ]
 
     class _FakeClient:
@@ -401,10 +419,11 @@ def test_deploy_instruments_ignores_session_close_failure_after_success(
             del append
             return [
                 _InstrumentInfo(
-                    id=f"id:{port_id}",
+                    id=f"id:{port_id}:{definition.alias}",
                     port_id=port_id,
-                    definition=definitions[0],
+                    definition=definition,
                 )
+                for definition in definitions
             ]
 
     class _FakeClient:
@@ -655,10 +674,11 @@ def test_deploy_instruments_retries_resource_allocation_on_session_create(
             del append
             return [
                 _InstrumentInfo(
-                    id=f"id:{port_id}",
+                    id=f"id:{port_id}:{definition.alias}",
                     port_id=port_id,
-                    definition=definitions[0],
+                    definition=definition,
                 )
+                for definition in definitions
             ]
 
     class _FakeClient:
@@ -771,18 +791,18 @@ def test_deploy_instruments_accepts_unit_prefixed_returned_alias(
         ) -> list[_InstrumentInfo]:
             del append
             deploy_definitions.extend(definitions)
-            returned_definition = _Definition(
-                alias="quel3-02-a01:Q00",
-                mode=definitions[0].mode,
-                role=definitions[0].role,
-                profile=definitions[0].profile,
-            )
             return [
                 _InstrumentInfo(
-                    id="inst-q00",
+                    id=f"inst-{definition.alias.lower()}",
                     port_id=port_id,
-                    definition=returned_definition,
+                    definition=_Definition(
+                        alias=f"quel3-02-a01:{definition.alias}",
+                        mode=definition.mode,
+                        role=definition.role,
+                        profile=definition.profile,
+                    ),
                 )
+                for definition in definitions
             ]
 
     class _FakeClient:
@@ -824,10 +844,20 @@ def test_deploy_instruments_accepts_unit_prefixed_returned_alias(
 
     deployed = manager.deploy_instruments(requests=(request,))
 
-    assert [definition.alias for definition in deploy_definitions] == ["Q00"]
+    assert [definition.alias for definition in deploy_definitions] == [
+        "Q00-0",
+        "Q00-1",
+        "Q00-2",
+        "Q00-3",
+    ]
     assert set(deployed) == {"Q00"}
-    assert deployed["Q00"][0].definition.alias == "quel3-02-a01:Q00"
-    assert manager.target_alias_map == {("BOX1", "Q00"): "quel3-02-a01:Q00"}
+    assert [info.definition.alias for info in deployed["Q00"]] == [
+        "quel3-02-a01:Q00-0",
+        "quel3-02-a01:Q00-1",
+        "quel3-02-a01:Q00-2",
+        "quel3-02-a01:Q00-3",
+    ]
+    assert manager.target_alias_map == {("BOX1", "Q00"): "quel3-02-a01:Q00-0"}
 
 
 def test_deploy_instruments_clears_cache_for_empty_requests() -> None:
@@ -978,16 +1008,22 @@ def test_deploy_instruments_groups_requests_by_port(
     assert deploy_calls[0][0] == "quel3-02-a01:tx_p04"
     assert deploy_calls[0][2] is False
     assert [definition.alias for definition in deploy_calls[0][1]] == [
-        "Q00",
-        "Q00-CR",
+        "Q00-0",
+        "Q00-1",
+        "Q00-2",
+        "Q00-3",
+        "Q00-CR-0",
+        "Q00-CR-1",
+        "Q00-CR-2",
+        "Q00-CR-3",
     ]
     assert manager.target_alias_map == {
-        ("BOX1", "Q00"): "quel3-02-a01:Q00",
-        ("BOX1", "Q00-CR"): "quel3-02-a01:Q00-CR",
+        ("BOX1", "Q00"): "quel3-02-a01:Q00-0",
+        ("BOX1", "Q00-CR"): "quel3-02-a01:Q00-CR-0",
     }
     assert set(deployed) == {"Q00", "Q00-CR"}
     assert deployed["Q00"][0].id == "id:quel3-02-a01:tx_p04:0"
-    assert deployed["Q00-CR"][0].id == "id:quel3-02-a01:tx_p04:1"
+    assert deployed["Q00-CR"][0].id == "id:quel3-02-a01:tx_p04:4"
 
 
 def test_deploy_instruments_uses_one_session_for_all_ports(
@@ -1453,12 +1489,14 @@ def test_refresh_instrument_cache_loads_existing_instruments(
             self.category = _Category()
 
     class _Definition:
-        def __init__(self, alias: str) -> None:
+        def __init__(self, alias: str, role: str) -> None:
             self.alias = alias
+            self.role = role
 
     class _InstrumentInfo:
-        def __init__(self, alias: str, port_id: str) -> None:
-            self.definition = _Definition(alias)
+        def __init__(self, alias: str, port_id: str, role: str) -> None:
+            self.id = f"inst-{alias.lower()}"
+            self.definition = _Definition(alias, role)
             self.port_id = port_id
 
     class _FakeClient:
@@ -1474,12 +1512,26 @@ def test_refresh_instrument_cache_loads_existing_instruments(
             _ = (exc_type, exc, tb)
 
         async def list_resource_infos(self) -> list[object]:
-            return [_ResourceInfo("inst-q00"), _ResourceInfo("inst-rq00")]
+            return [
+                *(_ResourceInfo(f"inst-q00-{index}") for index in range(4)),
+                _ResourceInfo("inst-rq00"),
+            ]
 
         async def get_instrument_info(self, resource_id: str) -> object:
             infos = {
-                "inst-q00": _InstrumentInfo("Q00", "quel3-02-a01:tx_p04"),
-                "inst-rq00": _InstrumentInfo("RQ00", "quel3-02-a01:trx_p00p04"),
+                **{
+                    f"inst-q00-{index}": _InstrumentInfo(
+                        f"Q00-{index}",
+                        "quel3-02-a01:tx_p04",
+                        "TRANSMITTER",
+                    )
+                    for index in range(4)
+                },
+                "inst-rq00": _InstrumentInfo(
+                    "RQ00",
+                    "quel3-02-a01:trx_p00p04",
+                    "TRANSCEIVER",
+                ),
             }
             return infos[resource_id]
 
@@ -1492,6 +1544,7 @@ def test_refresh_instrument_cache_loads_existing_instruments(
     cached = manager.refresh_instrument_cache()
 
     assert set(cached.keys()) == {"Q00", "RQ00"}
+    assert len(cached["Q00"]) == 4
     assert manager.target_alias_map == {}
     assert set(manager.last_deployed_instrument_infos.keys()) == {"Q00", "RQ00"}
 
@@ -1599,26 +1652,28 @@ def test_fetch_backend_settings_from_hardware_delegates_to_state_reader(
 def test_sync_backend_settings_to_cache_restores_alias_mapping_from_snapshot() -> None:
     """Given hardware snapshot, cache sync should restore alias mappings."""
     manager = Quel3ConfigurationManager()
+    transmitter_instruments = {
+        f"Q00-{index}": {
+            "resource_id": f"inst-q00-{index}",
+            "port_id": "quel3-02-a01:tx_p04",
+            "role": "TRANSMITTER",
+            "definition": {
+                "alias": f"Q00-{index}",
+                "role": "TRANSMITTER",
+                "mode": "FIXED_TIMELINE",
+                "profile": {
+                    "frequency_range_min": 4.1e9,
+                    "frequency_range_max": 4.3e9,
+                },
+            },
+        }
+        for index in range(4)
+    }
 
     manager.sync_backend_settings_to_cache(
         backend_settings={
             "BOX1": {
-                "instruments": {
-                    "Q00": {
-                        "resource_id": "inst-q00",
-                        "port_id": "quel3-02-a01:tx_p04",
-                        "role": "TRANSMITTER",
-                        "definition": {
-                            "alias": "Q00",
-                            "role": "TRANSMITTER",
-                            "mode": "FIXED_TIMELINE",
-                            "profile": {
-                                "frequency_range_min": 4.1e9,
-                                "frequency_range_max": 4.3e9,
-                            },
-                        },
-                    }
-                }
+                "instruments": transmitter_instruments,
             },
             "BOX2": {
                 "instruments": {
@@ -1642,15 +1697,22 @@ def test_sync_backend_settings_to_cache_restores_alias_mapping_from_snapshot() -
     )
 
     assert manager.target_alias_map == {
-        ("BOX1", "Q00"): "quel3-02-a01:Q00",
+        ("BOX1", "Q00"): "quel3-02-a01:Q00-0",
         ("BOX2", "RQ00"): "quel3-02-a02:RQ00",
     }
-    assert manager.last_deployed_instrument_infos["Q00"][0].id == "inst-q00"
+    assert [info.id for info in manager.last_deployed_instrument_infos["Q00"]] == [
+        "inst-q00-0",
+        "inst-q00-1",
+        "inst-q00-2",
+        "inst-q00-3",
+    ]
     assert (
         manager.last_deployed_instrument_infos["Q00"][0].port_id
         == "quel3-02-a01:tx_p04"
     )
-    assert manager.last_deployed_instrument_infos["Q00"][0].definition.alias == "Q00"
+    assert [
+        info.definition.alias for info in manager.last_deployed_instrument_infos["Q00"]
+    ] == ["Q00-0", "Q00-1", "Q00-2", "Q00-3"]
     assert (
         manager.last_deployed_instrument_infos["RQ00"][0].definition.role
         == "TRANSCEIVER"
@@ -1702,12 +1764,7 @@ def test_deploy_instruments_replaces_cached_alias(
         ),
     )
     manager._last_deployed_instrument_infos = {"Q00": (cached_info,)}  # noqa: SLF001
-    deploy_calls: list[tuple[str, list[object], bool]] = []
-    returned_info = _CachedInstrumentInfo(
-        id="inst-q00-new",
-        port_id="quel3-02-a01:tx_p04",
-        definition=_CachedDefinition(alias="Q00"),
-    )
+    deploy_calls: list[tuple[str, list[_Definition], bool]] = []
 
     class _FakeSession:
         async def __aenter__(self) -> _FakeSession:
@@ -1725,11 +1782,18 @@ def test_deploy_instruments_replaces_cached_alias(
             self,
             port_id: str,
             *,
-            definitions: list[object],
+            definitions: list[_Definition],
             append: bool = False,
-        ) -> list[object]:
+        ) -> list[_CachedInstrumentInfo]:
             deploy_calls.append((port_id, definitions, append))
-            return [returned_info]
+            return [
+                _CachedInstrumentInfo(
+                    id=f"inst-{definition.alias.lower()}-new",
+                    port_id=port_id,
+                    definition=_CachedDefinition(alias=definition.alias),
+                )
+                for definition in definitions
+            ]
 
     class _FakeClient:
         async def __aenter__(self) -> _FakeClient:
@@ -1774,8 +1838,13 @@ def test_deploy_instruments_replaces_cached_alias(
 
     assert len(deploy_calls) == 1
     assert deploy_calls[0][2] is False
-    assert deployed == {"Q00": (returned_info,)}
-    assert manager.target_alias_map == {("BOX1", "Q00"): "quel3-02-a01:Q00"}
+    assert [info.definition.alias for info in deployed["Q00"]] == [
+        "Q00-0",
+        "Q00-1",
+        "Q00-2",
+        "Q00-3",
+    ]
+    assert manager.target_alias_map == {("BOX1", "Q00"): "quel3-02-a01:Q00-0"}
 
 
 def test_deploy_instruments_replaces_cached_port_in_one_batched_deploy(
@@ -1908,5 +1977,14 @@ def test_deploy_instruments_replaces_cached_port_in_one_batched_deploy(
 
     assert len(deploy_calls) == 1
     assert deploy_calls[0][2] is False
-    assert [definition.alias for definition in deploy_calls[0][1]] == ["Q00", "Q00-CR"]
+    assert [definition.alias for definition in deploy_calls[0][1]] == [
+        "Q00-0",
+        "Q00-1",
+        "Q00-2",
+        "Q00-3",
+        "Q00-CR-0",
+        "Q00-CR-1",
+        "Q00-CR-2",
+        "Q00-CR-3",
+    ]
     assert set(deployed) == {"Q00", "Q00-CR"}


### PR DESCRIPTION
## Summary

- deploy each QuEL-3 `TRANSMITTER` as four fixed-timeline instruments suffixed `-0` through `-3`
- expand a transmitter timeline across all four physical instruments without changing amplitude, phase, frequency, or timing
- group the four physical instruments under their logical alias in backend caches
- keep non-transmitter instruments on the existing single-instrument path

## Compatibility

Existing QuEL-3 transmitter instruments must be redeployed so the four suffixed resources exist. Legacy suffix-free transmitter resources are rejected during execution.

## Validation

- focused Ruff check and format: passed
- focused Pyright check: passed
- QuEL-3 backend/system/measurement tests: 108 passed
- full `uv run pytest`: 1252 passed, 3 unrelated failures in the current worktree

## Follow-up

The public system-configuration guide and v1.5.0 release notes should document the four-instrument transmitter behavior in a separate docs update.