### PR TITLE
fix: make calibration notes JSON-safe with NumPy scalars

### DIFF
--- a/src/qubex/analysis/fitting.py
+++ b/src/qubex/analysis/fitting.py
@@ -1726,7 +1726,7 @@ def fit_rabi(
     dot_product = np.dot(data_direction, principal_component)
     ge_vector = principal_component if dot_product > 0 else -principal_component
     angle_ge = np.arctan2(ge_vector[1], ge_vector[0])
-    angle = angle_ge + np.pi / 2
+    angle = float(angle_ge + np.pi / 2)
 
     rotated = data * np.exp(-1j * angle)
     distance = float(np.mean(rotated.real))

--- a/src/qubex/experiment/models/experiment_note.py
+++ b/src/qubex/experiment/models/experiment_note.py
@@ -69,6 +69,7 @@ class ExperimentNote:
         ValueError
             If the value is not JSON serializable.
         """
+        value = self._sanitize_for_json(value)
         if not self._is_json_serializable(value):
             raise ValueError(f"Value for key '{key}' is not JSON serializable.")
 
@@ -77,9 +78,6 @@ class ExperimentNote:
         if isinstance(old_value, dict) and isinstance(value, dict):
             self._update_dict_recursively(old_value, value)
         else:
-            # Replace any non-finite float (NaN, Infinity, -Infinity) with None
-            if isinstance(value, (float, np.floating)) and not np.isfinite(value):
-                value = None
             self._dict[key] = value
 
         if old_value is not None:
@@ -307,20 +305,26 @@ class ExperimentNote:
 
     def _sanitize_for_json(self, obj: Any) -> Any:
         """
-        Recursively replace non-finite float values with None.
+        Recursively convert NumPy scalars and non-finite floats for JSON.
 
         Resulting structure conforms to RFC 8259 (no NaN/Infinity values).
 
 
-        Returns a sanitized copy of the object (dicts/lists are recreated).
+        Returns a sanitized copy of the object (containers are recreated).
         """
+        # NumPy scalars -> corresponding Python scalars
+        if isinstance(obj, np.generic):
+            obj = obj.item()
+
         # dict -> sanitize each value
         if isinstance(obj, dict):
             return {k: self._sanitize_for_json(v) for k, v in obj.items()}
 
-        # list/tuple -> sanitize each element (tuples become lists for JSON)
-        if isinstance(obj, (list, tuple)):
+        # list/tuple -> sanitize each element while preserving the container type
+        if isinstance(obj, list):
             return [self._sanitize_for_json(v) for v in obj]
+        if isinstance(obj, tuple):
+            return tuple(self._sanitize_for_json(v) for v in obj)
 
         # floats (including numpy floats): convert non-finite to None
         if isinstance(obj, (float, np.floating)):


### PR DESCRIPTION
## Background

PR #355 introduced NumPy 2 compatibility changes that can leave calibration results as NumPy float32 scalars. Standard JSON serialization rejects these values, including RabiParam.angle.

## Summary

- Return the Rabi fitting angle as a built-in Python float.
- Normalize NumPy scalar values at the ExperimentNote boundary before validation and storage.
- Preserve tuple containers and continue rejecting NumPy arrays and complex values.

## Compatibility

This adds support for NumPy scalar inputs without changing public APIs or stored JSON schemas. Existing JSON-compatible values retain their behavior.

## Validation

- Ruff on changed files: passed.
- Pyright on changed files: 0 errors.