### PR TITLE
Feature/mcm randomized benchmarking

### DIFF
--- a/src/qubex/contrib/__init__.py
+++ b/src/qubex/contrib/__init__.py
@@ -38,6 +38,10 @@ from .experiment.gf_calibration import (
     gf_ramsey_experiment,
     obtain_gf_rabi_params,
 )
+from .experiment.mcm_randomized_benchmarking import (
+    mcm_randomized_benchmarking,
+    mcm_rb_sequence,
+)
 from .experiment.measure_efh_chevron_pattern import (
     estimate_ef_frequency_from_chevron,
     estimate_ef_frequency_from_chevron_adaptive,
@@ -160,6 +164,8 @@ __all__ = [
     "ghz_state_tomography",
     "interleaved_purity_benchmarking",
     "ipb_experiment",
+    "mcm_randomized_benchmarking",
+    "mcm_rb_sequence",
     "measure_1d_cluster_state",
     "measure_bell_state_fidelities",
     "measure_bell_states",

--- a/src/qubex/contrib/experiment/__init__.py
+++ b/src/qubex/contrib/experiment/__init__.py
@@ -33,6 +33,10 @@ from .gf_calibration import (
     gf_ramsey_experiment,
     obtain_gf_rabi_params,
 )
+from .mcm_randomized_benchmarking import (
+    mcm_randomized_benchmarking,
+    mcm_rb_sequence,
+)
 from .measure_efh_chevron_pattern import (
     estimate_ef_frequency_from_chevron,
     estimate_ef_frequency_from_chevron_adaptive,
@@ -141,6 +145,8 @@ __all__ = [
     "ghz_state_tomography",
     "interleaved_purity_benchmarking",
     "ipb_experiment",
+    "mcm_randomized_benchmarking",
+    "mcm_rb_sequence",
     "measure_1d_cluster_state",
     "measure_bell_state_fidelities",
     "measure_bell_states",

--- a/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
+++ b/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Collection
 from dataclasses import dataclass
+from numbers import Real
 from typing import Literal, TypedDict, cast
 
 import numpy as np
@@ -21,7 +22,7 @@ from qubex.experiment.experiment_constants import (
 )
 from qubex.experiment.models import Result
 from qubex.measurement.models.measure_result import MultipleMeasureResult
-from qubex.pulse import Blank, PulseArray, PulseSchedule, VirtualZ, Waveform
+from qubex.pulse import Blank, FlatTop, PulseArray, PulseSchedule, VirtualZ, Waveform
 
 MCMRBProtocol = Literal["mcm-rb", "delay-rb", "mcm-rep"]
 
@@ -55,6 +56,15 @@ class _CompiledCliffordSequence:
 
     cliffords: tuple[PulseArray, ...]
     inverse: PulseArray
+
+
+@dataclass(frozen=True)
+class _ReadoutTiming:
+    """Active readout interval and ramp length on the sampling grid."""
+
+    active_start_samples: int
+    active_length_samples: int
+    ramp_length_samples: int
 
 
 class _TargetAnalysis(TypedDict):
@@ -101,6 +111,16 @@ def _validate_positive_integer(value: object, *, name: str) -> int:
     return resolved
 
 
+def _validate_positive_real(value: object, *, name: str) -> float:
+    """Return a positive finite scalar real after rejecting booleans."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"`{name}` must be a real number.")
+    resolved = float(value)
+    if not np.isfinite(resolved) or resolved <= 0:
+        raise ValueError(f"`{name}` must be positive and finite.")
+    return resolved
+
+
 def _resolve_qubit_pair(
     exp: Experiment,
     control: str,
@@ -134,10 +154,78 @@ def _validate_waveform(
     if waveform.duration <= 0:
         raise ValueError(f"`{name}` must have positive duration.")
 
+    if not isinstance(waveform, PulseArray):
+        return
+    for nested_waveform in waveform.get_flattened_waveforms(apply_frame_shifts=False):
+        if not np.isclose(
+            nested_waveform.sampling_period,
+            expected_sampling_period,
+            rtol=0.0,
+            atol=1e-12,
+        ):
+            raise ValueError(
+                f"Every pulse in `{name}` must use the experiment sampling period: "
+                f"{nested_waveform.sampling_period} ns != "
+                f"{expected_sampling_period} ns."
+            )
+
 
 def _blank(duration: float, sampling_period: float) -> Blank:
     """Build a blank pulse on the active sampling grid."""
     return Blank(duration=duration, sampling_period=sampling_period)
+
+
+def _infer_readout_timing(measurement: Waveform) -> _ReadoutTiming:
+    """Infer the active readout interval and FlatTop ramp in samples."""
+    active_indices = np.flatnonzero(np.asarray(measurement.values) != 0.0)
+    if active_indices.size == 0:
+        raise ValueError(
+            "The active readout interval cannot be inferred from an all-zero "
+            "measurement waveform."
+        )
+    active_start_samples = int(active_indices[0])
+    active_length_samples = int(active_indices[-1]) - active_start_samples + 1
+
+    if isinstance(measurement, PulseArray):
+        flat_tops = [
+            element
+            for element in measurement.flattened_elements
+            if isinstance(element, FlatTop)
+        ]
+    elif isinstance(measurement, FlatTop):
+        flat_tops = [measurement]
+    else:
+        flat_tops = []
+    if len(flat_tops) > 1:
+        raise ValueError(
+            "Echo timing requires a measurement waveform with at most one "
+            "FlatTop pulse."
+        )
+
+    ramp_length_samples = 0
+    if flat_tops:
+        ramp_samples = flat_tops[0].tau / measurement.sampling_period
+        ramp_length_samples = round(ramp_samples)
+        if not np.isclose(
+            ramp_samples,
+            ramp_length_samples,
+            rtol=0.0,
+            atol=1e-12,
+        ):
+            raise ValueError(
+                "The readout ramp duration must align with the measurement "
+                "sampling grid."
+            )
+        if 2 * ramp_length_samples > active_length_samples:
+            raise ValueError(
+                "The active readout duration must be at least twice the ramp duration."
+            )
+
+    return _ReadoutTiming(
+        active_start_samples=active_start_samples,
+        active_length_samples=active_length_samples,
+        ramp_length_samples=ramp_length_samples,
+    )
 
 
 def _measurement_control_block(
@@ -146,31 +234,60 @@ def _measurement_control_block(
     sampling_period: float,
     echo_x180: Waveform | None,
 ) -> Waveform:
-    """Build an idle or symmetric X-X echo matching one measurement window."""
+    """Build an idle or active-readout-aligned X-X echo block."""
     if echo_x180 is None:
         return _blank(measurement.duration, sampling_period)
 
-    free_samples = measurement.length - 2 * echo_x180.length
-    if free_samples < 0:
+    if measurement.length < 2 * echo_x180.length:
         raise ValueError(
             "The measurement duration must be at least twice the echo X180 "
             "pulse duration."
         )
-    if free_samples % 4 != 0:
+    timing = _infer_readout_timing(measurement)
+
+    # Trim half a ramp from each side of the active interval, then align the
+    # X180 centers with the quarter and three-quarter points of that interval.
+    # Quarter-sample units keep half-ramp and quarter-interval arithmetic exact.
+    first_center_quarters = (
+        4 * timing.active_start_samples
+        + timing.active_length_samples
+        + timing.ramp_length_samples
+    )
+    second_center_quarters = (
+        4 * timing.active_start_samples
+        + 3 * timing.active_length_samples
+        - timing.ramp_length_samples
+    )
+    leading_quarters = first_center_quarters - 2 * echo_x180.length
+    middle_quarters = (
+        second_center_quarters - first_center_quarters - 4 * echo_x180.length
+    )
+    trailing_quarters = (
+        4 * measurement.length - second_center_quarters - 2 * echo_x180.length
+    )
+    blank_quarters = (leading_quarters, middle_quarters, trailing_quarters)
+    if any(samples < 0 for samples in blank_quarters):
         raise ValueError(
-            "The free time in an echoed measurement block must be divisible "
-            "into four equal sampling-grid intervals."
+            "The measurement timing does not provide enough room for two "
+            "nonoverlapping echo X180 pulses at the ramp-trimmed active "
+            "readout quarter points."
+        )
+    if any(samples % 4 != 0 for samples in blank_quarters):
+        raise ValueError(
+            "The ramp-trimmed active readout quarter points do not align the "
+            "echo X180 pulses to the sampling grid."
         )
 
-    edge_duration = free_samples // 4 * sampling_period
-    middle_duration = free_samples // 2 * sampling_period
+    leading_duration, middle_duration, trailing_duration = (
+        samples // 4 * sampling_period for samples in blank_quarters
+    )
     return PulseArray(
         [
-            _blank(edge_duration, sampling_period),
+            _blank(leading_duration, sampling_period),
             echo_x180,
             _blank(middle_duration, sampling_period),
             echo_x180,
-            _blank(edge_duration, sampling_period),
+            _blank(trailing_duration, sampling_period),
         ]
     )
 
@@ -345,11 +462,16 @@ def mcm_rb_sequence(
         Nonnegative seed used to generate the one-qubit Clifford sequence.
     control_echo
         Whether to apply an X-X echo to the control during every measurement
-        or reference-delay window.
+        or reference-delay window. The X180 centers are placed at the quarter
+        and three-quarter points of the active readout interval after trimming
+        half a ramp duration from each end.
     x90
         Optional control X90 waveform override.
     measurement_waveform
-        Optional ancilla readout waveform override.
+        Optional ancilla readout waveform override. With `control_echo=True`,
+        the active interval is inferred from its nonzero samples. At most one
+        FlatTop pulse may be present; other pulse shapes are treated as having
+        zero ramp duration.
     echo_x180
         Optional control X180 waveform override used by the X-X echo. Ignored
         when `control_echo=False`.
@@ -748,19 +870,25 @@ def mcm_randomized_benchmarking(
         `"mcm-rep"`. The same generated Clifford sequence is shared across
         protocols for each sequence length and seed.
     control_echo
-        Whether to insert a symmetric X-X echo on the control during every
-        measurement or duration-matched delay window.
+        Whether to insert an X-X echo on the control during every measurement
+        or duration-matched delay window. The X180 centers are placed at the
+        quarter and three-quarter points of the active readout interval after
+        trimming half a ramp duration from each end.
     x90
         Optional control X90 waveform override.
     measurement_waveform
-        Optional ancilla readout waveform override.
+        Optional ancilla readout waveform override. With `control_echo=True`,
+        the active interval is inferred from its nonzero samples. At most one
+        FlatTop pulse may be present; other pulse shapes are treated as having
+        zero ramp duration.
     echo_x180
         Optional control X180 waveform override for echoed measurement blocks.
         Ignored when `control_echo=False`.
     n_shots
         Number of shots per schedule. Defaults to the experiment default.
     shot_interval
-        Interval between shots in ns. Defaults to the experiment default.
+        Positive finite interval between shots in ns. Defaults to the
+        experiment default.
     time_integration
         Whether to integrate each capture over time.
     xaxis_type
@@ -810,8 +938,9 @@ def mcm_randomized_benchmarking(
         DEFAULT_SHOTS if n_shots is None else n_shots,
         name="n_shots",
     )
-    resolved_shot_interval = (
-        DEFAULT_INTERVAL if shot_interval is None else float(shot_interval)
+    resolved_shot_interval = _validate_positive_real(
+        DEFAULT_INTERVAL if shot_interval is None else shot_interval,
+        name="shot_interval",
     )
     resolved_plot = True if plot is None else plot
     resolved_save_image = False if save_image is None else save_image

--- a/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
+++ b/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
@@ -1,0 +1,881 @@
+"""Measurement-crosstalk randomized benchmarking experiments."""
+
+from __future__ import annotations
+
+from collections.abc import Collection
+from dataclasses import dataclass
+from typing import Literal, TypedDict, cast
+
+import numpy as np
+from numpy.typing import ArrayLike, NDArray
+from plotly.graph_objects import Figure
+from tqdm import tqdm
+
+import qubex.visualization as viz
+from qubex.analysis import FitResult, FitStatus, fitting
+from qubex.experiment import Experiment
+from qubex.experiment.experiment_constants import (
+    DEFAULT_INTERVAL,
+    DEFAULT_RB_N_TRIALS,
+    DEFAULT_SHOTS,
+)
+from qubex.experiment.models import Result
+from qubex.measurement.models.measure_result import MultipleMeasureResult
+from qubex.pulse import Blank, PulseArray, PulseSchedule, VirtualZ, Waveform
+
+MCMRBProtocol = Literal["mcm-rb", "delay-rb", "mcm-rep"]
+
+_MCM_RB: MCMRBProtocol = "mcm-rb"
+_DELAY_RB: MCMRBProtocol = "delay-rb"
+_MCM_REP: MCMRBProtocol = "mcm-rep"
+_MCM_RB_PROTOCOLS: tuple[MCMRBProtocol, ...] = (_MCM_RB, _DELAY_RB, _MCM_REP)
+
+
+@dataclass(frozen=True)
+class _SequenceResources:
+    """Resolved labels and waveforms shared by all protocol schedules."""
+
+    control: str
+    ancilla: str
+    readout_label: str
+    sampling_period: float
+    x90: Waveform
+    measurement: Waveform
+    control_during_measurement: Waveform
+
+    @property
+    def targets(self) -> tuple[str, str]:
+        """Return the control and ancilla labels."""
+        return self.control, self.ancilla
+
+
+@dataclass(frozen=True)
+class _CompiledCliffordSequence:
+    """Physical waveforms for randomized Cliffords and their inverse."""
+
+    cliffords: tuple[PulseArray, ...]
+    inverse: PulseArray
+
+
+class _TargetAnalysis(TypedDict):
+    """Analysis payload for one protocol and terminal-measurement target."""
+
+    trials: NDArray[np.float64]
+    mean: NDArray[np.float64]
+    std: NDArray[np.float64]
+    fit_result: FitResult
+    decay_parameter: float | None
+    decay_parameter_err: float | None
+    error_per_cycle: float | None
+    error_per_cycle_err: float | None
+
+
+_TrialData = dict[MCMRBProtocol, dict[str, NDArray[np.float64]]]
+_ProtocolResults = dict[MCMRBProtocol, dict[str, _TargetAnalysis]]
+
+
+def _validate_protocol(protocol: str) -> MCMRBProtocol:
+    """Validate and narrow one protocol name."""
+    if protocol not in _MCM_RB_PROTOCOLS:
+        raise ValueError(
+            f"Invalid `protocol`: {protocol!r}. Expected one of {_MCM_RB_PROTOCOLS}."
+        )
+    return cast(MCMRBProtocol, protocol)
+
+
+def _validate_nonnegative_integer(value: object, *, name: str) -> int:
+    """Return a scalar integer after rejecting booleans and negative values."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"`{name}` must be a nonnegative integer.")
+    resolved = int(value)
+    if resolved < 0:
+        raise ValueError(f"`{name}` must be a nonnegative integer.")
+    return resolved
+
+
+def _validate_positive_integer(value: object, *, name: str) -> int:
+    """Return a scalar integer after requiring a value greater than zero."""
+    resolved = _validate_nonnegative_integer(value, name=name)
+    if resolved == 0:
+        raise ValueError(f"`{name}` must be a positive integer.")
+    return resolved
+
+
+def _resolve_qubit_pair(
+    exp: Experiment,
+    control: str,
+    ancilla: str,
+) -> tuple[str, str]:
+    """Resolve and validate distinct control and ancilla qubit labels."""
+    control_qubit = exp.ctx.resolve_qubit_label(control)
+    ancilla_qubit = exp.ctx.resolve_qubit_label(ancilla)
+    if control_qubit == ancilla_qubit:
+        raise ValueError("`control` and `ancilla` must resolve to different qubits.")
+    return control_qubit, ancilla_qubit
+
+
+def _validate_waveform(
+    waveform: Waveform,
+    *,
+    expected_sampling_period: float,
+    name: str,
+) -> None:
+    """Validate one nonempty waveform against the experiment sampling grid."""
+    if not np.isclose(
+        waveform.sampling_period,
+        expected_sampling_period,
+        rtol=0.0,
+        atol=1e-12,
+    ):
+        raise ValueError(
+            f"`{name}` sampling period must match the experiment sampling period: "
+            f"{waveform.sampling_period} ns != {expected_sampling_period} ns."
+        )
+    if waveform.duration <= 0:
+        raise ValueError(f"`{name}` must have positive duration.")
+
+
+def _blank(duration: float, sampling_period: float) -> Blank:
+    """Build a blank pulse on the active sampling grid."""
+    return Blank(duration=duration, sampling_period=sampling_period)
+
+
+def _measurement_control_block(
+    *,
+    measurement: Waveform,
+    sampling_period: float,
+    echo_x180: Waveform | None,
+) -> Waveform:
+    """Build an idle or symmetric X-X echo matching one measurement window."""
+    if echo_x180 is None:
+        return _blank(measurement.duration, sampling_period)
+
+    free_samples = measurement.length - 2 * echo_x180.length
+    if free_samples < 0:
+        raise ValueError(
+            "The measurement duration must be at least twice the echo X180 "
+            "pulse duration."
+        )
+    if free_samples % 4 != 0:
+        raise ValueError(
+            "The free time in an echoed measurement block must be divisible "
+            "into four equal sampling-grid intervals."
+        )
+
+    edge_duration = free_samples // 4 * sampling_period
+    middle_duration = free_samples // 2 * sampling_period
+    return PulseArray(
+        [
+            _blank(edge_duration, sampling_period),
+            echo_x180,
+            _blank(middle_duration, sampling_period),
+            echo_x180,
+            _blank(edge_duration, sampling_period),
+        ]
+    )
+
+
+def _resolve_sequence_resources(
+    exp: Experiment,
+    *,
+    control: str,
+    ancilla: str,
+    control_echo: bool,
+    x90: Waveform | None,
+    measurement_waveform: Waveform | None,
+    echo_x180: Waveform | None,
+) -> _SequenceResources:
+    """Resolve and validate labels and waveforms used by every protocol."""
+    sampling_period = float(exp.ctx.measurement.sampling_period)
+    if not np.isfinite(sampling_period) or sampling_period <= 0:
+        raise ValueError("The experiment sampling period must be positive and finite.")
+
+    x90_waveform = x90 if x90 is not None else exp.pulse.x90(control)
+    measurement = (
+        measurement_waveform
+        if measurement_waveform is not None
+        else exp.pulse.readout(ancilla)
+    )
+    _validate_waveform(
+        x90_waveform,
+        expected_sampling_period=sampling_period,
+        name="x90",
+    )
+    _validate_waveform(
+        measurement,
+        expected_sampling_period=sampling_period,
+        name="measurement_waveform",
+    )
+
+    resolved_echo: Waveform | None = None
+    if control_echo:
+        resolved_echo = echo_x180 if echo_x180 is not None else exp.pulse.x180(control)
+        _validate_waveform(
+            resolved_echo,
+            expected_sampling_period=sampling_period,
+            name="echo_x180",
+        )
+
+    return _SequenceResources(
+        control=control,
+        ancilla=ancilla,
+        readout_label=exp.experiment_system.resolve_read_label(ancilla),
+        sampling_period=sampling_period,
+        x90=x90_waveform,
+        measurement=measurement,
+        control_during_measurement=_measurement_control_block(
+            measurement=measurement,
+            sampling_period=sampling_period,
+            echo_x180=resolved_echo,
+        ),
+    )
+
+
+def _clifford_waveform(gates: list[str], x90: Waveform) -> PulseArray:
+    """Translate one Clifford decomposition to physical and virtual pulses."""
+    elements: list[Waveform | VirtualZ] = []
+    for gate in gates:
+        if gate == "X90":
+            elements.append(x90)
+        elif gate == "Z90":
+            elements.append(VirtualZ(np.pi / 2))
+        else:
+            raise ValueError(f"Unsupported 1Q Clifford gate `{gate}`.")
+    return PulseArray(elements)
+
+
+def _generate_clifford_sequence(
+    exp: Experiment,
+    *,
+    n_cliffords: int,
+    seed: int | None,
+    x90: Waveform,
+) -> _CompiledCliffordSequence:
+    """Generate and compile one randomized Clifford sequence and its inverse."""
+    cliffords, inverse = (
+        exp.benchmarking_service.clifford_generator.create_rb_sequences(
+            n=n_cliffords,
+            type="1Q",
+            seed=seed,
+        )
+    )
+    return _CompiledCliffordSequence(
+        cliffords=tuple(_clifford_waveform(clifford, x90) for clifford in cliffords),
+        inverse=_clifford_waveform(inverse, x90),
+    )
+
+
+def _build_protocol_schedule(
+    resources: _SequenceResources,
+    clifford_sequence: _CompiledCliffordSequence,
+    *,
+    protocol: MCMRBProtocol,
+) -> PulseSchedule:
+    """Build one protocol schedule from shared resources and Cliffords."""
+    with PulseSchedule([resources.control, resources.readout_label]) as schedule:
+        for clifford in clifford_sequence.cliffords:
+            control_operation: Waveform
+            if protocol == _MCM_REP:
+                control_operation = _blank(
+                    clifford.duration,
+                    resources.sampling_period,
+                )
+            else:
+                control_operation = clifford
+            schedule.add(resources.control, control_operation)
+            schedule.barrier()
+
+            ancilla_operation: Waveform
+            if protocol == _DELAY_RB:
+                ancilla_operation = _blank(
+                    resources.measurement.duration,
+                    resources.sampling_period,
+                )
+            else:
+                ancilla_operation = resources.measurement
+            schedule.add(resources.readout_label, ancilla_operation)
+            schedule.add(
+                resources.control,
+                resources.control_during_measurement,
+            )
+            schedule.barrier()
+
+        final_control_operation: Waveform
+        if protocol == _MCM_REP:
+            final_control_operation = _blank(
+                clifford_sequence.inverse.duration,
+                resources.sampling_period,
+            )
+        else:
+            final_control_operation = clifford_sequence.inverse
+        schedule.add(resources.control, final_control_operation)
+
+    return schedule
+
+
+def mcm_rb_sequence(
+    exp: Experiment,
+    control: str,
+    ancilla: str,
+    *,
+    protocol: MCMRBProtocol,
+    n_cliffords: int,
+    seed: int | None = None,
+    control_echo: bool = False,
+    x90: Waveform | None = None,
+    measurement_waveform: Waveform | None = None,
+    echo_x180: Waveform | None = None,
+) -> PulseSchedule:
+    """
+    Build one MCM-RB, delay-RB, or MCM-repetition pulse schedule.
+
+    Parameters
+    ----------
+    exp
+        Experiment instance that provides pulse and Clifford services.
+    control
+        Qubit receiving the randomized Clifford sequence.
+    ancilla
+        Qubit measured during every randomized-benchmarking cycle.
+    protocol
+        Sequence variant: `"mcm-rb"`, `"delay-rb"`, or `"mcm-rep"`.
+    n_cliffords
+        Number of randomized cycles. Must be nonnegative.
+    seed
+        Nonnegative seed used to generate the one-qubit Clifford sequence.
+    control_echo
+        Whether to apply an X-X echo to the control during every measurement
+        or reference-delay window.
+    x90
+        Optional control X90 waveform override.
+    measurement_waveform
+        Optional ancilla readout waveform override.
+    echo_x180
+        Optional control X180 waveform override used by the X-X echo. Ignored
+        when `control_echo=False`.
+
+    Returns
+    -------
+    PulseSchedule
+        Schedule before the terminal measurements are appended by execution.
+
+    Raises
+    ------
+    TypeError
+        Raised when a Clifford count or seed has an invalid type.
+    ValueError
+        Raised for invalid targets, protocol names, lengths, waveform timing,
+        or echo timing.
+
+    Notes
+    -----
+    `mcm-rep` replaces every randomized Clifford and the final inverse with
+    duration-matched delays. The three protocols therefore have equal total
+    duration for the same Clifford sequence and seed.
+    """
+    resolved_protocol = _validate_protocol(protocol)
+    resolved_n_cliffords = _validate_nonnegative_integer(
+        n_cliffords,
+        name="n_cliffords",
+    )
+    resolved_seed = (
+        None if seed is None else _validate_nonnegative_integer(seed, name="seed")
+    )
+    control_qubit, ancilla_qubit = _resolve_qubit_pair(exp, control, ancilla)
+    resources = _resolve_sequence_resources(
+        exp,
+        control=control_qubit,
+        ancilla=ancilla_qubit,
+        control_echo=control_echo,
+        x90=x90,
+        measurement_waveform=measurement_waveform,
+        echo_x180=echo_x180,
+    )
+    clifford_sequence = _generate_clifford_sequence(
+        exp,
+        n_cliffords=resolved_n_cliffords,
+        seed=resolved_seed,
+        x90=resources.x90,
+    )
+    return _build_protocol_schedule(
+        resources,
+        clifford_sequence,
+        protocol=resolved_protocol,
+    )
+
+
+def _integer_array(values: ArrayLike, *, name: str) -> NDArray[np.int64]:
+    """Validate and return a one-dimensional nonnegative integer array."""
+    raw = np.asarray(values)
+    if raw.ndim != 1 or raw.size == 0:
+        raise ValueError(f"`{name}` must be a nonempty one-dimensional array.")
+    if any(isinstance(value, (bool, np.bool_)) for value in raw.tolist()):
+        raise ValueError(f"`{name}` must contain integers, not booleans.")
+    try:
+        numeric = raw.astype(np.float64)
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"`{name}` must contain integers.") from exc
+    if not np.all(np.isfinite(numeric)) or not np.all(numeric == np.floor(numeric)):
+        raise ValueError(f"`{name}` must contain integers.")
+    if np.any(numeric >= 2**63):
+        raise ValueError(f"`{name}` values are too large.")
+    integer_values = numeric.astype(np.int64)
+    if np.any(integer_values < 0):
+        raise ValueError(f"`{name}` must contain nonnegative integers.")
+    return integer_values
+
+
+def _resolve_n_cliffords_range(
+    n_cliffords_range: ArrayLike | None,
+) -> NDArray[np.int64]:
+    """Return and validate the randomized-benchmarking sweep range."""
+    if n_cliffords_range is None:
+        n_cliffords = np.insert(
+            np.ceil(np.geomspace(1, 150, 14)).astype(np.int64),
+            0,
+            0,
+        )
+    else:
+        n_cliffords = _integer_array(
+            n_cliffords_range,
+            name="n_cliffords_range",
+        )
+    if len(n_cliffords) < 3:
+        raise ValueError("`n_cliffords_range` must contain at least three values.")
+    if np.any(np.diff(n_cliffords) <= 0):
+        raise ValueError("`n_cliffords_range` must be strictly increasing.")
+    return n_cliffords
+
+
+def _resolve_protocols(
+    protocols: Collection[MCMRBProtocol] | MCMRBProtocol | None,
+) -> tuple[MCMRBProtocol, ...]:
+    """Return unique protocol names in caller-specified order."""
+    if protocols is None:
+        return _MCM_RB_PROTOCOLS
+    candidates = [protocols] if isinstance(protocols, str) else list(protocols)
+    if not candidates:
+        raise ValueError("`protocols` must not be empty.")
+    resolved = cast(
+        tuple[MCMRBProtocol, ...],
+        tuple(_validate_protocol(protocol) for protocol in candidates),
+    )
+    if len(resolved) != len(set(resolved)):
+        raise ValueError("`protocols` must not contain duplicate values.")
+    return resolved
+
+
+def _resolve_seeds(
+    seeds: ArrayLike | None,
+    *,
+    n_trials: int,
+) -> NDArray[np.int64]:
+    """Return one validated random seed for every trial."""
+    if seeds is None:
+        return (
+            np.random.default_rng()
+            .integers(
+                0,
+                2**32,
+                size=n_trials,
+                dtype=np.uint32,
+            )
+            .astype(np.int64)
+        )
+    resolved = _integer_array(seeds, name="seeds")
+    if len(resolved) != n_trials:
+        raise ValueError("The number of seeds must be equal to the number of trials.")
+    return resolved
+
+
+def _extract_terminal_iq(
+    measure_result: MultipleMeasureResult,
+    exp: Experiment,
+    *,
+    target: str,
+) -> complex:
+    """Return the final capture for a qubit from a multi-capture result."""
+    readout_target = exp.experiment_system.resolve_read_label(target)
+    if readout_target in measure_result.data:
+        data_target = readout_target
+    elif target in measure_result.data:
+        data_target = target
+    else:
+        raise KeyError(
+            f"Neither `{readout_target}` nor `{target}` exists in measurement "
+            f"result targets {list(measure_result.data)}."
+        )
+    captures = measure_result.data[data_target]
+    if not captures:
+        raise ValueError(f"Measurement result for `{data_target}` has no captures.")
+    return complex(np.mean(np.asarray(captures[-1].kerneled)))
+
+
+def _ground_state_probability(exp: Experiment, target: str, iq: complex) -> float:
+    """Normalize a terminal IQ value into ground-state probability."""
+    normalized = exp.pulse.rabi_params[target].normalize(
+        np.asarray([iq], dtype=np.complex128)
+    )
+    return float(np.real(np.mean(np.asarray(normalized)))) / 2.0 + 0.5
+
+
+def _acquire_trials(
+    exp: Experiment,
+    *,
+    resources: _SequenceResources,
+    protocols: tuple[MCMRBProtocol, ...],
+    n_cliffords_range: NDArray[np.int64],
+    seeds: NDArray[np.int64],
+    n_shots: int,
+    shot_interval: float,
+    time_integration: bool,
+    enable_tqdm: bool,
+) -> _TrialData:
+    """Execute all schedules and collect terminal ground-state probabilities."""
+    trials: _TrialData = {
+        protocol: {
+            target: np.empty(
+                (len(n_cliffords_range), len(seeds)),
+                dtype=np.float64,
+            )
+            for target in resources.targets
+        }
+        for protocol in protocols
+    }
+    exp.ctx.reset_awg_and_capunits(qubits=set(resources.targets))
+    progress = tqdm(
+        total=len(n_cliffords_range) * len(seeds) * len(protocols),
+        desc="Running MCM randomized benchmarking",
+        disable=not enable_tqdm,
+    )
+    try:
+        for n_index, n_cliffords in enumerate(n_cliffords_range):
+            for trial_index, seed in enumerate(seeds):
+                clifford_sequence = _generate_clifford_sequence(
+                    exp,
+                    n_cliffords=int(n_cliffords),
+                    seed=int(seed),
+                    x90=resources.x90,
+                )
+                for protocol in protocols:
+                    sequence = _build_protocol_schedule(
+                        resources,
+                        clifford_sequence,
+                        protocol=protocol,
+                    )
+                    measure_result = exp.measurement_service.execute(
+                        sequence,
+                        mode="avg",
+                        n_shots=n_shots,
+                        shot_interval=shot_interval,
+                        time_integration=time_integration,
+                        state_classification=False,
+                        final_measurement=True,
+                        reset_awg_and_capunits=False,
+                        plot=False,
+                    )
+                    for target in resources.targets:
+                        iq = _extract_terminal_iq(
+                            measure_result,
+                            exp,
+                            target=target,
+                        )
+                        trials[protocol][target][n_index, trial_index] = (
+                            _ground_state_probability(exp, target, iq)
+                        )
+                    progress.update()
+    finally:
+        progress.close()
+    return trials
+
+
+def _fit_protocol_target(
+    *,
+    protocol: MCMRBProtocol,
+    target: str,
+    n_cliffords: NDArray[np.int64],
+    trials: NDArray[np.float64],
+    plot: bool,
+    xaxis_type: Literal["linear", "log"],
+) -> _TargetAnalysis:
+    """Aggregate and fit one target's terminal survival probabilities."""
+    mean = np.mean(trials, axis=1)
+    std = np.std(trials, axis=1)
+    fit_result = fitting.fit_rb(
+        target=target,
+        x=n_cliffords,
+        y=mean,
+        error_y=std if trials.shape[1] > 1 else None,
+        bounds=((0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
+        title=f"{protocol} randomized benchmarking",
+        xlabel="Number of Clifford/measurement cycles",
+        ylabel="Ground-state probability",
+        xaxis_type=xaxis_type,
+        yaxis_type="linear",
+        plot=plot,
+    )
+    decay_parameter: float | None = None
+    decay_parameter_err: float | None = None
+    error_per_cycle: float | None = None
+    error_per_cycle_err: float | None = None
+    if fit_result.status is FitStatus.SUCCESS:
+        decay_parameter = float(fit_result["p"])
+        decay_parameter_err = float(fit_result["p_err"])
+        error_per_cycle = 0.5 * (1.0 - decay_parameter)
+        error_per_cycle_err = 0.5 * decay_parameter_err
+
+    return {
+        "trials": trials,
+        "mean": mean,
+        "std": std,
+        "fit_result": fit_result,
+        "decay_parameter": decay_parameter,
+        "decay_parameter_err": decay_parameter_err,
+        "error_per_cycle": error_per_cycle,
+        "error_per_cycle_err": error_per_cycle_err,
+    }
+
+
+def _analyze_trials(
+    trials: _TrialData,
+    *,
+    targets: tuple[str, str],
+    n_cliffords: NDArray[np.int64],
+    plot: bool,
+    save_image: bool,
+    xaxis_type: Literal["linear", "log"],
+) -> tuple[_ProtocolResults, dict[str, Figure]]:
+    """Fit every protocol/target pair and collect available figures."""
+    protocol_results: _ProtocolResults = {}
+    figures: dict[str, Figure] = {}
+    for protocol, protocol_trials in trials.items():
+        target_results: dict[str, _TargetAnalysis] = {}
+        for target in targets:
+            target_result = _fit_protocol_target(
+                protocol=protocol,
+                target=target,
+                n_cliffords=n_cliffords,
+                trials=protocol_trials[target],
+                plot=plot,
+                xaxis_type=xaxis_type,
+            )
+            target_results[target] = target_result
+            fit_result = target_result["fit_result"]
+            if fit_result.status is not FitStatus.SUCCESS or fit_result.figure is None:
+                continue
+            figure_key = f"{protocol}:{target}"
+            figures[figure_key] = fit_result.figure
+            if save_image:
+                viz.save_figure(
+                    fit_result.figure,
+                    name=f"mcm_randomized_benchmarking_{protocol}_{target}",
+                )
+        protocol_results[protocol] = target_results
+    return protocol_results, figures
+
+
+def _measurement_induced_error(
+    protocol_results: _ProtocolResults,
+    *,
+    control: str,
+) -> dict[str, float] | None:
+    """Calculate the MCM-induced control error relative to delay-RB."""
+    if _MCM_RB not in protocol_results or _DELAY_RB not in protocol_results:
+        return None
+    mcm_result = protocol_results[_MCM_RB][control]
+    delay_result = protocol_results[_DELAY_RB][control]
+    p_mcm = mcm_result["decay_parameter"]
+    p_mcm_err = mcm_result["decay_parameter_err"]
+    p_delay = delay_result["decay_parameter"]
+    p_delay_err = delay_result["decay_parameter_err"]
+    if (
+        p_mcm is None
+        or p_mcm_err is None
+        or p_delay is None
+        or p_delay_err is None
+        or p_delay == 0.0
+    ):
+        return None
+
+    value = 0.5 * (1.0 - p_mcm / p_delay)
+    error = 0.5 * np.sqrt(
+        (p_mcm_err / p_delay) ** 2 + (p_mcm * p_delay_err / p_delay**2) ** 2
+    )
+    return {"value": float(value), "error": float(error)}
+
+
+def mcm_randomized_benchmarking(
+    exp: Experiment,
+    control: str,
+    ancilla: str,
+    *,
+    n_cliffords_range: ArrayLike | None = None,
+    n_trials: int | None = None,
+    seeds: ArrayLike | None = None,
+    protocols: Collection[MCMRBProtocol] | MCMRBProtocol | None = None,
+    control_echo: bool = False,
+    x90: Waveform | None = None,
+    measurement_waveform: Waveform | None = None,
+    echo_x180: Waveform | None = None,
+    n_shots: int | None = None,
+    shot_interval: float | None = None,
+    time_integration: bool = True,
+    xaxis_type: Literal["linear", "log"] = "linear",
+    plot: bool | None = None,
+    save_image: bool | None = None,
+    enable_tqdm: bool = False,
+) -> Result:
+    """
+    Run MCM-RB, delay-RB, and MCM-repetition experiments.
+
+    Parameters
+    ----------
+    exp
+        Experiment instance used to generate and execute the schedules.
+    control
+        Qubit receiving randomized Cliffords.
+    ancilla
+        Qubit measured during every randomized-benchmarking cycle.
+    n_cliffords_range
+        Strictly increasing nonnegative cycle counts. Defaults to 0 followed
+        by 14 geometrically spaced values from 1 through 150.
+    n_trials
+        Number of random Clifford trials per cycle count. Defaults to 30.
+    seeds
+        Nonnegative integer seed for every trial. Defaults to generated seeds.
+    protocols
+        Protocols to run. Defaults to all of `"mcm-rb"`, `"delay-rb"`, and
+        `"mcm-rep"`. The same generated Clifford sequence is shared across
+        protocols for each sequence length and seed.
+    control_echo
+        Whether to insert a symmetric X-X echo on the control during every
+        measurement or duration-matched delay window.
+    x90
+        Optional control X90 waveform override.
+    measurement_waveform
+        Optional ancilla readout waveform override.
+    echo_x180
+        Optional control X180 waveform override for echoed measurement blocks.
+        Ignored when `control_echo=False`.
+    n_shots
+        Number of shots per schedule. Defaults to the experiment default.
+    shot_interval
+        Interval between shots in ns. Defaults to the experiment default.
+    time_integration
+        Whether to integrate each capture over time.
+    xaxis_type
+        X-axis scale used by fit figures.
+    plot
+        Whether to display fit figures. Defaults to `True`.
+    save_image
+        Whether to save successful fit figures. Defaults to `False`.
+    enable_tqdm
+        Whether to show schedule-execution progress.
+
+    Returns
+    -------
+    Result
+        Raw terminal probabilities, per-protocol statistics and fits, the
+        MCM-induced control error, metadata, and named fit figures. Protocol
+        results are stored under `result.data["protocols"][protocol][target]`.
+
+    Raises
+    ------
+    TypeError
+        Raised when a trial or shot count has an invalid type.
+    ValueError
+        Raised when targets, sweep values, seeds, protocols, or pulse timing
+        are invalid.
+
+    Notes
+    -----
+    Intermediate MCM outcomes are intentionally discarded. Only the terminal
+    capture for the control and ancilla is normalized and fitted. When both
+    MCM-RB and delay-RB succeed, the reported induced error is
+    `(1 - p_mcm / p_delay) / 2`.
+
+    MCM-RB and delay-RB have the standard randomized-benchmarking exponential
+    form under the usual assumptions. MCM-repetition is fitted to the same
+    form for comparison, but its decay is not generally guaranteed to be
+    exponential because the ancilla is not Clifford twirled.
+    """
+    resolved_n_cliffords = _resolve_n_cliffords_range(n_cliffords_range)
+    resolved_protocols = _resolve_protocols(protocols)
+    resolved_n_trials = _validate_positive_integer(
+        DEFAULT_RB_N_TRIALS if n_trials is None else n_trials,
+        name="n_trials",
+    )
+    resolved_seeds = _resolve_seeds(seeds, n_trials=resolved_n_trials)
+    resolved_n_shots = _validate_positive_integer(
+        DEFAULT_SHOTS if n_shots is None else n_shots,
+        name="n_shots",
+    )
+    resolved_shot_interval = (
+        DEFAULT_INTERVAL if shot_interval is None else float(shot_interval)
+    )
+    resolved_plot = True if plot is None else plot
+    resolved_save_image = False if save_image is None else save_image
+    if xaxis_type not in ("linear", "log"):
+        raise ValueError("`xaxis_type` must be either `linear` or `log`.")
+
+    control_qubit, ancilla_qubit = _resolve_qubit_pair(exp, control, ancilla)
+    exp.pulse.validate_rabi_params([control_qubit, ancilla_qubit])
+    resources = _resolve_sequence_resources(
+        exp,
+        control=control_qubit,
+        ancilla=ancilla_qubit,
+        control_echo=control_echo,
+        x90=x90,
+        measurement_waveform=measurement_waveform,
+        echo_x180=echo_x180,
+    )
+    trials = _acquire_trials(
+        exp,
+        resources=resources,
+        protocols=resolved_protocols,
+        n_cliffords_range=resolved_n_cliffords,
+        seeds=resolved_seeds,
+        n_shots=resolved_n_shots,
+        shot_interval=resolved_shot_interval,
+        time_integration=time_integration,
+        enable_tqdm=enable_tqdm,
+    )
+    protocol_results, figures = _analyze_trials(
+        trials,
+        targets=resources.targets,
+        n_cliffords=resolved_n_cliffords,
+        plot=resolved_plot,
+        save_image=resolved_save_image,
+        xaxis_type=xaxis_type,
+    )
+
+    return Result(
+        data={
+            "n_cliffords": resolved_n_cliffords,
+            "seeds": resolved_seeds,
+            "protocols": protocol_results,
+            "measurement_induced_control_error": _measurement_induced_error(
+                protocol_results,
+                control=control_qubit,
+            ),
+            "metadata": {
+                "control": control_qubit,
+                "ancilla": ancilla_qubit,
+                "protocols": resolved_protocols,
+                "control_echo": control_echo,
+                "n_trials": resolved_n_trials,
+                "n_shots": resolved_n_shots,
+                "shot_interval": resolved_shot_interval,
+                "time_integration": time_integration,
+                "measurement_duration": resources.measurement.duration,
+            },
+        },
+        figures=figures or None,
+    )
+
+
+__all__ = [
+    "MCMRBProtocol",
+    "mcm_randomized_benchmarking",
+    "mcm_rb_sequence",
+]

--- a/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
+++ b/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
@@ -45,8 +45,6 @@ _MCM_RB: MCMRBProtocol = "mcm-rb"
 _DELAY_RB: MCMRBProtocol = "delay-rb"
 _MCM_REP: MCMRBProtocol = "mcm-rep"
 _DELAY_REP: MCMRBProtocol = "delay-rep"
-# The suffix selects the control operation (Clifford or matched delay), while
-# the prefix selects the ancilla operation (readout or matched delay).
 _SUPPORTED_PROTOCOLS: tuple[MCMRBProtocol, ...] = (
     _MCM_RB,
     _DELAY_RB,
@@ -415,10 +413,10 @@ def _normalize_waveform_overrides(
     exp: Experiment,
     *,
     targets: tuple[str, ...],
-    override: _WaveformOverride,
+    override: object,
     name: str,
 ) -> dict[str, Waveform]:
-    """Normalize waveform overrides to resolved target labels."""
+    """Validate and normalize waveform overrides to resolved target labels."""
     if override is None:
         return {}
     if isinstance(override, Waveform):
@@ -454,9 +452,9 @@ def _normalize_measurement_scales(
     exp: Experiment,
     *,
     targets: tuple[str, ...],
-    measurement_scale: _MeasurementScale,
+    measurement_scale: object,
 ) -> dict[str, float]:
-    """Normalize scalar or target-keyed readout scales to resolved labels."""
+    """Validate and normalize readout scales to resolved target labels."""
     if measurement_scale is None:
         return {}
     if isinstance(measurement_scale, Real):
@@ -1028,44 +1026,44 @@ def mcm_rb_sequence(
 
     Parameters
     ----------
-    exp
+    exp : Experiment
         Experiment instance that provides pulse and Clifford services.
-    control
+    control : Collection[str] | str
         One control/spectator label or an ordered collection of labels. RB
         protocols apply independently randomized Cliffords and inverses to
         the controls; repetition protocols replace them with duration-matched
         delays.
-    ancilla
+    ancilla : Collection[str] | str
         One ancilla/readout-target label or an ordered collection of labels.
         MCM protocols read all ancillas simultaneously; delay protocols
         replace every readout with a duration-matched delay.
-    protocol
+    protocol : MCMRBProtocol
         Sequence variant: `"mcm-rb"`, `"delay-rb"`, `"mcm-rep"`, or
         `"delay-rep"`. Repetition protocols replace the control Cliffords with
         duration-matched delays. Delay protocols replace the intermediate
         readout pulses with duration-matched delays.
-    n_cliffords
+    n_cliffords : int
         Number of protocol cycles. Must be nonnegative.
-    seed
+    seed : int | None
         Optional nonnegative root seed. Multiple controls receive independent
         derived Clifford streams, and randomized ancillas receive independent
         derived I/X180 streams. `None` requests nondeterministic streams.
         Repetition protocols use the generated Clifford durations only.
-    control_echo
+    control_echo : bool
         Whether to apply an X-X echo to every control during every measurement
         or reference-delay window. The X180 centers are placed at the quarter
         and three-quarter points of the common ramp-trimmed active readout
         interval. Repetition protocols therefore contain control pulses during
         these windows when this option is `True`.
-    ancilla_mode
+    ancilla_mode : Literal["standard", "randomized"]
         Ancilla sequence mode. `"standard"` preserves the original protocol.
         `"randomized"` inserts a seeded I/X180 before every measurement or
         reference delay and applies a final parity recovery.
-    x90
+    x90 : Waveform | Mapping[str, Waveform] | None
         Optional control X90 override. Pass a waveform for one control or a
         target-keyed mapping for multiple controls. Omitted mapping entries use
         calibrated defaults.
-    measurement_waveform
+    measurement_waveform : Waveform | Mapping[str, Waveform] | None
         Optional ancilla readout override. Pass a waveform for one ancilla or a
         target-keyed mapping for multiple ancillas. Omitted mapping entries use
         calibrated defaults. Multiple ancillas must have identical
@@ -1073,18 +1071,18 @@ def mcm_rb_sequence(
         differ. Active intervals are inferred from nonzero samples; at most one
         FlatTop pulse may be present in each waveform, and other shapes are
         treated as having zero ramp duration.
-    measurement_scale
+    measurement_scale : float | Mapping[str, float] | None
         Optional positive scale for each intermediate ancilla readout. A scalar
         scales every selected ancilla's own calibrated readout; a target-keyed
         mapping scales only listed ancillas and leaves other ancillas at 1.0.
         This option is mutually exclusive with `measurement_waveform`. The
         returned schedule does not contain terminal measurements.
-    echo_x180
+    echo_x180 : Waveform | Mapping[str, Waveform] | None
         Optional control X180 override used by the X-X echo. Pass a waveform
         for one control or a target-keyed mapping for multiple controls.
         Omitted mapping entries use calibrated defaults. Ignored when
         `control_echo=False`.
-    ancilla_x180
+    ancilla_x180 : Waveform | Mapping[str, Waveform] | None
         Optional ancilla X180 override used for randomized I/X180 operations
         and parity recovery. Pass a waveform for one ancilla or a target-keyed
         mapping for multiple ancillas. Omitted mapping entries use calibrated
@@ -1384,7 +1382,7 @@ def _fit_decay_parameter(
                 bounds=((0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
                 maxfev=20_000,
             )
-    except (FloatingPointError, RuntimeError, ValueError):
+    except (FloatingPointError, RuntimeError, ValueError, np.linalg.LinAlgError):
         return None
     decay_parameter = float(parameters[1])
     if not np.isfinite(decay_parameter):
@@ -1480,6 +1478,14 @@ def _optional_finite_float(value: object) -> float | None:
     return resolved if np.isfinite(resolved) else None
 
 
+def _optional_nonnegative_finite_float(value: object) -> float | None:
+    """Return a nonnegative finite float or None for an invalid uncertainty."""
+    resolved = _optional_finite_float(value)
+    if resolved is None or resolved < 0.0:
+        return None
+    return resolved
+
+
 def _fit_validity(
     fit_result: FitResult,
     *,
@@ -1564,25 +1570,33 @@ def _fit_protocol_target(
     """Aggregate and fit one target's terminal survival probabilities."""
     mean = np.mean(trials, axis=1)
     std = np.std(trials, axis=1)
-    fit_result = fitting.fit_rb(
-        target=target,
-        x=n_cliffords,
-        y=mean,
-        error_y=std if trials.shape[1] > 1 else None,
-        bounds=((0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
-        title=f"{protocol} measurement-crosstalk benchmarking",
-        xlabel="Number of protocol cycles",
-        ylabel="Ground-state probability",
-        xaxis_type=xaxis_type,
-        yaxis_type="linear",
-        plot=plot,
-    )
+    if np.all(np.isfinite(trials)):
+        fit_result = fitting.fit_rb(
+            target=target,
+            x=n_cliffords,
+            y=mean,
+            error_y=std if trials.shape[1] > 1 else None,
+            bounds=((0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
+            title=f"{protocol} measurement-crosstalk benchmarking",
+            xlabel="Number of protocol cycles",
+            ylabel="Ground-state probability",
+            xaxis_type=xaxis_type,
+            yaxis_type="linear",
+            plot=plot,
+        )
+    else:
+        fit_result = FitResult(
+            status=FitStatus.ERROR,
+            message="RB fitting failed: terminal probabilities contain non-finite values.",
+        )
     decay_parameter: float | None = None
     decay_parameter_fit_err: float | None = None
     error_per_cycle: float | None = None
     if fit_result.status is FitStatus.SUCCESS:
         decay_parameter = _optional_finite_float(fit_result.data.get("p"))
-        decay_parameter_fit_err = _optional_finite_float(fit_result.data.get("p_err"))
+        decay_parameter_fit_err = _optional_nonnegative_finite_float(
+            fit_result.data.get("p_err")
+        )
         if decay_parameter is not None:
             error_per_cycle = 0.5 * (1.0 - decay_parameter)
 
@@ -1712,11 +1726,13 @@ def _measurement_induced_error(
     measurement_result = protocol_results[measurement_protocol][target]
     reference_result = protocol_results[reference_protocol][target]
     p_measurement = measurement_result["decay_parameter"]
-    p_measurement_err = _optional_finite_float(
+    p_measurement_err = _optional_nonnegative_finite_float(
         measurement_result["fit"].data.get("p_err")
     )
     p_reference = reference_result["decay_parameter"]
-    p_reference_err = _optional_finite_float(reference_result["fit"].data.get("p_err"))
+    p_reference_err = _optional_nonnegative_finite_float(
+        reference_result["fit"].data.get("p_err")
+    )
     if p_measurement is None or p_reference is None or p_reference == 0.0:
         return None
 
@@ -2005,47 +2021,49 @@ def mcm_randomized_benchmarking(
 
     Parameters
     ----------
-    exp
+    exp : Experiment
         Experiment instance used to generate and execute the schedules.
-    control
+    control : Collection[str] | str
         One control/spectator label or an ordered collection of labels. RB
         protocols apply independently randomized Cliffords to all controls;
         repetition protocols apply duration-matched delays instead.
-    ancilla
+    ancilla : Collection[str] | str
         One ancilla/readout-target label or an ordered collection of labels.
         MCM protocols read all ancillas simultaneously; delay protocols
         replace every readout with a duration-matched delay.
-    n_cliffords_range
+    n_cliffords_range : ArrayLike | None
         At least three strictly increasing nonnegative cycle counts. Defaults
         to 0 followed by 14 geometrically spaced values from 1 through 150.
-    n_trials
+        Four or more values are required for a fit to pass the sequence-count
+        validity check.
+    n_trials : int | None
         Positive number of seed trials per cycle count. Defaults to 30.
-    seeds
+    seeds : ArrayLike | None
         One nonnegative integer seed for every trial. Defaults to generated
         seeds. Values must have integer types and fit in signed 64 bits.
-    protocols
+    protocols : Collection[MCMRBProtocol] | MCMRBProtocol | None
         Protocols to run. Defaults to all of `"mcm-rb"`, `"delay-rb"`, and
         `"mcm-rep"` in standard mode and to the matched `"mcm-rb"` and
         `"delay-rb"` pair in randomized mode. `"mcm-rep"` and `"delay-rep"`
         are opt-in in randomized mode; `"delay-rep"` is opt-in in both modes.
         The same per-target Clifford and ancilla I/X180 sequences are shared
         across protocols for each sequence length and root seed.
-    control_echo
+    control_echo : bool
         Whether to insert an X-X echo on every control during each measurement
         or duration-matched delay window. The X180 centers are placed at the
         quarter and three-quarter points of the common ramp-trimmed active
         readout interval. Repetition protocols omit randomized Cliffords but
         are not strictly idle when echo is enabled.
-    ancilla_mode
+    ancilla_mode : Literal["standard", "randomized"]
         Ancilla sequence mode. `"standard"` preserves the original suite.
         `"randomized"` inserts a seeded I/X180 before every measurement or
         reference delay, followed by an X180 for odd parity or a
         duration-matched blank for even parity.
-    x90
+    x90 : Waveform | Mapping[str, Waveform] | None
         Optional control X90 override. Use a waveform for one control or a
         target-keyed mapping for multiple controls. Omitted mapping entries use
         calibrated defaults.
-    measurement_waveform
+    measurement_waveform : Waveform | Mapping[str, Waveform] | None
         Optional ancilla readout override. Use a waveform for one ancilla or a
         target-keyed mapping for multiple ancillas. Multiple ancillas must have
         identical ramp-trimmed active intervals, although their total slot
@@ -2054,52 +2072,52 @@ def mcm_randomized_benchmarking(
         pulse may be present in each waveform, and other shapes have zero
         inferred ramp duration. The override affects only intermediate
         readouts; terminal measurements use calibrated defaults.
-    measurement_scale
+    measurement_scale : float | Mapping[str, float] | None
         Optional positive scale for each intermediate ancilla readout. A scalar
         scales every selected ancilla's own calibrated readout; a target-keyed
         mapping scales only listed ancillas and leaves other ancillas at 1.0.
         This option is mutually exclusive with `measurement_waveform`. Terminal
         measurements continue to use calibrated default readouts.
-    echo_x180
+    echo_x180 : Waveform | Mapping[str, Waveform] | None
         Optional control X180 override for echoed measurement blocks. Use a
         waveform for one control or a target-keyed mapping for multiple
         controls. Omitted mapping entries use calibrated defaults. Ignored when
         `control_echo=False`.
-    ancilla_x180
+    ancilla_x180 : Waveform | Mapping[str, Waveform] | None
         Optional ancilla X180 override used by randomized mode. Use a waveform
         for one ancilla or a target-keyed mapping for multiple ancillas. Omitted
         mapping entries use calibrated defaults. Ignored in standard mode.
-    n_shots
+    n_shots : int | None
         Number of shots per schedule. Defaults to the experiment default.
-    shot_interval
+    shot_interval : float | None
         Positive finite interval between shots in ns. Defaults to the
         experiment default.
-    time_integration
+    time_integration : bool
         Whether to integrate each capture over time.
-    n_bootstrap
+    n_bootstrap : int
         Number of paired trial-column bootstrap resamples. Defaults to 1000.
         Set to 0 to disable bootstrap uncertainty. Bootstrap requires at least
         four sequence lengths and two trials. Fit-covariance uncertainty is
         used if fewer than 80% of resampled fits succeed.
-    bootstrap_seed
+    bootstrap_seed : int | None
         Nonnegative seed for paired bootstrap resampling. Defaults to 0 for
         reproducible analysis. Pass `None` for nondeterministic resampling.
-    bootstrap_confidence_level
+    bootstrap_confidence_level : float
         Percentile-bootstrap confidence level strictly between 0 and 1.
         Defaults to 0.95.
-    min_fit_r_squared
+    min_fit_r_squared : float | None
         Minimum R-squared for a fit to be marked valid. Defaults to 0.9. Pass
         `None` to omit the R-squared threshold while retaining other checks.
-    xaxis_type
+    xaxis_type : Literal["linear", "log"]
         X-axis scale used by fit figures.
-    plot
+    plot : bool | None
         Whether to display fit figures. Defaults to `True`.
-    save_image
+    save_image : bool | None
         Whether to save successful fit figures. Defaults to `False`.
-    print_summary
+    print_summary : bool
         Whether to print protocol-fit and measurement-induced-error summary
         tables. This is independent of `plot` and defaults to `True`.
-    enable_tqdm
+    enable_tqdm : bool
         Whether to show schedule-execution progress. Defaults to `True`.
 
     Returns
@@ -2165,7 +2183,9 @@ def mcm_randomized_benchmarking(
     reports checks for sequence-count sufficiency, finite parameters and
     uncertainty, a decay parameter at its bound, and the optional R-squared
     threshold. Estimates remain available when a check fails, but callers should
-    inspect `fit_validity` before interpreting them.
+    inspect `fit_validity` before interpreting them. Numerical fitting failures
+    are recorded as unsuccessful `FitResult` objects so the acquired trial data
+    remain available for offline analysis.
 
     Independent control and ancilla random streams are assigned in resolved
     input order. Ancilla I/X180 choices are generated once per sequence length
@@ -2176,6 +2196,10 @@ def mcm_randomized_benchmarking(
     simultaneous combined readout and is not an attribution to any individual
     ancilla. Per-target fits are marginal analyses of averaged terminal IQ;
     they do not quantify correlated multi-qubit errors.
+
+    The workflow resets the selected AWG and capture resources once before
+    acquisition. When `save_image=True`, successful fit figures are written
+    through the configured visualization output path.
 
     The experiment synchronizes the global pulse-library sampling period with
     `exp.ctx.measurement.sampling_period` before constructing schedules.

--- a/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
+++ b/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import warnings
 from collections.abc import Callable, Collection, Mapping
 from dataclasses import dataclass
 from numbers import Real
@@ -10,6 +11,9 @@ from typing import Literal, TypedDict, cast
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
 from plotly.graph_objects import Figure
+from rich.console import Console
+from rich.table import Table
+from scipy.optimize import OptimizeWarning, curve_fit
 from tqdm import tqdm
 
 import qubex.visualization as viz
@@ -31,6 +35,8 @@ from qubex.pulse import (
     Waveform,
     set_sampling_period,
 )
+
+console = Console()
 
 MCMRBProtocol = Literal["mcm-rb", "delay-rb", "mcm-rep", "delay-rep"]
 _AncillaMode = Literal["standard", "randomized"]
@@ -59,8 +65,14 @@ _STANDARD_ANCILLA: _AncillaMode = "standard"
 _RANDOMIZED_ANCILLA: _AncillaMode = "randomized"
 _CONTROL_RANDOMIZATION_SPAWN_KEY = (0,)
 _ANCILLA_RANDOMIZATION_SPAWN_KEY = (1,)
+_DEFAULT_N_BOOTSTRAP = 1_000
+_DEFAULT_BOOTSTRAP_CONFIDENCE_LEVEL = 0.95
+_DEFAULT_MIN_FIT_R_SQUARED = 0.9
+_MIN_BOOTSTRAP_SUCCESS_RATE = 0.8
 
 _WaveformOverride = Waveform | Mapping[str, Waveform] | None
+_MeasurementScale = float | Mapping[str, float] | None
+_MeasurementSource = Literal["calibrated", "scaled_calibrated", "custom"]
 
 
 @dataclass(frozen=True)
@@ -73,6 +85,8 @@ class _SequenceResources:
     sampling_period: float
     x90s: Mapping[str, Waveform]
     measurements: Mapping[str, Waveform]
+    measurement_scales: Mapping[str, float | None]
+    measurement_sources: Mapping[str, _MeasurementSource]
     controls_during_measurement: Mapping[str, Waveform]
     ancilla_x180s: Mapping[str, Waveform]
 
@@ -122,25 +136,71 @@ class _TargetAnalysis(TypedDict):
     trials: NDArray[np.float64]
     mean: NDArray[np.float64]
     std: NDArray[np.float64]
-    fit_result: FitResult
+    fit: FitResult
     decay_parameter: float | None
-    decay_parameter_err: float | None
+    decay_parameter_uncertainty: float | None
+    uncertainty_method: Literal["paired_bootstrap", "fit_covariance", "unavailable"]
     error_per_cycle: float | None
-    error_per_cycle_err: float | None
+    error_per_cycle_uncertainty: float | None
+    bootstrap: _BootstrapSummary
+    fit_validity: _FitValidity
+
+
+class _BootstrapSummary(TypedDict):
+    """Bootstrap availability, success fraction, and uncertainty summary."""
+
+    successful_resamples: int
+    success_rate: float | None
+    standard_error: float | None
+    confidence_interval: tuple[float, float] | None
+    unavailable_reason: str | None
+
+
+class _FitValidity(TypedDict):
+    """Diagnostics that distinguish optimizer convergence from fit validity."""
+
+    is_valid: bool
+    reasons: tuple[str, ...]
+    r_squared: float | None
+
+
+class _PairedFitValidity(TypedDict):
+    """Combined fit validity for a measurement/reference protocol pair."""
+
+    is_valid: bool
+    reasons: tuple[str, ...]
+    measurement_protocol: MCMRBProtocol
+    reference_protocol: MCMRBProtocol
 
 
 class _ErrorEstimate(TypedDict):
-    """Value and propagated uncertainty for one induced-error estimate."""
+    """Value, uncertainty, and validity for one induced-error estimate."""
 
     value: float
-    error: float
+    uncertainty: float | None
+    uncertainty_method: Literal[
+        "paired_bootstrap", "independent_fit_propagation", "unavailable"
+    ]
+    bootstrap: _BootstrapSummary
+    fit_validity: _PairedFitValidity
+
+
+_TargetErrorEstimates = dict[str, _ErrorEstimate | None]
+
+
+class _MeasurementInducedErrors(TypedDict):
+    """All ratio-based error estimates reported by the experiment."""
+
+    control: _TargetErrorEstimates
+    ancilla_population_with_cliffords: _TargetErrorEstimates
+    ancilla_population_with_control_delay: _TargetErrorEstimates
 
 
 _TrialData = dict[MCMRBProtocol, dict[str, NDArray[np.float64]]]
 _ProtocolResults = dict[MCMRBProtocol, dict[str, _TargetAnalysis]]
+_BootstrapDecayParameters = dict[MCMRBProtocol, dict[str, NDArray[np.float64]]]
 _CompiledCliffordSequences = Mapping[str, _CompiledCliffordSequence]
 _CompiledAncillaSequences = Mapping[str, _CompiledAncillaSequence]
-_TargetErrorPayload = _ErrorEstimate | dict[str, _ErrorEstimate | None] | None
 
 
 def _validate_protocol(protocol: str) -> MCMRBProtocol:
@@ -194,6 +254,26 @@ def _validate_positive_real(value: object, *, name: str) -> float:
     resolved = float(value)
     if not np.isfinite(resolved) or resolved <= 0:
         raise ValueError(f"`{name}` must be positive and finite.")
+    return resolved
+
+
+def _validate_open_unit_interval(value: object, *, name: str) -> float:
+    """Return a finite scalar strictly between zero and one."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"`{name}` must be a real number.")
+    resolved = float(value)
+    if not np.isfinite(resolved) or not 0.0 < resolved < 1.0:
+        raise ValueError(f"`{name}` must be finite and strictly between 0 and 1.")
+    return resolved
+
+
+def _validate_fit_r_squared_threshold(value: object) -> float:
+    """Return a finite fit-validity threshold in the closed unit interval."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError("`min_fit_r_squared` must be a real number or None.")
+    resolved = float(value)
+    if not np.isfinite(resolved) or not 0.0 <= resolved <= 1.0:
+        raise ValueError("`min_fit_r_squared` must be finite and between 0 and 1.")
     return resolved
 
 
@@ -370,6 +450,106 @@ def _normalize_waveform_overrides(
     return overrides
 
 
+def _normalize_measurement_scales(
+    exp: Experiment,
+    *,
+    targets: tuple[str, ...],
+    measurement_scale: _MeasurementScale,
+) -> dict[str, float]:
+    """Normalize scalar or target-keyed readout scales to resolved labels."""
+    if measurement_scale is None:
+        return {}
+    if isinstance(measurement_scale, Real):
+        scale = _validate_positive_real(
+            measurement_scale,
+            name="measurement_scale",
+        )
+        return dict.fromkeys(targets, scale)
+    if not isinstance(measurement_scale, Mapping):
+        raise TypeError(
+            "`measurement_scale` must be a real number or target-keyed mapping."
+        )
+
+    scales: dict[str, float] = {}
+    for label, value in measurement_scale.items():
+        if not isinstance(label, str):
+            raise TypeError(
+                "`measurement_scale` mapping keys must be qubit-label strings."
+            )
+        target = exp.ctx.resolve_qubit_label(label)
+        if target not in targets:
+            raise ValueError(
+                "`measurement_scale` contains a value for unselected target "
+                f"{target!r}."
+            )
+        if target in scales:
+            raise ValueError(
+                f"`measurement_scale` contains duplicate values for target {target!r}."
+            )
+        scales[target] = _validate_positive_real(
+            value,
+            name=f"measurement_scale[{target}]",
+        )
+    return scales
+
+
+def _resolve_measurements(
+    exp: Experiment,
+    *,
+    targets: tuple[str, ...],
+    measurement_waveform: _WaveformOverride,
+    measurement_scale: _MeasurementScale,
+    sampling_period: float,
+) -> tuple[
+    dict[str, Waveform],
+    dict[str, float | None],
+    dict[str, _MeasurementSource],
+]:
+    """Resolve intermediate readouts and record how each waveform was obtained."""
+    if measurement_waveform is not None and measurement_scale is not None:
+        raise ValueError(
+            "`measurement_waveform` and `measurement_scale` are mutually exclusive."
+        )
+
+    waveform_overrides = _normalize_waveform_overrides(
+        exp,
+        targets=targets,
+        override=measurement_waveform,
+        name="measurement_waveform",
+    )
+    scale_overrides = _normalize_measurement_scales(
+        exp,
+        targets=targets,
+        measurement_scale=measurement_scale,
+    )
+    measurements: dict[str, Waveform] = {}
+    scales: dict[str, float | None] = {}
+    sources: dict[str, _MeasurementSource] = {}
+    for target in targets:
+        custom_waveform = waveform_overrides.get(target)
+        if custom_waveform is not None:
+            waveform = custom_waveform
+            scale: float | None = None
+            source: _MeasurementSource = "custom"
+        else:
+            waveform = exp.pulse.readout(target)
+            scale = scale_overrides.get(target, 1.0)
+            if target in scale_overrides:
+                waveform = waveform.scaled(scale)
+                source = "scaled_calibrated"
+            else:
+                source = "calibrated"
+        _validate_waveform(
+            waveform,
+            expected_sampling_period=sampling_period,
+            name=f"measurement_waveform[{target}]",
+        )
+        measurements[target] = waveform
+        scales[target] = scale
+        sources[target] = source
+    return measurements, scales, sources
+
+
 def _blank(duration: float, sampling_period: float) -> Blank:
     """Build a blank pulse on the active sampling grid."""
     return Blank(duration=duration, sampling_period=sampling_period)
@@ -496,8 +676,6 @@ def _validate_matching_readout_intervals(
     measurements: Mapping[str, Waveform],
 ) -> None:
     """Require equal ramp-trimmed active intervals for multiple readouts."""
-    if len(measurements) == 1:
-        return
     intervals_half_samples = {
         target: _infer_readout_timing(measurement).ramp_trimmed_interval_half_samples
         for target, measurement in measurements.items()
@@ -525,6 +703,7 @@ def _resolve_sequence_resources(
     ancilla_mode: _AncillaMode,
     x90: _WaveformOverride,
     measurement_waveform: _WaveformOverride,
+    measurement_scale: _MeasurementScale,
     echo_x180: _WaveformOverride,
     ancilla_x180: _WaveformOverride,
 ) -> _SequenceResources:
@@ -542,13 +721,12 @@ def _resolve_sequence_resources(
         sampling_period=sampling_period,
         name="x90",
     )
-    measurements = _resolve_waveforms(
+    measurements, measurement_scales, measurement_sources = _resolve_measurements(
         exp,
         targets=ancillas,
-        override=measurement_waveform,
-        default_factory=exp.pulse.readout,
+        measurement_waveform=measurement_waveform,
+        measurement_scale=measurement_scale,
         sampling_period=sampling_period,
-        name="measurement_waveform",
     )
     _validate_matching_readout_intervals(measurements)
     reference_measurement = next(iter(measurements.values()))
@@ -588,6 +766,8 @@ def _resolve_sequence_resources(
         sampling_period=sampling_period,
         x90s=x90s,
         measurements=measurements,
+        measurement_scales=measurement_scales,
+        measurement_sources=measurement_sources,
         controls_during_measurement={
             target: _measurement_control_block(
                 measurement=reference_measurement,
@@ -839,6 +1019,7 @@ def mcm_rb_sequence(
     ancilla_mode: Literal["standard", "randomized"] = "standard",
     x90: Waveform | Mapping[str, Waveform] | None = None,
     measurement_waveform: Waveform | Mapping[str, Waveform] | None = None,
+    measurement_scale: float | Mapping[str, float] | None = None,
     echo_x180: Waveform | Mapping[str, Waveform] | None = None,
     ancilla_x180: Waveform | Mapping[str, Waveform] | None = None,
 ) -> PulseSchedule:
@@ -866,10 +1047,10 @@ def mcm_rb_sequence(
     n_cliffords
         Number of protocol cycles. Must be nonnegative.
     seed
-        Nonnegative root seed. Multiple controls receive independent derived
-        Clifford streams, and multiple randomized ancillas receive independent
-        derived I/X180 streams. Repetition protocols use the generated
-        Clifford durations only.
+        Optional nonnegative root seed. Multiple controls receive independent
+        derived Clifford streams, and randomized ancillas receive independent
+        derived I/X180 streams. `None` requests nondeterministic streams.
+        Repetition protocols use the generated Clifford durations only.
     control_echo
         Whether to apply an X-X echo to every control during every measurement
         or reference-delay window. The X180 centers are placed at the quarter
@@ -892,6 +1073,12 @@ def mcm_rb_sequence(
         differ. Active intervals are inferred from nonzero samples; at most one
         FlatTop pulse may be present in each waveform, and other shapes are
         treated as having zero ramp duration.
+    measurement_scale
+        Optional positive scale for each intermediate ancilla readout. A scalar
+        scales every selected ancilla's own calibrated readout; a target-keyed
+        mapping scales only listed ancillas and leaves other ancillas at 1.0.
+        This option is mutually exclusive with `measurement_waveform`. The
+        returned schedule does not contain terminal measurements.
     echo_x180
         Optional control X180 override used by the X-X echo. Pass a waveform
         for one control or a target-keyed mapping for multiple controls.
@@ -955,6 +1142,7 @@ def mcm_rb_sequence(
         ancilla_mode=resolved_ancilla_mode,
         x90=x90,
         measurement_waveform=measurement_waveform,
+        measurement_scale=measurement_scale,
         echo_x180=echo_x180,
         ancilla_x180=ancilla_x180,
     )
@@ -1171,12 +1359,205 @@ def _acquire_trials(
     return trials
 
 
+def _fit_decay_parameter(
+    n_cliffords: NDArray[np.int64],
+    probabilities: NDArray[np.float64],
+) -> float | None:
+    """Fit one bootstrap mean curve and return only its decay parameter."""
+
+    def decay(
+        n_cycles: NDArray[np.int64],
+        amplitude: float,
+        decay_parameter: float,
+        offset: float,
+    ) -> NDArray[np.float64]:
+        return amplitude * decay_parameter**n_cycles + offset
+
+    try:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", OptimizeWarning)
+            parameters, _ = curve_fit(
+                decay,
+                n_cliffords,
+                probabilities,
+                p0=(0.5, 1.0, 0.5),
+                bounds=((0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
+                maxfev=20_000,
+            )
+    except (FloatingPointError, RuntimeError, ValueError):
+        return None
+    decay_parameter = float(parameters[1])
+    if not np.isfinite(decay_parameter):
+        return None
+    return decay_parameter
+
+
+def _bootstrap_plan(
+    *,
+    n_sequence_lengths: int,
+    n_trials: int,
+    n_resamples: int,
+    seed: int | None,
+) -> tuple[NDArray[np.int64] | None, str | None]:
+    """Return shared trial-column resamples or an availability diagnosis."""
+    if n_resamples == 0:
+        return None, "disabled"
+    if n_sequence_lengths <= 3:
+        return None, "at_least_four_sequence_lengths_required"
+    if n_trials < 2:
+        return None, "at_least_two_trials_required"
+    indices = np.random.default_rng(seed).integers(
+        0,
+        n_trials,
+        size=(n_resamples, n_trials),
+        dtype=np.int64,
+    )
+    return indices, None
+
+
+def _bootstrap_decay_parameters(
+    n_cliffords: NDArray[np.int64],
+    trials: NDArray[np.float64],
+    bootstrap_indices: NDArray[np.int64] | None,
+) -> NDArray[np.float64]:
+    """Fit decay parameters after resampling complete trial columns."""
+    if bootstrap_indices is None:
+        return np.empty(0, dtype=np.float64)
+    decay_parameters = np.full(len(bootstrap_indices), np.nan, dtype=np.float64)
+    for index, trial_indices in enumerate(bootstrap_indices):
+        probabilities = np.mean(trials[:, trial_indices], axis=1)
+        decay_parameter = _fit_decay_parameter(n_cliffords, probabilities)
+        if decay_parameter is not None:
+            decay_parameters[index] = decay_parameter
+    return decay_parameters
+
+
+def _bootstrap_summary(
+    samples: NDArray[np.float64],
+    *,
+    requested_resamples: int,
+    confidence_level: float,
+    unavailable_reason: str | None,
+) -> _BootstrapSummary:
+    """Summarize finite bootstrap samples without exposing every resample."""
+    finite_samples = samples[np.isfinite(samples)]
+    n_successful = len(finite_samples)
+    standard_error: float | None = None
+    confidence_interval: tuple[float, float] | None = None
+    reason = unavailable_reason
+    if n_successful >= 2:
+        alpha = (1.0 - confidence_level) / 2.0
+        quantiles = np.quantile(finite_samples, [alpha, 1.0 - alpha])
+        standard_error = float(np.std(finite_samples, ddof=1))
+        confidence_interval = (float(quantiles[0]), float(quantiles[1]))
+    elif reason is None:
+        reason = "fewer_than_two_successful_resamples"
+    success_rate = (
+        float(n_successful / requested_resamples)
+        if requested_resamples > 0 and unavailable_reason is None
+        else None
+    )
+    if (
+        reason is None
+        and success_rate is not None
+        and success_rate < _MIN_BOOTSTRAP_SUCCESS_RATE
+    ):
+        reason = "success_rate_below_threshold"
+    return {
+        "successful_resamples": n_successful,
+        "success_rate": success_rate,
+        "standard_error": standard_error,
+        "confidence_interval": confidence_interval,
+        "unavailable_reason": reason,
+    }
+
+
+def _optional_finite_float(value: object) -> float | None:
+    """Return a finite scalar float or None for missing and invalid values."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        return None
+    resolved = float(value)
+    return resolved if np.isfinite(resolved) else None
+
+
+def _fit_validity(
+    fit_result: FitResult,
+    *,
+    n_sequence_lengths: int,
+    min_r_squared: float | None,
+) -> _FitValidity:
+    """Diagnose whether a converged bounded exponential fit is interpretable."""
+    reasons: list[str] = []
+    if fit_result.status is not FitStatus.SUCCESS:
+        reasons.append("fit_not_successful")
+    if n_sequence_lengths <= 3:
+        reasons.append("insufficient_sequence_lengths")
+
+    amplitude = _optional_finite_float(fit_result.data.get("A"))
+    amplitude_err = _optional_finite_float(fit_result.data.get("A_err"))
+    offset = _optional_finite_float(fit_result.data.get("C"))
+    offset_err = _optional_finite_float(fit_result.data.get("C_err"))
+    if amplitude is None:
+        reasons.append("amplitude_unavailable")
+    elif np.isclose(amplitude, 0.0, rtol=0.0, atol=1e-8) or np.isclose(
+        amplitude,
+        1.0,
+        rtol=0.0,
+        atol=1e-8,
+    ):
+        reasons.append("amplitude_at_fit_bound")
+    if amplitude_err is None or amplitude_err < 0.0:
+        reasons.append("amplitude_uncertainty_unavailable")
+    if offset is None:
+        reasons.append("offset_unavailable")
+    elif np.isclose(offset, 0.0, rtol=0.0, atol=1e-8) or np.isclose(
+        offset,
+        1.0,
+        rtol=0.0,
+        atol=1e-8,
+    ):
+        reasons.append("offset_at_fit_bound")
+    if offset_err is None or offset_err < 0.0:
+        reasons.append("offset_uncertainty_unavailable")
+
+    decay_parameter = _optional_finite_float(fit_result.data.get("p"))
+    decay_parameter_err = _optional_finite_float(fit_result.data.get("p_err"))
+    if decay_parameter is None:
+        reasons.append("decay_parameter_unavailable")
+    elif np.isclose(decay_parameter, 0.0, rtol=0.0, atol=1e-8) or np.isclose(
+        decay_parameter,
+        1.0,
+        rtol=0.0,
+        atol=1e-8,
+    ):
+        reasons.append("decay_parameter_at_fit_bound")
+    if decay_parameter_err is None or decay_parameter_err < 0.0:
+        reasons.append("decay_parameter_uncertainty_unavailable")
+
+    r_squared = _optional_finite_float(fit_result.data.get("r2"))
+    if min_r_squared is not None:
+        if r_squared is None:
+            reasons.append("r_squared_unavailable")
+        elif r_squared < min_r_squared:
+            reasons.append("r_squared_below_threshold")
+    return {
+        "is_valid": not reasons,
+        "reasons": tuple(reasons),
+        "r_squared": r_squared,
+    }
+
+
 def _fit_protocol_target(
     *,
     protocol: MCMRBProtocol,
     target: str,
     n_cliffords: NDArray[np.int64],
     trials: NDArray[np.float64],
+    bootstrap_samples: NDArray[np.float64],
+    requested_bootstrap_resamples: int,
+    bootstrap_confidence_level: float,
+    bootstrap_unavailable_reason: str | None,
+    min_fit_r_squared: float | None,
     plot: bool,
     xaxis_type: Literal["linear", "log"],
 ) -> _TargetAnalysis:
@@ -1197,24 +1578,59 @@ def _fit_protocol_target(
         plot=plot,
     )
     decay_parameter: float | None = None
-    decay_parameter_err: float | None = None
+    decay_parameter_fit_err: float | None = None
     error_per_cycle: float | None = None
-    error_per_cycle_err: float | None = None
     if fit_result.status is FitStatus.SUCCESS:
-        decay_parameter = float(fit_result["p"])
-        decay_parameter_err = float(fit_result["p_err"])
-        error_per_cycle = 0.5 * (1.0 - decay_parameter)
-        error_per_cycle_err = 0.5 * decay_parameter_err
+        decay_parameter = _optional_finite_float(fit_result.data.get("p"))
+        decay_parameter_fit_err = _optional_finite_float(fit_result.data.get("p_err"))
+        if decay_parameter is not None:
+            error_per_cycle = 0.5 * (1.0 - decay_parameter)
+
+    bootstrap = _bootstrap_summary(
+        bootstrap_samples,
+        requested_resamples=requested_bootstrap_resamples,
+        confidence_level=bootstrap_confidence_level,
+        unavailable_reason=bootstrap_unavailable_reason,
+    )
+    if decay_parameter is None:
+        decay_parameter_uncertainty = None
+        uncertainty_method: Literal[
+            "paired_bootstrap", "fit_covariance", "unavailable"
+        ] = "unavailable"
+    elif (
+        bootstrap["standard_error"] is not None
+        and bootstrap["unavailable_reason"] is None
+    ):
+        decay_parameter_uncertainty = bootstrap["standard_error"]
+        uncertainty_method = "paired_bootstrap"
+    elif decay_parameter_fit_err is not None:
+        decay_parameter_uncertainty = decay_parameter_fit_err
+        uncertainty_method = "fit_covariance"
+    else:
+        decay_parameter_uncertainty = None
+        uncertainty_method = "unavailable"
+    error_per_cycle_uncertainty = (
+        None
+        if decay_parameter_uncertainty is None
+        else 0.5 * decay_parameter_uncertainty
+    )
 
     return {
         "trials": trials,
         "mean": mean,
         "std": std,
-        "fit_result": fit_result,
+        "fit": fit_result,
         "decay_parameter": decay_parameter,
-        "decay_parameter_err": decay_parameter_err,
+        "decay_parameter_uncertainty": decay_parameter_uncertainty,
+        "uncertainty_method": uncertainty_method,
         "error_per_cycle": error_per_cycle,
-        "error_per_cycle_err": error_per_cycle_err,
+        "error_per_cycle_uncertainty": error_per_cycle_uncertainty,
+        "bootstrap": bootstrap,
+        "fit_validity": _fit_validity(
+            fit_result,
+            n_sequence_lengths=len(n_cliffords),
+            min_r_squared=min_fit_r_squared,
+        ),
     }
 
 
@@ -1223,26 +1639,51 @@ def _analyze_trials(
     *,
     targets: tuple[str, ...],
     n_cliffords: NDArray[np.int64],
+    n_bootstrap: int,
+    bootstrap_seed: int | None,
+    bootstrap_confidence_level: float,
+    min_fit_r_squared: float | None,
     plot: bool,
     save_image: bool,
     xaxis_type: Literal["linear", "log"],
-) -> tuple[_ProtocolResults, dict[str, Figure]]:
+) -> tuple[_ProtocolResults, dict[str, Figure], _BootstrapDecayParameters]:
     """Fit every protocol/target pair and collect available figures."""
     protocol_results: _ProtocolResults = {}
     figures: dict[str, Figure] = {}
+    bootstrap_decay_parameters: _BootstrapDecayParameters = {}
+    first_protocol = next(iter(trials.values()))
+    first_target_trials = next(iter(first_protocol.values()))
+    bootstrap_indices, bootstrap_unavailable_reason = _bootstrap_plan(
+        n_sequence_lengths=len(n_cliffords),
+        n_trials=first_target_trials.shape[1],
+        n_resamples=n_bootstrap,
+        seed=bootstrap_seed,
+    )
     for protocol, protocol_trials in trials.items():
         target_results: dict[str, _TargetAnalysis] = {}
+        protocol_bootstrap: dict[str, NDArray[np.float64]] = {}
         for target in targets:
+            bootstrap_samples = _bootstrap_decay_parameters(
+                n_cliffords,
+                protocol_trials[target],
+                bootstrap_indices,
+            )
+            protocol_bootstrap[target] = bootstrap_samples
             target_result = _fit_protocol_target(
                 protocol=protocol,
                 target=target,
                 n_cliffords=n_cliffords,
                 trials=protocol_trials[target],
+                bootstrap_samples=bootstrap_samples,
+                requested_bootstrap_resamples=n_bootstrap,
+                bootstrap_confidence_level=bootstrap_confidence_level,
+                bootstrap_unavailable_reason=bootstrap_unavailable_reason,
+                min_fit_r_squared=min_fit_r_squared,
                 plot=plot,
                 xaxis_type=xaxis_type,
             )
             target_results[target] = target_result
-            fit_result = target_result["fit_result"]
+            fit_result = target_result["fit"]
             if fit_result.status is not FitStatus.SUCCESS or fit_result.figure is None:
                 continue
             figure_key = f"{protocol}:{target}"
@@ -1253,79 +1694,281 @@ def _analyze_trials(
                     name=f"mcm_randomized_benchmarking_{protocol}_{target}",
                 )
         protocol_results[protocol] = target_results
-    return protocol_results, figures
+        bootstrap_decay_parameters[protocol] = protocol_bootstrap
+    return protocol_results, figures, bootstrap_decay_parameters
 
 
 def _measurement_induced_error(
     protocol_results: _ProtocolResults,
+    bootstrap_decay_parameters: _BootstrapDecayParameters,
     *,
     target: str,
     measurement_protocol: MCMRBProtocol,
     reference_protocol: MCMRBProtocol,
+    requested_bootstrap_resamples: int,
+    bootstrap_confidence_level: float,
 ) -> _ErrorEstimate | None:
     """Calculate one target's induced error from a matched protocol pair."""
     measurement_result = protocol_results[measurement_protocol][target]
     reference_result = protocol_results[reference_protocol][target]
     p_measurement = measurement_result["decay_parameter"]
-    p_measurement_err = measurement_result["decay_parameter_err"]
+    p_measurement_err = _optional_finite_float(
+        measurement_result["fit"].data.get("p_err")
+    )
     p_reference = reference_result["decay_parameter"]
-    p_reference_err = reference_result["decay_parameter_err"]
-    if (
-        p_measurement is None
-        or p_measurement_err is None
-        or p_reference is None
-        or p_reference_err is None
-        or p_reference == 0.0
-    ):
+    p_reference_err = _optional_finite_float(reference_result["fit"].data.get("p_err"))
+    if p_measurement is None or p_reference is None or p_reference == 0.0:
         return None
 
     value = 0.5 * (1.0 - p_measurement / p_reference)
-    error = 0.5 * np.sqrt(
-        (p_measurement_err / p_reference) ** 2
-        + (p_measurement * p_reference_err / p_reference**2) ** 2
+    analytic_error = (
+        None
+        if p_measurement_err is None or p_reference_err is None
+        else float(
+            0.5
+            * np.sqrt(
+                (p_measurement_err / p_reference) ** 2
+                + (p_measurement * p_reference_err / p_reference**2) ** 2
+            )
+        )
     )
-    return {"value": float(value), "error": float(error)}
+    measurement_samples = bootstrap_decay_parameters[measurement_protocol][target]
+    reference_samples = bootstrap_decay_parameters[reference_protocol][target]
+    with np.errstate(divide="ignore", invalid="ignore"):
+        bootstrap_samples = 0.5 * (1.0 - measurement_samples / reference_samples)
+    bootstrap_samples = bootstrap_samples[reference_samples != 0.0]
+    measurement_bootstrap = measurement_result["bootstrap"]
+    plan_unavailable_reason = (
+        measurement_bootstrap["unavailable_reason"]
+        if measurement_samples.size == 0
+        else None
+    )
+    bootstrap = _bootstrap_summary(
+        bootstrap_samples,
+        requested_resamples=requested_bootstrap_resamples,
+        confidence_level=bootstrap_confidence_level,
+        unavailable_reason=plan_unavailable_reason,
+    )
+    if (
+        bootstrap["standard_error"] is not None
+        and bootstrap["unavailable_reason"] is None
+    ):
+        uncertainty = bootstrap["standard_error"]
+        uncertainty_method: Literal[
+            "paired_bootstrap", "independent_fit_propagation", "unavailable"
+        ] = "paired_bootstrap"
+    elif analytic_error is not None:
+        uncertainty = analytic_error
+        uncertainty_method = "independent_fit_propagation"
+    else:
+        uncertainty = None
+        uncertainty_method = "unavailable"
+
+    validity_reasons = tuple(
+        f"{protocol}:{reason}"
+        for protocol, target_result in (
+            (measurement_protocol, measurement_result),
+            (reference_protocol, reference_result),
+        )
+        for reason in target_result["fit_validity"]["reasons"]
+    )
+    return {
+        "value": float(value),
+        "uncertainty": uncertainty,
+        "uncertainty_method": uncertainty_method,
+        "bootstrap": bootstrap,
+        "fit_validity": {
+            "is_valid": not validity_reasons,
+            "reasons": validity_reasons,
+            "measurement_protocol": measurement_protocol,
+            "reference_protocol": reference_protocol,
+        },
+    }
 
 
 def _measurement_induced_errors(
     protocol_results: _ProtocolResults,
+    bootstrap_decay_parameters: _BootstrapDecayParameters,
     *,
     targets: tuple[str, ...],
     measurement_protocol: MCMRBProtocol,
     reference_protocol: MCMRBProtocol,
-) -> _TargetErrorPayload:
-    """Return one estimate directly or multiple estimates keyed by target."""
+    requested_bootstrap_resamples: int,
+    bootstrap_confidence_level: float,
+) -> _TargetErrorEstimates:
+    """Return one target-keyed estimate for every target in the role."""
     if (
         measurement_protocol not in protocol_results
         or reference_protocol not in protocol_results
     ):
-        return None
-    estimates = {
+        return dict.fromkeys(targets)
+    return {
         target: _measurement_induced_error(
             protocol_results,
+            bootstrap_decay_parameters,
             target=target,
             measurement_protocol=measurement_protocol,
             reference_protocol=reference_protocol,
+            requested_bootstrap_resamples=requested_bootstrap_resamples,
+            bootstrap_confidence_level=bootstrap_confidence_level,
         )
         for target in targets
     }
-    if len(targets) == 1:
-        return estimates[targets[0]]
-    return estimates
 
 
-def _waveform_duration_payload(
-    waveforms: Mapping[str, Waveform],
+def _intermediate_measurement_metadata(
+    resources: _SequenceResources,
+) -> dict[str, dict[str, object]]:
+    """Describe the exact intermediate readout used for every ancilla."""
+    metadata: dict[str, dict[str, object]] = {}
+    for target in resources.ancillas:
+        measurement = resources.measurements[target]
+        timing = _infer_readout_timing(measurement)
+        interval = tuple(
+            half_samples * resources.sampling_period / 2.0
+            for half_samples in timing.ramp_trimmed_interval_half_samples
+        )
+        values = np.asarray(measurement.values)
+        metadata[target] = {
+            "source": resources.measurement_sources[target],
+            "scale": resources.measurement_scales[target],
+            "duration_ns": measurement.duration,
+            "peak_amplitude": float(np.max(np.abs(values))),
+            "integrated_power": float(
+                np.sum(np.abs(values) ** 2) * resources.sampling_period
+            ),
+            "integrated_power_units": "amplitude_squared_ns",
+            "ramp_trimmed_active_interval_ns": interval,
+        }
+    return metadata
+
+
+def _format_summary_estimate(
+    value: float | None,
+    uncertainty: float | None,
     *,
-    targets: tuple[str, ...],
-) -> float | dict[str, float] | None:
-    """Return scalar or target-keyed waveform durations for result metadata."""
-    if not waveforms:
-        return None
-    durations = {target: waveforms[target].duration for target in targets}
-    if len(targets) == 1:
-        return durations[targets[0]]
-    return durations
+    scale: float,
+    precision: int,
+) -> str:
+    """Format a value and optional uncertainty for a summary-table cell."""
+    if value is None:
+        return "—"
+    value_text = f"{scale * value:.{precision}f}"
+    if uncertainty is None:
+        return value_text
+    return f"{value_text} ± {scale * uncertainty:.{precision}f}"
+
+
+def _format_fit_validity(validity: _FitValidity | _PairedFitValidity) -> str:
+    """Format fit validity and optional R-squared for a summary-table cell."""
+    status = "[green]valid[/green]" if validity["is_valid"] else "[red]invalid[/red]"
+    r_squared = validity.get("r_squared")
+    if r_squared is None:
+        return status
+    return f"{status} (R²={r_squared:.4f})"
+
+
+def _print_summary_tables(
+    protocol_results: _ProtocolResults,
+    measurement_induced_errors: _MeasurementInducedErrors,
+    *,
+    controls: tuple[str, ...],
+    ancillas: tuple[str, ...],
+) -> None:
+    """Print compact protocol-fit and induced-error summary tables."""
+    protocol_table = Table(
+        title="MCM randomized benchmarking: protocol fits",
+        header_style="bold",
+    )
+    protocol_table.add_column("Protocol")
+    protocol_table.add_column("Target")
+    protocol_table.add_column("p ± uncertainty", justify="right")
+    protocol_table.add_column("Error/cycle [%]", justify="right")
+    protocol_table.add_column("Uncertainty")
+    protocol_table.add_column("Fit validity")
+    for protocol, target_results in protocol_results.items():
+        for target, target_result in target_results.items():
+            protocol_table.add_row(
+                protocol,
+                target,
+                _format_summary_estimate(
+                    target_result["decay_parameter"],
+                    target_result["decay_parameter_uncertainty"],
+                    scale=1.0,
+                    precision=6,
+                ),
+                _format_summary_estimate(
+                    target_result["error_per_cycle"],
+                    target_result["error_per_cycle_uncertainty"],
+                    scale=100.0,
+                    precision=4,
+                ),
+                target_result["uncertainty_method"],
+                _format_fit_validity(target_result["fit_validity"]),
+            )
+    console.print(protocol_table)
+
+    error_table = Table(
+        title="MCM randomized benchmarking: measurement-induced errors",
+        header_style="bold",
+    )
+    error_table.add_column("Quantity")
+    error_table.add_column("Target")
+    error_table.add_column("Error [%/cycle]", justify="right")
+    error_table.add_column("Protocol pair")
+    error_table.add_column("Uncertainty")
+    error_table.add_column("Fit validity")
+    error_groups = (
+        (
+            "control",
+            controls,
+            measurement_induced_errors["control"],
+            _MCM_RB,
+            _DELAY_RB,
+        ),
+        (
+            "ancilla population with Cliffords",
+            ancillas,
+            measurement_induced_errors["ancilla_population_with_cliffords"],
+            _MCM_RB,
+            _DELAY_RB,
+        ),
+        (
+            "ancilla population with control delay",
+            ancillas,
+            measurement_induced_errors["ancilla_population_with_control_delay"],
+            _MCM_REP,
+            _DELAY_REP,
+        ),
+    )
+    has_error_rows = False
+    for (
+        quantity,
+        targets,
+        estimates,
+        measurement_protocol,
+        reference_protocol,
+    ) in error_groups:
+        for target in targets:
+            estimate = estimates[target]
+            if estimate is None:
+                continue
+            has_error_rows = True
+            error_table.add_row(
+                quantity,
+                target,
+                _format_summary_estimate(
+                    estimate["value"],
+                    estimate["uncertainty"],
+                    scale=100.0,
+                    precision=4,
+                ),
+                f"{measurement_protocol} / {reference_protocol}",
+                estimate["uncertainty_method"],
+                _format_fit_validity(estimate["fit_validity"]),
+            )
+    if has_error_rows:
+        console.print(error_table)
 
 
 def mcm_randomized_benchmarking(
@@ -1341,15 +1984,21 @@ def mcm_randomized_benchmarking(
     ancilla_mode: Literal["standard", "randomized"] = "standard",
     x90: Waveform | Mapping[str, Waveform] | None = None,
     measurement_waveform: Waveform | Mapping[str, Waveform] | None = None,
+    measurement_scale: float | Mapping[str, float] | None = None,
     echo_x180: Waveform | Mapping[str, Waveform] | None = None,
     ancilla_x180: Waveform | Mapping[str, Waveform] | None = None,
     n_shots: int | None = None,
     shot_interval: float | None = None,
     time_integration: bool = True,
+    n_bootstrap: int = _DEFAULT_N_BOOTSTRAP,
+    bootstrap_seed: int | None = 0,
+    bootstrap_confidence_level: float = _DEFAULT_BOOTSTRAP_CONFIDENCE_LEVEL,
+    min_fit_r_squared: float | None = _DEFAULT_MIN_FIT_R_SQUARED,
     xaxis_type: Literal["linear", "log"] = "linear",
     plot: bool | None = None,
     save_image: bool | None = None,
-    enable_tqdm: bool = False,
+    print_summary: bool = True,
+    enable_tqdm: bool = True,
 ) -> Result:
     """
     Run selected measurement-crosstalk randomized-benchmarking protocols.
@@ -1367,10 +2016,10 @@ def mcm_randomized_benchmarking(
         MCM protocols read all ancillas simultaneously; delay protocols
         replace every readout with a duration-matched delay.
     n_cliffords_range
-        Strictly increasing nonnegative cycle counts. Defaults to 0 followed
-        by 14 geometrically spaced values from 1 through 150.
+        At least three strictly increasing nonnegative cycle counts. Defaults
+        to 0 followed by 14 geometrically spaced values from 1 through 150.
     n_trials
-        Number of seed trials per cycle count. Defaults to 30.
+        Positive number of seed trials per cycle count. Defaults to 30.
     seeds
         One nonnegative integer seed for every trial. Defaults to generated
         seeds. Values must have integer types and fit in signed 64 bits.
@@ -1403,7 +2052,14 @@ def mcm_randomized_benchmarking(
         durations may differ. Omitted mapping entries use calibrated defaults.
         Active intervals are inferred from nonzero samples; at most one FlatTop
         pulse may be present in each waveform, and other shapes have zero
-        inferred ramp duration.
+        inferred ramp duration. The override affects only intermediate
+        readouts; terminal measurements use calibrated defaults.
+    measurement_scale
+        Optional positive scale for each intermediate ancilla readout. A scalar
+        scales every selected ancilla's own calibrated readout; a target-keyed
+        mapping scales only listed ancillas and leaves other ancillas at 1.0.
+        This option is mutually exclusive with `measurement_waveform`. Terminal
+        measurements continue to use calibrated default readouts.
     echo_x180
         Optional control X180 override for echoed measurement blocks. Use a
         waveform for one control or a target-keyed mapping for multiple
@@ -1420,30 +2076,48 @@ def mcm_randomized_benchmarking(
         experiment default.
     time_integration
         Whether to integrate each capture over time.
+    n_bootstrap
+        Number of paired trial-column bootstrap resamples. Defaults to 1000.
+        Set to 0 to disable bootstrap uncertainty. Bootstrap requires at least
+        four sequence lengths and two trials. Fit-covariance uncertainty is
+        used if fewer than 80% of resampled fits succeed.
+    bootstrap_seed
+        Nonnegative seed for paired bootstrap resampling. Defaults to 0 for
+        reproducible analysis. Pass `None` for nondeterministic resampling.
+    bootstrap_confidence_level
+        Percentile-bootstrap confidence level strictly between 0 and 1.
+        Defaults to 0.95.
+    min_fit_r_squared
+        Minimum R-squared for a fit to be marked valid. Defaults to 0.9. Pass
+        `None` to omit the R-squared threshold while retaining other checks.
     xaxis_type
         X-axis scale used by fit figures.
     plot
         Whether to display fit figures. Defaults to `True`.
     save_image
         Whether to save successful fit figures. Defaults to `False`.
+    print_summary
+        Whether to print protocol-fit and measurement-induced-error summary
+        tables. This is independent of `plot` and defaults to `True`.
     enable_tqdm
-        Whether to show schedule-execution progress.
+        Whether to show schedule-execution progress. Defaults to `True`.
 
     Returns
     -------
     Result
         Raw terminal probabilities, per-protocol statistics and fits, the
-        optional MCM-induced control error, randomized-ancilla population
-        errors with Clifford-driven or delayed control, metadata, and named
-        fit figures.
+        MCM-induced error estimates, fit-validity and bootstrap diagnostics,
+        metadata, and named fit figures.
         Protocol results are stored under
-        `result.data["protocols"][protocol][target]`. The Clifford-driven and
-        control-delay ancilla estimates are stored as
-        `measurement_induced_ancilla_population_error` and
-        `measurement_induced_ancilla_population_error_with_idle_control`.
-        Each induced-error field contains one estimate for a single target, a
-        target-keyed mapping when that role contains multiple targets, or
-        `None` when its matched protocol pair was not run.
+        `result.data["protocol_results"][protocol][target]`. Induced errors are
+        grouped under `result.data["measurement_induced_errors"]` as
+        `control`, `ancilla_population_with_cliffords`, and
+        `ancilla_population_with_control_delay`.
+        Every induced-error field is a target-keyed mapping regardless of the
+        number of targets. Its value is `None` when the matched protocol pair
+        was not run or its decay ratio cannot be evaluated. An otherwise valid
+        ratio is retained with `uncertainty=None` when no uncertainty estimate
+        is available.
 
     Raises
     ------
@@ -1478,10 +2152,20 @@ def mcm_randomized_benchmarking(
     Randomized mode benchmarks ancilla computational-basis population
     preservation, not general single-qubit or state-assignment fidelity. Its
     induced ancilla error estimate assumes the randomized I/X180 and
-    measurement channels produce compatible exponential decays. The
-    uncertainty of an induced-error estimate treats the two fitted decay
-    parameters as independent even though matched random sequences can
-    correlate them.
+    measurement channels produce compatible exponential decays. Paired
+    bootstrap resampling preserves correlations by resampling the same complete
+    trial/root-seed columns for all sequence lengths, protocols, and targets.
+    When bootstrap is unavailable, induced-error uncertainty falls back to
+    independent propagation of fit-covariance uncertainties.
+    Per-protocol `decay_parameter_uncertainty` likewise prefers the bootstrap
+    standard error. The covariance-based parameter uncertainty remains
+    available as `fit.data["p_err"]`.
+
+    Optimizer convergence alone does not make a fit valid. Each protocol result
+    reports checks for sequence-count sufficiency, finite parameters and
+    uncertainty, a decay parameter at its bound, and the optional R-squared
+    threshold. Estimates remain available when a check fails, but callers should
+    inspect `fit_validity` before interpreting them.
 
     Independent control and ancilla random streams are assigned in resolved
     input order. Ancilla I/X180 choices are generated once per sequence length
@@ -1515,6 +2199,24 @@ def mcm_randomized_benchmarking(
         DEFAULT_INTERVAL if shot_interval is None else shot_interval,
         name="shot_interval",
     )
+    resolved_n_bootstrap = _validate_nonnegative_integer(
+        n_bootstrap,
+        name="n_bootstrap",
+    )
+    resolved_bootstrap_seed = (
+        None
+        if bootstrap_seed is None
+        else _validate_nonnegative_integer(bootstrap_seed, name="bootstrap_seed")
+    )
+    resolved_bootstrap_confidence_level = _validate_open_unit_interval(
+        bootstrap_confidence_level,
+        name="bootstrap_confidence_level",
+    )
+    resolved_min_fit_r_squared = (
+        None
+        if min_fit_r_squared is None
+        else _validate_fit_r_squared_threshold(min_fit_r_squared)
+    )
     resolved_plot = True if plot is None else plot
     resolved_save_image = False if save_image is None else save_image
     resolved_xaxis_type = _validate_xaxis_type(xaxis_type)
@@ -1529,6 +2231,7 @@ def mcm_randomized_benchmarking(
         ancilla_mode=resolved_ancilla_mode,
         x90=x90,
         measurement_waveform=measurement_waveform,
+        measurement_scale=measurement_scale,
         echo_x180=echo_x180,
         ancilla_x180=ancilla_x180,
     )
@@ -1543,70 +2246,111 @@ def mcm_randomized_benchmarking(
         time_integration=time_integration,
         enable_tqdm=enable_tqdm,
     )
-    protocol_results, figures = _analyze_trials(
+    protocol_results, figures, bootstrap_decay_parameters = _analyze_trials(
         trials,
         targets=resources.targets,
         n_cliffords=resolved_n_cliffords,
+        n_bootstrap=resolved_n_bootstrap,
+        bootstrap_seed=resolved_bootstrap_seed,
+        bootstrap_confidence_level=resolved_bootstrap_confidence_level,
+        min_fit_r_squared=resolved_min_fit_r_squared,
         plot=resolved_plot,
         save_image=resolved_save_image,
         xaxis_type=resolved_xaxis_type,
     )
 
-    return Result(
+    control_error = _measurement_induced_errors(
+        protocol_results,
+        bootstrap_decay_parameters,
+        targets=control_qubits,
+        measurement_protocol=_MCM_RB,
+        reference_protocol=_DELAY_RB,
+        requested_bootstrap_resamples=resolved_n_bootstrap,
+        bootstrap_confidence_level=resolved_bootstrap_confidence_level,
+    )
+    ancilla_population_error: _TargetErrorEstimates = (
+        _measurement_induced_errors(
+            protocol_results,
+            bootstrap_decay_parameters,
+            targets=ancilla_qubits,
+            measurement_protocol=_MCM_RB,
+            reference_protocol=_DELAY_RB,
+            requested_bootstrap_resamples=resolved_n_bootstrap,
+            bootstrap_confidence_level=resolved_bootstrap_confidence_level,
+        )
+        if resolved_ancilla_mode == _RANDOMIZED_ANCILLA
+        else dict.fromkeys(ancilla_qubits)
+    )
+    ancilla_population_error_with_control_delay: _TargetErrorEstimates = (
+        _measurement_induced_errors(
+            protocol_results,
+            bootstrap_decay_parameters,
+            targets=ancilla_qubits,
+            measurement_protocol=_MCM_REP,
+            reference_protocol=_DELAY_REP,
+            requested_bootstrap_resamples=resolved_n_bootstrap,
+            bootstrap_confidence_level=resolved_bootstrap_confidence_level,
+        )
+        if resolved_ancilla_mode == _RANDOMIZED_ANCILLA
+        else dict.fromkeys(ancilla_qubits)
+    )
+    measurement_induced_errors: _MeasurementInducedErrors = {
+        "control": control_error,
+        "ancilla_population_with_cliffords": ancilla_population_error,
+        "ancilla_population_with_control_delay": (
+            ancilla_population_error_with_control_delay
+        ),
+    }
+
+    result = Result(
         data={
             "n_cliffords": resolved_n_cliffords,
             "seeds": resolved_seeds,
-            "protocols": protocol_results,
-            "measurement_induced_control_error": _measurement_induced_errors(
-                protocol_results,
-                targets=control_qubits,
-                measurement_protocol=_MCM_RB,
-                reference_protocol=_DELAY_RB,
-            ),
-            "measurement_induced_ancilla_population_error": (
-                _measurement_induced_errors(
-                    protocol_results,
-                    targets=ancilla_qubits,
-                    measurement_protocol=_MCM_RB,
-                    reference_protocol=_DELAY_RB,
-                )
-                if resolved_ancilla_mode == _RANDOMIZED_ANCILLA
-                else None
-            ),
-            "measurement_induced_ancilla_population_error_with_idle_control": (
-                _measurement_induced_errors(
-                    protocol_results,
-                    targets=ancilla_qubits,
-                    measurement_protocol=_MCM_REP,
-                    reference_protocol=_DELAY_REP,
-                )
-                if resolved_ancilla_mode == _RANDOMIZED_ANCILLA
-                else None
-            ),
+            "protocol_results": protocol_results,
+            "measurement_induced_errors": measurement_induced_errors,
             "metadata": {
-                "control": control_qubits[0] if len(control_qubits) == 1 else None,
-                "ancilla": ancilla_qubits[0] if len(ancilla_qubits) == 1 else None,
                 "controls": control_qubits,
                 "ancillas": ancilla_qubits,
-                "protocols": resolved_protocols,
                 "control_echo": control_echo,
                 "ancilla_mode": resolved_ancilla_mode,
-                "n_trials": resolved_n_trials,
-                "n_shots": resolved_n_shots,
-                "shot_interval": resolved_shot_interval,
-                "time_integration": time_integration,
-                "measurement_duration": _waveform_duration_payload(
-                    resources.measurements,
-                    targets=ancilla_qubits,
-                ),
-                "ancilla_x180_duration": _waveform_duration_payload(
-                    resources.ancilla_x180s,
-                    targets=ancilla_qubits,
-                ),
+                "acquisition": {
+                    "n_trials": resolved_n_trials,
+                    "n_shots": resolved_n_shots,
+                    "shot_interval_ns": resolved_shot_interval,
+                    "time_integration": time_integration,
+                },
+                "analysis": {
+                    "n_bootstrap": resolved_n_bootstrap,
+                    "bootstrap_seed": resolved_bootstrap_seed,
+                    "bootstrap_confidence_level": resolved_bootstrap_confidence_level,
+                    "min_bootstrap_success_rate": _MIN_BOOTSTRAP_SUCCESS_RATE,
+                    "min_fit_r_squared": resolved_min_fit_r_squared,
+                },
+                "pulses": {
+                    "intermediate_measurements": (
+                        _intermediate_measurement_metadata(resources)
+                    ),
+                    "terminal_measurements": {
+                        "targets": resources.targets,
+                        "source": "calibrated_default",
+                    },
+                    "ancilla_x180_durations_ns": {
+                        target: waveform.duration
+                        for target, waveform in resources.ancilla_x180s.items()
+                    },
+                },
             },
         },
         figures=figures or None,
     )
+    if print_summary:
+        _print_summary_tables(
+            protocol_results,
+            measurement_induced_errors,
+            controls=control_qubits,
+            ancillas=ancilla_qubits,
+        )
+    return result
 
 
 __all__ = [

--- a/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
+++ b/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
@@ -25,11 +25,16 @@ from qubex.measurement.models.measure_result import MultipleMeasureResult
 from qubex.pulse import Blank, FlatTop, PulseArray, PulseSchedule, VirtualZ, Waveform
 
 MCMRBProtocol = Literal["mcm-rb", "delay-rb", "mcm-rep"]
+_AncillaMode = Literal["standard", "randomized"]
 
 _MCM_RB: MCMRBProtocol = "mcm-rb"
 _DELAY_RB: MCMRBProtocol = "delay-rb"
 _MCM_REP: MCMRBProtocol = "mcm-rep"
 _MCM_RB_PROTOCOLS: tuple[MCMRBProtocol, ...] = (_MCM_RB, _DELAY_RB, _MCM_REP)
+_STANDARD_ANCILLA: _AncillaMode = "standard"
+_RANDOMIZED_ANCILLA: _AncillaMode = "randomized"
+_RANDOMIZED_ANCILLA_PROTOCOLS: tuple[MCMRBProtocol, ...] = (_MCM_RB, _DELAY_RB)
+_ANCILLA_RANDOMIZATION_SPAWN_KEY = (1,)
 
 
 @dataclass(frozen=True)
@@ -43,6 +48,7 @@ class _SequenceResources:
     x90: Waveform
     measurement: Waveform
     control_during_measurement: Waveform
+    ancilla_x180: Waveform | None
 
     @property
     def targets(self) -> tuple[str, str]:
@@ -56,6 +62,14 @@ class _CompiledCliffordSequence:
 
     cliffords: tuple[PulseArray, ...]
     inverse: PulseArray
+
+
+@dataclass(frozen=True)
+class _CompiledAncillaSequence:
+    """Duration-matched ancilla I/X operations and their parity recovery."""
+
+    operations: tuple[Waveform, ...]
+    recovery: Waveform
 
 
 @dataclass(frozen=True)
@@ -91,6 +105,29 @@ def _validate_protocol(protocol: str) -> MCMRBProtocol:
             f"Invalid `protocol`: {protocol!r}. Expected one of {_MCM_RB_PROTOCOLS}."
         )
     return cast(MCMRBProtocol, protocol)
+
+
+def _validate_ancilla_mode(ancilla_mode: str) -> _AncillaMode:
+    """Validate and narrow the ancilla sequence mode."""
+    if ancilla_mode not in (_STANDARD_ANCILLA, _RANDOMIZED_ANCILLA):
+        raise ValueError(
+            "Invalid `ancilla_mode`: "
+            f"{ancilla_mode!r}. Expected 'standard' or 'randomized'."
+        )
+    return cast(_AncillaMode, ancilla_mode)
+
+
+def _validate_protocol_for_ancilla_mode(
+    protocol: MCMRBProtocol,
+    *,
+    ancilla_mode: _AncillaMode,
+) -> None:
+    """Reject protocols incompatible with randomized ancilla recovery."""
+    if ancilla_mode == _RANDOMIZED_ANCILLA and protocol == _MCM_REP:
+        raise ValueError(
+            "`mcm-rep` is not supported when `ancilla_mode='randomized'`; "
+            "use `mcm-rb` and `delay-rb` as a matched pair."
+        )
 
 
 def _validate_nonnegative_integer(value: object, *, name: str) -> int:
@@ -298,9 +335,11 @@ def _resolve_sequence_resources(
     control: str,
     ancilla: str,
     control_echo: bool,
+    ancilla_mode: _AncillaMode,
     x90: Waveform | None,
     measurement_waveform: Waveform | None,
     echo_x180: Waveform | None,
+    ancilla_x180: Waveform | None,
 ) -> _SequenceResources:
     """Resolve and validate labels and waveforms used by every protocol."""
     sampling_period = float(exp.ctx.measurement.sampling_period)
@@ -333,6 +372,17 @@ def _resolve_sequence_resources(
             name="echo_x180",
         )
 
+    resolved_ancilla_x180: Waveform | None = None
+    if ancilla_mode == _RANDOMIZED_ANCILLA:
+        resolved_ancilla_x180 = (
+            ancilla_x180 if ancilla_x180 is not None else exp.pulse.x180(ancilla)
+        )
+        _validate_waveform(
+            resolved_ancilla_x180,
+            expected_sampling_period=sampling_period,
+            name="ancilla_x180",
+        )
+
     return _SequenceResources(
         control=control,
         ancilla=ancilla,
@@ -345,6 +395,7 @@ def _resolve_sequence_resources(
             sampling_period=sampling_period,
             echo_x180=resolved_echo,
         ),
+        ancilla_x180=resolved_ancilla_x180,
     )
 
 
@@ -382,15 +433,51 @@ def _generate_clifford_sequence(
     )
 
 
+def _compile_ancilla_sequence(
+    resources: _SequenceResources,
+    *,
+    n_cliffords: int,
+    seed: int | None,
+) -> _CompiledAncillaSequence | None:
+    """Compile reproducible ancilla I/X choices when randomized mode is active."""
+    x180 = resources.ancilla_x180
+    if x180 is None:
+        return None
+
+    seed_sequence = np.random.SeedSequence(
+        seed,
+        spawn_key=_ANCILLA_RANDOMIZATION_SPAWN_KEY,
+    )
+    values = np.random.default_rng(seed_sequence).integers(
+        0,
+        2,
+        size=n_cliffords,
+        dtype=np.int8,
+    )
+    identity = _blank(x180.duration, resources.sampling_period)
+    operations = tuple(x180 if value else identity for value in values)
+    recovery = x180 if np.count_nonzero(values) % 2 else identity
+    return _CompiledAncillaSequence(operations=operations, recovery=recovery)
+
+
 def _build_protocol_schedule(
     resources: _SequenceResources,
     clifford_sequence: _CompiledCliffordSequence,
     *,
     protocol: MCMRBProtocol,
+    ancilla_sequence: _CompiledAncillaSequence | None = None,
 ) -> PulseSchedule:
     """Build one protocol schedule from shared resources and Cliffords."""
-    with PulseSchedule([resources.control, resources.readout_label]) as schedule:
-        for clifford in clifford_sequence.cliffords:
+    schedule_labels = [resources.control, resources.readout_label]
+    if ancilla_sequence is not None:
+        schedule_labels.insert(1, resources.ancilla)
+        if len(ancilla_sequence.operations) != len(clifford_sequence.cliffords):
+            raise RuntimeError(
+                "The ancilla sequence length must match the Clifford sequence."
+            )
+
+    with PulseSchedule(schedule_labels) as schedule:
+        for cycle_index, clifford in enumerate(clifford_sequence.cliffords):
             control_operation: Waveform
             if protocol == _MCM_REP:
                 control_operation = _blank(
@@ -402,19 +489,30 @@ def _build_protocol_schedule(
             schedule.add(resources.control, control_operation)
             schedule.barrier()
 
-            ancilla_operation: Waveform
+            if ancilla_sequence is not None:
+                schedule.add(
+                    resources.ancilla,
+                    ancilla_sequence.operations[cycle_index],
+                )
+                schedule.barrier()
+
+            measurement_operation: Waveform
             if protocol == _DELAY_RB:
-                ancilla_operation = _blank(
+                measurement_operation = _blank(
                     resources.measurement.duration,
                     resources.sampling_period,
                 )
             else:
-                ancilla_operation = resources.measurement
-            schedule.add(resources.readout_label, ancilla_operation)
+                measurement_operation = resources.measurement
+            schedule.add(resources.readout_label, measurement_operation)
             schedule.add(
                 resources.control,
                 resources.control_during_measurement,
             )
+            schedule.barrier()
+
+        if ancilla_sequence is not None:
+            schedule.add(resources.ancilla, ancilla_sequence.recovery)
             schedule.barrier()
 
         final_control_operation: Waveform
@@ -439,9 +537,11 @@ def mcm_rb_sequence(
     n_cliffords: int,
     seed: int | None = None,
     control_echo: bool = False,
+    ancilla_mode: Literal["standard", "randomized"] = "standard",
     x90: Waveform | None = None,
     measurement_waveform: Waveform | None = None,
     echo_x180: Waveform | None = None,
+    ancilla_x180: Waveform | None = None,
 ) -> PulseSchedule:
     """
     Build one MCM-RB, delay-RB, or MCM-repetition pulse schedule.
@@ -465,6 +565,11 @@ def mcm_rb_sequence(
         or reference-delay window. The X180 centers are placed at the quarter
         and three-quarter points of the active readout interval after trimming
         half a ramp duration from each end.
+    ancilla_mode
+        Ancilla sequence mode. `"standard"` preserves the original protocol.
+        `"randomized"` inserts a seeded I/X180 before every measurement or
+        reference delay and applies a final parity recovery. Randomized mode
+        supports only `"mcm-rb"` and `"delay-rb"`.
     x90
         Optional control X90 waveform override.
     measurement_waveform
@@ -475,6 +580,9 @@ def mcm_rb_sequence(
     echo_x180
         Optional control X180 waveform override used by the X-X echo. Ignored
         when `control_echo=False`.
+    ancilla_x180
+        Optional ancilla X180 waveform override used for randomized I/X180
+        operations and parity recovery. Ignored in standard mode.
 
     Returns
     -------
@@ -486,16 +594,26 @@ def mcm_rb_sequence(
     TypeError
         Raised when a Clifford count or seed has an invalid type.
     ValueError
-        Raised for invalid targets, protocol names, lengths, waveform timing,
-        or echo timing.
+        Raised for invalid targets, protocol or ancilla mode names, lengths,
+        waveform timing, or echo timing.
 
     Notes
     -----
-    `mcm-rep` replaces every randomized Clifford and the final inverse with
-    duration-matched delays. The three protocols therefore have equal total
-    duration for the same Clifford sequence and seed.
+    In standard mode, `mcm-rep` replaces every randomized Clifford and the
+    final inverse with duration-matched delays. All selected protocols have
+    equal total duration for the same Clifford sequence and seed.
+
+    In randomized mode, the seed determines both the Clifford sequence and a
+    separate ancilla I/X180 random stream. The final ancilla recovery is X180
+    exactly when the programmed sequence has odd parity. One static I/X180
+    sequence is encoded in the returned schedule.
     """
     resolved_protocol = _validate_protocol(protocol)
+    resolved_ancilla_mode = _validate_ancilla_mode(ancilla_mode)
+    _validate_protocol_for_ancilla_mode(
+        resolved_protocol,
+        ancilla_mode=resolved_ancilla_mode,
+    )
     resolved_n_cliffords = _validate_nonnegative_integer(
         n_cliffords,
         name="n_cliffords",
@@ -509,9 +627,11 @@ def mcm_rb_sequence(
         control=control_qubit,
         ancilla=ancilla_qubit,
         control_echo=control_echo,
+        ancilla_mode=resolved_ancilla_mode,
         x90=x90,
         measurement_waveform=measurement_waveform,
         echo_x180=echo_x180,
+        ancilla_x180=ancilla_x180,
     )
     clifford_sequence = _generate_clifford_sequence(
         exp,
@@ -519,10 +639,16 @@ def mcm_rb_sequence(
         seed=resolved_seed,
         x90=resources.x90,
     )
+    ancilla_sequence = _compile_ancilla_sequence(
+        resources,
+        n_cliffords=resolved_n_cliffords,
+        seed=resolved_seed,
+    )
     return _build_protocol_schedule(
         resources,
         clifford_sequence,
         protocol=resolved_protocol,
+        ancilla_sequence=ancilla_sequence,
     )
 
 
@@ -531,20 +657,20 @@ def _integer_array(values: ArrayLike, *, name: str) -> NDArray[np.int64]:
     raw = np.asarray(values)
     if raw.ndim != 1 or raw.size == 0:
         raise ValueError(f"`{name}` must be a nonempty one-dimensional array.")
-    if any(isinstance(value, (bool, np.bool_)) for value in raw.tolist()):
-        raise ValueError(f"`{name}` must contain integers, not booleans.")
-    try:
-        numeric = raw.astype(np.float64)
-    except (TypeError, ValueError) as exc:
-        raise ValueError(f"`{name}` must contain integers.") from exc
-    if not np.all(np.isfinite(numeric)) or not np.all(numeric == np.floor(numeric)):
-        raise ValueError(f"`{name}` must contain integers.")
-    if np.any(numeric >= 2**63):
-        raise ValueError(f"`{name}` values are too large.")
-    integer_values = numeric.astype(np.int64)
-    if np.any(integer_values < 0):
-        raise ValueError(f"`{name}` must contain nonnegative integers.")
-    return integer_values
+
+    resolved: list[int] = []
+    for value in raw.tolist():
+        if isinstance(value, (bool, np.bool_)):
+            raise TypeError(f"`{name}` must contain integers, not booleans.")
+        if not isinstance(value, (int, np.integer)):
+            raise TypeError(f"`{name}` must contain integers.")
+        integer = int(value)
+        if integer < 0:
+            raise ValueError(f"`{name}` must contain nonnegative integers.")
+        if integer > np.iinfo(np.int64).max:
+            raise ValueError(f"`{name}` values are too large.")
+        resolved.append(integer)
+    return np.asarray(resolved, dtype=np.int64)
 
 
 def _resolve_n_cliffords_range(
@@ -571,9 +697,13 @@ def _resolve_n_cliffords_range(
 
 def _resolve_protocols(
     protocols: Collection[MCMRBProtocol] | MCMRBProtocol | None,
+    *,
+    ancilla_mode: _AncillaMode,
 ) -> tuple[MCMRBProtocol, ...]:
     """Return unique protocol names in caller-specified order."""
     if protocols is None:
+        if ancilla_mode == _RANDOMIZED_ANCILLA:
+            return _RANDOMIZED_ANCILLA_PROTOCOLS
         return _MCM_RB_PROTOCOLS
     candidates = [protocols] if isinstance(protocols, str) else list(protocols)
     if not candidates:
@@ -584,6 +714,11 @@ def _resolve_protocols(
     )
     if len(resolved) != len(set(resolved)):
         raise ValueError("`protocols` must not contain duplicate values.")
+    for protocol in resolved:
+        _validate_protocol_for_ancilla_mode(
+            protocol,
+            ancilla_mode=ancilla_mode,
+        )
     return resolved
 
 
@@ -679,11 +814,17 @@ def _acquire_trials(
                     seed=int(seed),
                     x90=resources.x90,
                 )
+                ancilla_sequence = _compile_ancilla_sequence(
+                    resources,
+                    n_cliffords=int(n_cliffords),
+                    seed=int(seed),
+                )
                 for protocol in protocols:
                     sequence = _build_protocol_schedule(
                         resources,
                         clifford_sequence,
                         protocol=protocol,
+                        ancilla_sequence=ancilla_sequence,
                     )
                     measure_result = exp.measurement_service.execute(
                         sequence,
@@ -799,13 +940,13 @@ def _analyze_trials(
 def _measurement_induced_error(
     protocol_results: _ProtocolResults,
     *,
-    control: str,
+    target: str,
 ) -> dict[str, float] | None:
-    """Calculate the MCM-induced control error relative to delay-RB."""
+    """Calculate one target's MCM-induced error relative to delay-RB."""
     if _MCM_RB not in protocol_results or _DELAY_RB not in protocol_results:
         return None
-    mcm_result = protocol_results[_MCM_RB][control]
-    delay_result = protocol_results[_DELAY_RB][control]
+    mcm_result = protocol_results[_MCM_RB][target]
+    delay_result = protocol_results[_DELAY_RB][target]
     p_mcm = mcm_result["decay_parameter"]
     p_mcm_err = mcm_result["decay_parameter_err"]
     p_delay = delay_result["decay_parameter"]
@@ -836,9 +977,11 @@ def mcm_randomized_benchmarking(
     seeds: ArrayLike | None = None,
     protocols: Collection[MCMRBProtocol] | MCMRBProtocol | None = None,
     control_echo: bool = False,
+    ancilla_mode: Literal["standard", "randomized"] = "standard",
     x90: Waveform | None = None,
     measurement_waveform: Waveform | None = None,
     echo_x180: Waveform | None = None,
+    ancilla_x180: Waveform | None = None,
     n_shots: int | None = None,
     shot_interval: float | None = None,
     time_integration: bool = True,
@@ -848,7 +991,7 @@ def mcm_randomized_benchmarking(
     enable_tqdm: bool = False,
 ) -> Result:
     """
-    Run MCM-RB, delay-RB, and MCM-repetition experiments.
+    Run selected measurement-crosstalk randomized-benchmarking protocols.
 
     Parameters
     ----------
@@ -864,16 +1007,25 @@ def mcm_randomized_benchmarking(
     n_trials
         Number of random Clifford trials per cycle count. Defaults to 30.
     seeds
-        Nonnegative integer seed for every trial. Defaults to generated seeds.
+        One nonnegative integer seed for every trial. Defaults to generated
+        seeds. Values must have integer types and fit in signed 64 bits.
     protocols
         Protocols to run. Defaults to all of `"mcm-rb"`, `"delay-rb"`, and
-        `"mcm-rep"`. The same generated Clifford sequence is shared across
-        protocols for each sequence length and seed.
+        `"mcm-rep"` in standard mode and to the matched `"mcm-rb"` and
+        `"delay-rb"` pair in randomized mode. The same generated Clifford and
+        ancilla I/X180 sequences are shared across protocols for each sequence
+        length and seed.
     control_echo
         Whether to insert an X-X echo on the control during every measurement
         or duration-matched delay window. The X180 centers are placed at the
         quarter and three-quarter points of the active readout interval after
         trimming half a ramp duration from each end.
+    ancilla_mode
+        Ancilla sequence mode. `"standard"` preserves the original suite.
+        `"randomized"` inserts a seeded I/X180 before every measurement or
+        reference delay, followed by an X180 for odd parity or a
+        duration-matched blank for even parity. Randomized mode does not
+        support `"mcm-rep"`.
     x90
         Optional control X90 waveform override.
     measurement_waveform
@@ -884,6 +1036,9 @@ def mcm_randomized_benchmarking(
     echo_x180
         Optional control X180 waveform override for echoed measurement blocks.
         Ignored when `control_echo=False`.
+    ancilla_x180
+        Optional ancilla X180 waveform override used by randomized mode.
+        Ignored in standard mode.
     n_shots
         Number of shots per schedule. Defaults to the experiment default.
     shot_interval
@@ -904,16 +1059,18 @@ def mcm_randomized_benchmarking(
     -------
     Result
         Raw terminal probabilities, per-protocol statistics and fits, the
-        MCM-induced control error, metadata, and named fit figures. Protocol
-        results are stored under `result.data["protocols"][protocol][target]`.
+        MCM-induced control error, optional randomized-ancilla population
+        error, metadata, and named fit figures. Protocol results are stored
+        under `result.data["protocols"][protocol][target]`.
 
     Raises
     ------
     TypeError
-        Raised when a trial or shot count has an invalid type.
+        Raised when a sweep value, seed, trial count, or shot count has an
+        invalid type.
     ValueError
-        Raised when targets, sweep values, seeds, protocols, or pulse timing
-        are invalid.
+        Raised when targets, sweep values, seeds, protocols, ancilla mode, or
+        pulse timing are invalid.
 
     Notes
     -----
@@ -922,13 +1079,30 @@ def mcm_randomized_benchmarking(
     MCM-RB and delay-RB succeed, the reported induced error is
     `(1 - p_mcm / p_delay) / 2`.
 
-    MCM-RB and delay-RB have the standard randomized-benchmarking exponential
-    form under the usual assumptions. MCM-repetition is fitted to the same
-    form for comparison, but its decay is not generally guaranteed to be
-    exponential because the ancilla is not Clifford twirled.
+    Control-qubit MCM-RB and delay-RB have the standard
+    randomized-benchmarking exponential form under the usual assumptions.
+    MCM-repetition is fitted to the same form for comparison, but its decay is
+    not generally guaranteed to be exponential because the ancilla is not
+    Clifford twirled.
+
+    Randomized mode benchmarks ancilla computational-basis population
+    preservation, not general single-qubit or state-assignment fidelity. Its
+    induced ancilla error estimate assumes the randomized I/X180 and
+    measurement channels produce compatible exponential decays. The
+    uncertainty of an induced-error estimate treats the two fitted decay
+    parameters as independent even though matched random sequences can
+    correlate them.
+
+    The ancilla I/X180 choices are generated once per sequence length and
+    trial seed, then reused for every shot of that schedule. Randomization is
+    averaged across trials rather than varied shot by shot.
     """
+    resolved_ancilla_mode = _validate_ancilla_mode(ancilla_mode)
     resolved_n_cliffords = _resolve_n_cliffords_range(n_cliffords_range)
-    resolved_protocols = _resolve_protocols(protocols)
+    resolved_protocols = _resolve_protocols(
+        protocols,
+        ancilla_mode=resolved_ancilla_mode,
+    )
     resolved_n_trials = _validate_positive_integer(
         DEFAULT_RB_N_TRIALS if n_trials is None else n_trials,
         name="n_trials",
@@ -954,9 +1128,11 @@ def mcm_randomized_benchmarking(
         control=control_qubit,
         ancilla=ancilla_qubit,
         control_echo=control_echo,
+        ancilla_mode=resolved_ancilla_mode,
         x90=x90,
         measurement_waveform=measurement_waveform,
         echo_x180=echo_x180,
+        ancilla_x180=ancilla_x180,
     )
     trials = _acquire_trials(
         exp,
@@ -985,18 +1161,32 @@ def mcm_randomized_benchmarking(
             "protocols": protocol_results,
             "measurement_induced_control_error": _measurement_induced_error(
                 protocol_results,
-                control=control_qubit,
+                target=control_qubit,
+            ),
+            "measurement_induced_ancilla_population_error": (
+                _measurement_induced_error(
+                    protocol_results,
+                    target=ancilla_qubit,
+                )
+                if resolved_ancilla_mode == _RANDOMIZED_ANCILLA
+                else None
             ),
             "metadata": {
                 "control": control_qubit,
                 "ancilla": ancilla_qubit,
                 "protocols": resolved_protocols,
                 "control_echo": control_echo,
+                "ancilla_mode": resolved_ancilla_mode,
                 "n_trials": resolved_n_trials,
                 "n_shots": resolved_n_shots,
                 "shot_interval": resolved_shot_interval,
                 "time_integration": time_integration,
                 "measurement_duration": resources.measurement.duration,
+                "ancilla_x180_duration": (
+                    resources.ancilla_x180.duration
+                    if resources.ancilla_x180 is not None
+                    else None
+                ),
             },
         },
         figures=figures or None,

--- a/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
+++ b/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
@@ -1,8 +1,8 @@
-"""MCM randomized-benchmarking and repetition experiments."""
+"""Single- and multi-qubit MCM benchmarking and repetition experiments."""
 
 from __future__ import annotations
 
-from collections.abc import Collection
+from collections.abc import Callable, Collection, Mapping
 from dataclasses import dataclass
 from numbers import Real
 from typing import Literal, TypedDict, cast
@@ -57,26 +57,29 @@ _CONTROL_DELAY_PROTOCOLS: tuple[MCMRBProtocol, ...] = (_MCM_REP, _DELAY_REP)
 _READOUT_DELAY_PROTOCOLS: tuple[MCMRBProtocol, ...] = (_DELAY_RB, _DELAY_REP)
 _STANDARD_ANCILLA: _AncillaMode = "standard"
 _RANDOMIZED_ANCILLA: _AncillaMode = "randomized"
+_CONTROL_RANDOMIZATION_SPAWN_KEY = (0,)
 _ANCILLA_RANDOMIZATION_SPAWN_KEY = (1,)
+
+_WaveformOverride = Waveform | Mapping[str, Waveform] | None
 
 
 @dataclass(frozen=True)
 class _SequenceResources:
     """Resolved labels and waveforms shared by all protocol schedules."""
 
-    control: str
-    ancilla: str
-    readout_label: str
+    controls: tuple[str, ...]
+    ancillas: tuple[str, ...]
+    readout_labels: Mapping[str, str]
     sampling_period: float
-    x90: Waveform
-    measurement: Waveform
-    control_during_measurement: Waveform
-    ancilla_x180: Waveform | None
+    x90s: Mapping[str, Waveform]
+    measurements: Mapping[str, Waveform]
+    controls_during_measurement: Mapping[str, Waveform]
+    ancilla_x180s: Mapping[str, Waveform]
 
     @property
-    def targets(self) -> tuple[str, str]:
-        """Return the control and ancilla labels."""
-        return self.control, self.ancilla
+    def targets(self) -> tuple[str, ...]:
+        """Return all control and ancilla labels in role order."""
+        return (*self.controls, *self.ancillas)
 
 
 @dataclass(frozen=True)
@@ -103,6 +106,15 @@ class _ReadoutTiming:
     active_length_samples: int
     ramp_length_samples: int
 
+    @property
+    def ramp_trimmed_interval_half_samples(self) -> tuple[int, int]:
+        """Return interval bounds in half-sample units."""
+        return (
+            2 * self.active_start_samples + self.ramp_length_samples,
+            2 * (self.active_start_samples + self.active_length_samples)
+            - self.ramp_length_samples,
+        )
+
 
 class _TargetAnalysis(TypedDict):
     """Analysis payload for one protocol and terminal-measurement target."""
@@ -117,8 +129,18 @@ class _TargetAnalysis(TypedDict):
     error_per_cycle_err: float | None
 
 
+class _ErrorEstimate(TypedDict):
+    """Value and propagated uncertainty for one induced-error estimate."""
+
+    value: float
+    error: float
+
+
 _TrialData = dict[MCMRBProtocol, dict[str, NDArray[np.float64]]]
 _ProtocolResults = dict[MCMRBProtocol, dict[str, _TargetAnalysis]]
+_CompiledCliffordSequences = Mapping[str, _CompiledCliffordSequence]
+_CompiledAncillaSequences = Mapping[str, _CompiledAncillaSequence]
+_TargetErrorPayload = _ErrorEstimate | dict[str, _ErrorEstimate | None] | None
 
 
 def _validate_protocol(protocol: str) -> MCMRBProtocol:
@@ -175,17 +197,72 @@ def _validate_positive_real(value: object, *, name: str) -> float:
     return resolved
 
 
-def _resolve_qubit_pair(
+def _find_duplicates(values: Collection[str]) -> tuple[str, ...]:
+    """Return duplicate labels in first repeated-occurrence order."""
+    seen: set[str] = set()
+    duplicates: list[str] = []
+    for value in values:
+        if value in seen and value not in duplicates:
+            duplicates.append(value)
+        seen.add(value)
+    return tuple(duplicates)
+
+
+def _resolve_target_role(
     exp: Experiment,
-    control: str,
-    ancilla: str,
-) -> tuple[str, str]:
-    """Resolve and validate distinct control and ancilla qubit labels."""
-    control_qubit = exp.ctx.resolve_qubit_label(control)
-    ancilla_qubit = exp.ctx.resolve_qubit_label(ancilla)
-    if control_qubit == ancilla_qubit:
-        raise ValueError("`control` and `ancilla` must resolve to different qubits.")
-    return control_qubit, ancilla_qubit
+    targets: Collection[str] | str,
+    *,
+    name: str,
+) -> tuple[str, ...]:
+    """Resolve one nonempty, duplicate-free target role."""
+    labels = [targets] if isinstance(targets, str) else list(targets)
+    if not labels:
+        raise ValueError(f"`{name}` must contain at least one qubit.")
+    if any(not isinstance(label, str) for label in labels):
+        raise TypeError(f"`{name}` must contain only qubit-label strings.")
+
+    resolved = tuple(exp.ctx.resolve_qubit_label(label) for label in labels)
+    duplicates = _find_duplicates(resolved)
+    if duplicates:
+        raise ValueError(
+            f"`{name}` contains duplicate resolved qubit(s): {duplicates}."
+        )
+    return resolved
+
+
+def _resolve_target_groups(
+    exp: Experiment,
+    control: Collection[str] | str,
+    ancilla: Collection[str] | str,
+) -> tuple[tuple[str, ...], tuple[str, ...]]:
+    """Resolve and validate disjoint control and ancilla target groups."""
+    controls = _resolve_target_role(exp, control, name="control")
+    ancillas = _resolve_target_role(exp, ancilla, name="ancilla")
+    ancilla_set = set(ancillas)
+    overlap = tuple(target for target in controls if target in ancilla_set)
+    if overlap:
+        raise ValueError(
+            "`control` and `ancilla` must resolve to disjoint qubit groups; "
+            f"overlap: {overlap}."
+        )
+
+    all_targets = (*controls, *ancillas)
+    readout_labels = tuple(
+        exp.experiment_system.resolve_read_label(target) for target in all_targets
+    )
+    duplicate_readouts = _find_duplicates(readout_labels)
+    if duplicate_readouts:
+        raise ValueError(
+            "Selected qubits must resolve to distinct readout labels; "
+            f"duplicates: {duplicate_readouts}."
+        )
+    collisions = set(all_targets) & set(readout_labels)
+    if collisions:
+        raise ValueError(
+            "Control, ancilla, and readout labels must be distinct; "
+            f"collisions: {tuple(sorted(collisions))}."
+        )
+    return controls, ancillas
 
 
 def _validate_waveform(
@@ -224,6 +301,75 @@ def _validate_waveform(
             )
 
 
+def _resolve_waveforms(
+    exp: Experiment,
+    *,
+    targets: tuple[str, ...],
+    override: _WaveformOverride,
+    default_factory: Callable[[str], Waveform],
+    sampling_period: float,
+    name: str,
+) -> dict[str, Waveform]:
+    """Resolve a scalar or target-keyed waveform override for one role."""
+    overrides = _normalize_waveform_overrides(
+        exp,
+        targets=targets,
+        override=override,
+        name=name,
+    )
+    resolved: dict[str, Waveform] = {}
+    for target in targets:
+        waveform = overrides.get(target)
+        if waveform is None:
+            waveform = default_factory(target)
+        _validate_waveform(
+            waveform,
+            expected_sampling_period=sampling_period,
+            name=f"{name}[{target}]",
+        )
+        resolved[target] = waveform
+    return resolved
+
+
+def _normalize_waveform_overrides(
+    exp: Experiment,
+    *,
+    targets: tuple[str, ...],
+    override: _WaveformOverride,
+    name: str,
+) -> dict[str, Waveform]:
+    """Normalize waveform overrides to resolved target labels."""
+    if override is None:
+        return {}
+    if isinstance(override, Waveform):
+        if len(targets) != 1:
+            raise ValueError(
+                f"`{name}` must be a target-keyed mapping when multiple "
+                "qubits are selected."
+            )
+        return {targets[0]: override}
+    if not isinstance(override, Mapping):
+        raise TypeError(f"`{name}` must be a waveform or target-keyed mapping.")
+
+    overrides: dict[str, Waveform] = {}
+    for label, waveform in override.items():
+        if not isinstance(label, str):
+            raise TypeError(f"`{name}` mapping keys must be qubit-label strings.")
+        if not isinstance(waveform, Waveform):
+            raise TypeError(f"`{name}` mapping values must be waveforms.")
+        target = exp.ctx.resolve_qubit_label(label)
+        if target not in targets:
+            raise ValueError(
+                f"`{name}` contains an override for unselected target {target!r}."
+            )
+        if target in overrides:
+            raise ValueError(
+                f"`{name}` contains duplicate overrides for target {target!r}."
+            )
+        overrides[target] = waveform
+    return overrides
+
+
 def _blank(duration: float, sampling_period: float) -> Blank:
     """Build a blank pulse on the active sampling grid."""
     return Blank(duration=duration, sampling_period=sampling_period)
@@ -252,7 +398,7 @@ def _infer_readout_timing(measurement: Waveform) -> _ReadoutTiming:
         flat_tops = []
     if len(flat_tops) > 1:
         raise ValueError(
-            "Echo timing requires a measurement waveform with at most one "
+            "Readout timing inference requires a waveform with at most one "
             "FlatTop pulse."
         )
 
@@ -285,17 +431,19 @@ def _infer_readout_timing(measurement: Waveform) -> _ReadoutTiming:
 def _measurement_control_block(
     *,
     measurement: Waveform,
+    slot_duration: float,
     sampling_period: float,
     echo_x180: Waveform | None,
 ) -> Waveform:
     """Build an idle or active-readout-aligned X-X echo block."""
     if echo_x180 is None:
-        return _blank(measurement.duration, sampling_period)
+        return _blank(slot_duration, sampling_period)
 
-    if measurement.length < 2 * echo_x180.length:
+    slot_length = round(slot_duration / sampling_period)
+    if slot_length < 2 * echo_x180.length:
         raise ValueError(
-            "The measurement duration must be at least twice the echo X180 "
-            "pulse duration."
+            "The measurement slot duration must be at least twice the echo "
+            "X180 pulse duration."
         )
     timing = _infer_readout_timing(measurement)
 
@@ -316,9 +464,7 @@ def _measurement_control_block(
     middle_quarters = (
         second_center_quarters - first_center_quarters - 4 * echo_x180.length
     )
-    trailing_quarters = (
-        4 * measurement.length - second_center_quarters - 2 * echo_x180.length
-    )
+    trailing_quarters = 4 * slot_length - second_center_quarters - 2 * echo_x180.length
     blank_quarters = (leading_quarters, middle_quarters, trailing_quarters)
     if any(samples < 0 for samples in blank_quarters):
         raise ValueError(
@@ -346,17 +492,41 @@ def _measurement_control_block(
     )
 
 
+def _validate_matching_readout_intervals(
+    measurements: Mapping[str, Waveform],
+) -> None:
+    """Require equal ramp-trimmed active intervals for multiple readouts."""
+    if len(measurements) == 1:
+        return
+    intervals_half_samples = {
+        target: _infer_readout_timing(measurement).ramp_trimmed_interval_half_samples
+        for target, measurement in measurements.items()
+    }
+    if len(set(intervals_half_samples.values())) != 1:
+        sampling_period = next(iter(measurements.values())).sampling_period
+        intervals_ns = {
+            target: tuple(
+                half_samples * sampling_period / 2.0 for half_samples in interval
+            )
+            for target, interval in intervals_half_samples.items()
+        }
+        raise ValueError(
+            "All ancilla ramp-trimmed active intervals must match; "
+            f"got {intervals_ns} ns."
+        )
+
+
 def _resolve_sequence_resources(
     exp: Experiment,
     *,
-    control: str,
-    ancilla: str,
+    controls: tuple[str, ...],
+    ancillas: tuple[str, ...],
     control_echo: bool,
     ancilla_mode: _AncillaMode,
-    x90: Waveform | None,
-    measurement_waveform: Waveform | None,
-    echo_x180: Waveform | None,
-    ancilla_x180: Waveform | None,
+    x90: _WaveformOverride,
+    measurement_waveform: _WaveformOverride,
+    echo_x180: _WaveformOverride,
+    ancilla_x180: _WaveformOverride,
 ) -> _SequenceResources:
     """Resolve and validate labels and waveforms used by every protocol."""
     sampling_period = float(exp.ctx.measurement.sampling_period)
@@ -364,56 +534,70 @@ def _resolve_sequence_resources(
         raise ValueError("The experiment sampling period must be positive and finite.")
     set_sampling_period(sampling_period)
 
-    x90_waveform = x90 if x90 is not None else exp.pulse.x90(control)
-    measurement = (
-        measurement_waveform
-        if measurement_waveform is not None
-        else exp.pulse.readout(ancilla)
-    )
-    _validate_waveform(
-        x90_waveform,
-        expected_sampling_period=sampling_period,
+    x90s = _resolve_waveforms(
+        exp,
+        targets=controls,
+        override=x90,
+        default_factory=exp.pulse.x90,
+        sampling_period=sampling_period,
         name="x90",
     )
-    _validate_waveform(
-        measurement,
-        expected_sampling_period=sampling_period,
+    measurements = _resolve_waveforms(
+        exp,
+        targets=ancillas,
+        override=measurement_waveform,
+        default_factory=exp.pulse.readout,
+        sampling_period=sampling_period,
         name="measurement_waveform",
     )
+    _validate_matching_readout_intervals(measurements)
+    reference_measurement = next(iter(measurements.values()))
+    measurement_slot_duration = max(
+        measurement.duration for measurement in measurements.values()
+    )
 
-    resolved_echo: Waveform | None = None
+    echo_x180s: dict[str, Waveform] = {}
     if control_echo:
-        resolved_echo = echo_x180 if echo_x180 is not None else exp.pulse.x180(control)
-        _validate_waveform(
-            resolved_echo,
-            expected_sampling_period=sampling_period,
+        echo_x180s = _resolve_waveforms(
+            exp,
+            targets=controls,
+            override=echo_x180,
+            default_factory=exp.pulse.x180,
+            sampling_period=sampling_period,
             name="echo_x180",
         )
 
-    resolved_ancilla_x180: Waveform | None = None
+    ancilla_x180s: dict[str, Waveform] = {}
     if ancilla_mode == _RANDOMIZED_ANCILLA:
-        resolved_ancilla_x180 = (
-            ancilla_x180 if ancilla_x180 is not None else exp.pulse.x180(ancilla)
-        )
-        _validate_waveform(
-            resolved_ancilla_x180,
-            expected_sampling_period=sampling_period,
+        ancilla_x180s = _resolve_waveforms(
+            exp,
+            targets=ancillas,
+            override=ancilla_x180,
+            default_factory=exp.pulse.x180,
+            sampling_period=sampling_period,
             name="ancilla_x180",
         )
 
     return _SequenceResources(
-        control=control,
-        ancilla=ancilla,
-        readout_label=exp.experiment_system.resolve_read_label(ancilla),
+        controls=controls,
+        ancillas=ancillas,
+        readout_labels={
+            target: exp.experiment_system.resolve_read_label(target)
+            for target in ancillas
+        },
         sampling_period=sampling_period,
-        x90=x90_waveform,
-        measurement=measurement,
-        control_during_measurement=_measurement_control_block(
-            measurement=measurement,
-            sampling_period=sampling_period,
-            echo_x180=resolved_echo,
-        ),
-        ancilla_x180=resolved_ancilla_x180,
+        x90s=x90s,
+        measurements=measurements,
+        controls_during_measurement={
+            target: _measurement_control_block(
+                measurement=reference_measurement,
+                slot_duration=measurement_slot_duration,
+                sampling_period=sampling_period,
+                echo_x180=echo_x180s.get(target),
+            )
+            for target in controls
+        },
+        ancilla_x180s=ancilla_x180s,
     )
 
 
@@ -451,115 +635,212 @@ def _generate_clifford_sequence(
     )
 
 
-def _compile_ancilla_sequence(
+def _derive_seed(seed: int | None, *, spawn_key: tuple[int, ...]) -> int:
+    """Derive one uint32 child seed from a trial seed and stream key."""
+    seed_sequence = np.random.SeedSequence(seed, spawn_key=spawn_key)
+    return int(seed_sequence.generate_state(1, dtype=np.uint32)[0])
+
+
+def _compile_clifford_sequences(
+    exp: Experiment,
     resources: _SequenceResources,
     *,
     n_cliffords: int,
     seed: int | None,
-) -> _CompiledAncillaSequence | None:
-    """Compile reproducible ancilla I/X choices when randomized mode is active."""
-    x180 = resources.ancilla_x180
-    if x180 is None:
-        return None
+) -> dict[str, _CompiledCliffordSequence]:
+    """Compile an independent randomized Clifford stream for every control."""
+    compiled: dict[str, _CompiledCliffordSequence] = {}
+    for index, control in enumerate(resources.controls):
+        control_seed = (
+            seed
+            if len(resources.controls) == 1
+            else _derive_seed(
+                seed,
+                spawn_key=(*_CONTROL_RANDOMIZATION_SPAWN_KEY, index),
+            )
+        )
+        compiled[control] = _generate_clifford_sequence(
+            exp,
+            n_cliffords=n_cliffords,
+            seed=control_seed,
+            x90=resources.x90s[control],
+        )
+    return compiled
 
-    seed_sequence = np.random.SeedSequence(
-        seed,
-        spawn_key=_ANCILLA_RANDOMIZATION_SPAWN_KEY,
-    )
-    values = np.random.default_rng(seed_sequence).integers(
-        0,
-        2,
-        size=n_cliffords,
-        dtype=np.int8,
-    )
-    identity = _blank(x180.duration, resources.sampling_period)
-    operations = tuple(x180 if value else identity for value in values)
-    recovery = x180 if np.count_nonzero(values) % 2 else identity
-    return _CompiledAncillaSequence(operations=operations, recovery=recovery)
+
+def _compile_ancilla_sequences(
+    resources: _SequenceResources,
+    *,
+    n_cliffords: int,
+    seed: int | None,
+) -> dict[str, _CompiledAncillaSequence]:
+    """Compile an independent reproducible I/X stream for every ancilla."""
+    if not resources.ancilla_x180s:
+        return {}
+
+    compiled: dict[str, _CompiledAncillaSequence] = {}
+    for index, ancilla in enumerate(resources.ancillas):
+        x180 = resources.ancilla_x180s[ancilla]
+        spawn_key = (
+            _ANCILLA_RANDOMIZATION_SPAWN_KEY
+            if len(resources.ancillas) == 1
+            else (*_ANCILLA_RANDOMIZATION_SPAWN_KEY, index)
+        )
+        values = np.random.default_rng(
+            np.random.SeedSequence(seed, spawn_key=spawn_key)
+        ).integers(
+            0,
+            2,
+            size=n_cliffords,
+            dtype=np.int8,
+        )
+        identity = _blank(x180.duration, resources.sampling_period)
+        operations = tuple(x180 if value else identity for value in values)
+        recovery = x180 if np.count_nonzero(values) % 2 else identity
+        compiled[ancilla] = _CompiledAncillaSequence(
+            operations=operations,
+            recovery=recovery,
+        )
+    return compiled
+
+
+def _duration_matched_operation(
+    operation: Waveform,
+    *,
+    replace_with_blank: bool,
+    sampling_period: float,
+) -> Waveform:
+    """Return a waveform or a duration-matched blank."""
+    if not replace_with_blank:
+        return operation
+    return _blank(operation.duration, sampling_period)
+
+
+def _add_parallel_layer(
+    schedule: PulseSchedule,
+    operations: Mapping[str, Waveform],
+) -> None:
+    """Add simultaneous channel operations and synchronize their endpoints."""
+    for label, operation in operations.items():
+        schedule.add(label, operation)
+    schedule.barrier()
+
+
+def _validate_compiled_sequence_lengths(
+    resources: _SequenceResources,
+    clifford_sequences: _CompiledCliffordSequences,
+    ancilla_sequences: _CompiledAncillaSequences,
+) -> int:
+    """Return the common cycle count after validating compiled sequences."""
+    n_cycles = len(clifford_sequences[resources.controls[0]].cliffords)
+    if any(
+        len(sequence.cliffords) != n_cycles for sequence in clifford_sequences.values()
+    ):
+        raise RuntimeError("All control Clifford sequences must have equal length.")
+    if any(
+        len(sequence.operations) != n_cycles for sequence in ancilla_sequences.values()
+    ):
+        raise RuntimeError(
+            "Every ancilla sequence length must match the Clifford sequence."
+        )
+    return n_cycles
 
 
 def _build_protocol_schedule(
     resources: _SequenceResources,
-    clifford_sequence: _CompiledCliffordSequence,
+    clifford_sequences: _CompiledCliffordSequences,
     *,
     protocol: MCMRBProtocol,
-    ancilla_sequence: _CompiledAncillaSequence | None = None,
+    ancilla_sequences: _CompiledAncillaSequences,
 ) -> PulseSchedule:
     """Build one protocol schedule from shared resources and Cliffords."""
-    schedule_labels = [resources.control, resources.readout_label]
-    if ancilla_sequence is not None:
-        schedule_labels.insert(1, resources.ancilla)
-        if len(ancilla_sequence.operations) != len(clifford_sequence.cliffords):
-            raise RuntimeError(
-                "The ancilla sequence length must match the Clifford sequence."
-            )
+    schedule_labels = [*resources.controls]
+    if ancilla_sequences:
+        schedule_labels.extend(resources.ancillas)
+    schedule_labels.extend(
+        resources.readout_labels[ancilla] for ancilla in resources.ancillas
+    )
+
+    n_cycles = _validate_compiled_sequence_lengths(
+        resources,
+        clifford_sequences,
+        ancilla_sequences,
+    )
+    replace_control_with_blank = protocol in _CONTROL_DELAY_PROTOCOLS
+    replace_readout_with_blank = protocol in _READOUT_DELAY_PROTOCOLS
 
     with PulseSchedule(schedule_labels) as schedule:
-        for cycle_index, clifford in enumerate(clifford_sequence.cliffords):
-            control_operation: Waveform
-            if protocol in _CONTROL_DELAY_PROTOCOLS:
-                control_operation = _blank(
-                    clifford.duration,
-                    resources.sampling_period,
-                )
-            else:
-                control_operation = clifford
-            schedule.add(resources.control, control_operation)
-            schedule.barrier()
-
-            if ancilla_sequence is not None:
-                schedule.add(
-                    resources.ancilla,
-                    ancilla_sequence.operations[cycle_index],
-                )
-                schedule.barrier()
-
-            measurement_operation: Waveform
-            if protocol in _READOUT_DELAY_PROTOCOLS:
-                measurement_operation = _blank(
-                    resources.measurement.duration,
-                    resources.sampling_period,
-                )
-            else:
-                measurement_operation = resources.measurement
-            schedule.add(resources.readout_label, measurement_operation)
-            schedule.add(
-                resources.control,
-                resources.control_during_measurement,
+        for cycle_index in range(n_cycles):
+            _add_parallel_layer(
+                schedule,
+                {
+                    control: _duration_matched_operation(
+                        clifford_sequences[control].cliffords[cycle_index],
+                        replace_with_blank=replace_control_with_blank,
+                        sampling_period=resources.sampling_period,
+                    )
+                    for control in resources.controls
+                },
             )
-            schedule.barrier()
 
-        if ancilla_sequence is not None:
-            schedule.add(resources.ancilla, ancilla_sequence.recovery)
-            schedule.barrier()
+            if ancilla_sequences:
+                _add_parallel_layer(
+                    schedule,
+                    {
+                        ancilla: ancilla_sequences[ancilla].operations[cycle_index]
+                        for ancilla in resources.ancillas
+                    },
+                )
 
-        final_control_operation: Waveform
-        if protocol in _CONTROL_DELAY_PROTOCOLS:
-            final_control_operation = _blank(
-                clifford_sequence.inverse.duration,
-                resources.sampling_period,
+            measurement_layer = {
+                resources.readout_labels[ancilla]: _duration_matched_operation(
+                    resources.measurements[ancilla],
+                    replace_with_blank=replace_readout_with_blank,
+                    sampling_period=resources.sampling_period,
+                )
+                for ancilla in resources.ancillas
+            }
+            measurement_layer.update(resources.controls_during_measurement)
+            _add_parallel_layer(schedule, measurement_layer)
+
+        if ancilla_sequences:
+            _add_parallel_layer(
+                schedule,
+                {
+                    ancilla: ancilla_sequences[ancilla].recovery
+                    for ancilla in resources.ancillas
+                },
             )
-        else:
-            final_control_operation = clifford_sequence.inverse
-        schedule.add(resources.control, final_control_operation)
+
+        _add_parallel_layer(
+            schedule,
+            {
+                control: _duration_matched_operation(
+                    clifford_sequences[control].inverse,
+                    replace_with_blank=replace_control_with_blank,
+                    sampling_period=resources.sampling_period,
+                )
+                for control in resources.controls
+            },
+        )
 
     return schedule
 
 
 def mcm_rb_sequence(
     exp: Experiment,
-    control: str,
-    ancilla: str,
+    control: Collection[str] | str,
+    ancilla: Collection[str] | str,
     *,
     protocol: MCMRBProtocol,
     n_cliffords: int,
     seed: int | None = None,
     control_echo: bool = False,
     ancilla_mode: Literal["standard", "randomized"] = "standard",
-    x90: Waveform | None = None,
-    measurement_waveform: Waveform | None = None,
-    echo_x180: Waveform | None = None,
-    ancilla_x180: Waveform | None = None,
+    x90: Waveform | Mapping[str, Waveform] | None = None,
+    measurement_waveform: Waveform | Mapping[str, Waveform] | None = None,
+    echo_x180: Waveform | Mapping[str, Waveform] | None = None,
+    ancilla_x180: Waveform | Mapping[str, Waveform] | None = None,
 ) -> PulseSchedule:
     """
     Build one MCM-RB, delay-RB, MCM-repetition, or delay-repetition schedule.
@@ -569,13 +850,14 @@ def mcm_rb_sequence(
     exp
         Experiment instance that provides pulse and Clifford services.
     control
-        Control or spectator qubit. RB protocols apply randomized Cliffords
-        and their inverse; repetition protocols replace them with
-        duration-matched delays.
+        One control/spectator label or an ordered collection of labels. RB
+        protocols apply independently randomized Cliffords and inverses to
+        the controls; repetition protocols replace them with duration-matched
+        delays.
     ancilla
-        Ancilla or readout-target qubit. MCM protocols apply its intermediate
-        readout; delay protocols replace that readout with a duration-matched
-        delay.
+        One ancilla/readout-target label or an ordered collection of labels.
+        MCM protocols read all ancillas simultaneously; delay protocols
+        replace every readout with a duration-matched delay.
     protocol
         Sequence variant: `"mcm-rb"`, `"delay-rb"`, `"mcm-rep"`, or
         `"delay-rep"`. Repetition protocols replace the control Cliffords with
@@ -584,32 +866,42 @@ def mcm_rb_sequence(
     n_cliffords
         Number of protocol cycles. Must be nonnegative.
     seed
-        Nonnegative seed for the Clifford sequence and the independent
-        randomized-ancilla I/X180 stream. Repetition protocols use the
-        generated Clifford durations only.
+        Nonnegative root seed. Multiple controls receive independent derived
+        Clifford streams, and multiple randomized ancillas receive independent
+        derived I/X180 streams. Repetition protocols use the generated
+        Clifford durations only.
     control_echo
-        Whether to apply an X-X echo to the control during every measurement
+        Whether to apply an X-X echo to every control during every measurement
         or reference-delay window. The X180 centers are placed at the quarter
-        and three-quarter points of the active readout interval after trimming
-        half a ramp duration from each end. Repetition protocols therefore
-        contain control pulses during these windows when this option is `True`.
+        and three-quarter points of the common ramp-trimmed active readout
+        interval. Repetition protocols therefore contain control pulses during
+        these windows when this option is `True`.
     ancilla_mode
         Ancilla sequence mode. `"standard"` preserves the original protocol.
         `"randomized"` inserts a seeded I/X180 before every measurement or
         reference delay and applies a final parity recovery.
     x90
-        Optional control X90 waveform override.
+        Optional control X90 override. Pass a waveform for one control or a
+        target-keyed mapping for multiple controls. Omitted mapping entries use
+        calibrated defaults.
     measurement_waveform
-        Optional ancilla readout waveform override. With `control_echo=True`,
-        the active interval is inferred from its nonzero samples. At most one
-        FlatTop pulse may be present; other pulse shapes are treated as having
-        zero ramp duration.
+        Optional ancilla readout override. Pass a waveform for one ancilla or a
+        target-keyed mapping for multiple ancillas. Omitted mapping entries use
+        calibrated defaults. Multiple ancillas must have identical
+        ramp-trimmed active intervals, although their total slot durations may
+        differ. Active intervals are inferred from nonzero samples; at most one
+        FlatTop pulse may be present in each waveform, and other shapes are
+        treated as having zero ramp duration.
     echo_x180
-        Optional control X180 waveform override used by the X-X echo. Ignored
-        when `control_echo=False`.
+        Optional control X180 override used by the X-X echo. Pass a waveform
+        for one control or a target-keyed mapping for multiple controls.
+        Omitted mapping entries use calibrated defaults. Ignored when
+        `control_echo=False`.
     ancilla_x180
-        Optional ancilla X180 waveform override used for randomized I/X180
-        operations and parity recovery. Ignored in standard mode.
+        Optional ancilla X180 override used for randomized I/X180 operations
+        and parity recovery. Pass a waveform for one ancilla or a target-keyed
+        mapping for multiple ancillas. Omitted mapping entries use calibrated
+        defaults. Ignored in standard mode.
 
     Returns
     -------
@@ -619,10 +911,12 @@ def mcm_rb_sequence(
     Raises
     ------
     TypeError
-        Raised when a Clifford count or seed has an invalid type.
+        Raised when a target, Clifford count, seed, or waveform override has
+        an invalid type.
     ValueError
-        Raised for invalid targets, protocol or ancilla mode names, lengths,
-        waveform timing, or echo timing.
+        Raised for invalid or overlapping target groups, protocol or ancilla
+        mode names, waveform mappings, mismatched ancilla active intervals, or
+        echo timing.
 
     Notes
     -----
@@ -631,10 +925,14 @@ def mcm_rb_sequence(
     equal total duration when built with the same cycle count, seed, ancilla
     mode, and echo options.
 
-    In randomized mode, the seed determines both the Clifford sequence and a
-    separate ancilla I/X180 random stream. The final ancilla recovery is X180
-    exactly when the programmed sequence has odd parity. One static I/X180
-    sequence is encoded in the returned schedule.
+    In randomized mode, the final recovery on each ancilla is X180 exactly
+    when that ancilla's programmed sequence has odd parity. One static I/X180
+    sequence per ancilla is encoded in the returned schedule. Independent
+    random streams are assigned in resolved input order.
+
+    When multiple ancillas are selected, every control is exposed to their
+    simultaneous combined readout. The schedule does not attribute a measured
+    control error to an individual ancilla.
 
     Construction synchronizes the global pulse-library sampling period with
     `exp.ctx.measurement.sampling_period`.
@@ -648,11 +946,11 @@ def mcm_rb_sequence(
     resolved_seed = (
         None if seed is None else _validate_nonnegative_integer(seed, name="seed")
     )
-    control_qubit, ancilla_qubit = _resolve_qubit_pair(exp, control, ancilla)
+    control_qubits, ancilla_qubits = _resolve_target_groups(exp, control, ancilla)
     resources = _resolve_sequence_resources(
         exp,
-        control=control_qubit,
-        ancilla=ancilla_qubit,
+        controls=control_qubits,
+        ancillas=ancilla_qubits,
         control_echo=control_echo,
         ancilla_mode=resolved_ancilla_mode,
         x90=x90,
@@ -660,22 +958,22 @@ def mcm_rb_sequence(
         echo_x180=echo_x180,
         ancilla_x180=ancilla_x180,
     )
-    clifford_sequence = _generate_clifford_sequence(
+    clifford_sequences = _compile_clifford_sequences(
         exp,
+        resources,
         n_cliffords=resolved_n_cliffords,
         seed=resolved_seed,
-        x90=resources.x90,
     )
-    ancilla_sequence = _compile_ancilla_sequence(
+    ancilla_sequences = _compile_ancilla_sequences(
         resources,
         n_cliffords=resolved_n_cliffords,
         seed=resolved_seed,
     )
     return _build_protocol_schedule(
         resources,
-        clifford_sequence,
+        clifford_sequences,
         protocol=resolved_protocol,
-        ancilla_sequence=ancilla_sequence,
+        ancilla_sequences=ancilla_sequences,
     )
 
 
@@ -735,9 +1033,8 @@ def _resolve_protocols(
     candidates = [protocols] if isinstance(protocols, str) else list(protocols)
     if not candidates:
         raise ValueError("`protocols` must not be empty.")
-    resolved = cast(
-        tuple[MCMRBProtocol, ...],
-        tuple(_validate_protocol(protocol) for protocol in candidates),
+    resolved: tuple[MCMRBProtocol, ...] = tuple(
+        _validate_protocol(protocol) for protocol in candidates
     )
     if len(resolved) != len(set(resolved)):
         raise ValueError("`protocols` must not contain duplicate values.")
@@ -830,13 +1127,13 @@ def _acquire_trials(
     try:
         for n_index, n_cliffords in enumerate(n_cliffords_range):
             for trial_index, seed in enumerate(seeds):
-                clifford_sequence = _generate_clifford_sequence(
+                clifford_sequences = _compile_clifford_sequences(
                     exp,
+                    resources,
                     n_cliffords=int(n_cliffords),
                     seed=int(seed),
-                    x90=resources.x90,
                 )
-                ancilla_sequence = _compile_ancilla_sequence(
+                ancilla_sequences = _compile_ancilla_sequences(
                     resources,
                     n_cliffords=int(n_cliffords),
                     seed=int(seed),
@@ -844,9 +1141,9 @@ def _acquire_trials(
                 for protocol in protocols:
                     sequence = _build_protocol_schedule(
                         resources,
-                        clifford_sequence,
+                        clifford_sequences,
                         protocol=protocol,
-                        ancilla_sequence=ancilla_sequence,
+                        ancilla_sequences=ancilla_sequences,
                     )
                     measure_result = exp.measurement_service.execute(
                         sequence,
@@ -924,7 +1221,7 @@ def _fit_protocol_target(
 def _analyze_trials(
     trials: _TrialData,
     *,
-    targets: tuple[str, str],
+    targets: tuple[str, ...],
     n_cliffords: NDArray[np.int64],
     plot: bool,
     save_image: bool,
@@ -965,13 +1262,8 @@ def _measurement_induced_error(
     target: str,
     measurement_protocol: MCMRBProtocol,
     reference_protocol: MCMRBProtocol,
-) -> dict[str, float] | None:
+) -> _ErrorEstimate | None:
     """Calculate one target's induced error from a matched protocol pair."""
-    if (
-        measurement_protocol not in protocol_results
-        or reference_protocol not in protocol_results
-    ):
-        return None
     measurement_result = protocol_results[measurement_protocol][target]
     reference_result = protocol_results[reference_protocol][target]
     p_measurement = measurement_result["decay_parameter"]
@@ -995,10 +1287,51 @@ def _measurement_induced_error(
     return {"value": float(value), "error": float(error)}
 
 
+def _measurement_induced_errors(
+    protocol_results: _ProtocolResults,
+    *,
+    targets: tuple[str, ...],
+    measurement_protocol: MCMRBProtocol,
+    reference_protocol: MCMRBProtocol,
+) -> _TargetErrorPayload:
+    """Return one estimate directly or multiple estimates keyed by target."""
+    if (
+        measurement_protocol not in protocol_results
+        or reference_protocol not in protocol_results
+    ):
+        return None
+    estimates = {
+        target: _measurement_induced_error(
+            protocol_results,
+            target=target,
+            measurement_protocol=measurement_protocol,
+            reference_protocol=reference_protocol,
+        )
+        for target in targets
+    }
+    if len(targets) == 1:
+        return estimates[targets[0]]
+    return estimates
+
+
+def _waveform_duration_payload(
+    waveforms: Mapping[str, Waveform],
+    *,
+    targets: tuple[str, ...],
+) -> float | dict[str, float] | None:
+    """Return scalar or target-keyed waveform durations for result metadata."""
+    if not waveforms:
+        return None
+    durations = {target: waveforms[target].duration for target in targets}
+    if len(targets) == 1:
+        return durations[targets[0]]
+    return durations
+
+
 def mcm_randomized_benchmarking(
     exp: Experiment,
-    control: str,
-    ancilla: str,
+    control: Collection[str] | str,
+    ancilla: Collection[str] | str,
     *,
     n_cliffords_range: ArrayLike | None = None,
     n_trials: int | None = None,
@@ -1006,10 +1339,10 @@ def mcm_randomized_benchmarking(
     protocols: Collection[MCMRBProtocol] | MCMRBProtocol | None = None,
     control_echo: bool = False,
     ancilla_mode: Literal["standard", "randomized"] = "standard",
-    x90: Waveform | None = None,
-    measurement_waveform: Waveform | None = None,
-    echo_x180: Waveform | None = None,
-    ancilla_x180: Waveform | None = None,
+    x90: Waveform | Mapping[str, Waveform] | None = None,
+    measurement_waveform: Waveform | Mapping[str, Waveform] | None = None,
+    echo_x180: Waveform | Mapping[str, Waveform] | None = None,
+    ancilla_x180: Waveform | Mapping[str, Waveform] | None = None,
     n_shots: int | None = None,
     shot_interval: float | None = None,
     time_integration: bool = True,
@@ -1026,12 +1359,13 @@ def mcm_randomized_benchmarking(
     exp
         Experiment instance used to generate and execute the schedules.
     control
-        Control or spectator qubit. RB protocols apply randomized Cliffords;
+        One control/spectator label or an ordered collection of labels. RB
+        protocols apply independently randomized Cliffords to all controls;
         repetition protocols apply duration-matched delays instead.
     ancilla
-        Ancilla or readout-target qubit. MCM protocols apply its intermediate
-        readout; delay protocols replace that readout with a duration-matched
-        delay.
+        One ancilla/readout-target label or an ordered collection of labels.
+        MCM protocols read all ancillas simultaneously; delay protocols
+        replace every readout with a duration-matched delay.
     n_cliffords_range
         Strictly increasing nonnegative cycle counts. Defaults to 0 followed
         by 14 geometrically spaced values from 1 through 150.
@@ -1045,32 +1379,40 @@ def mcm_randomized_benchmarking(
         `"mcm-rep"` in standard mode and to the matched `"mcm-rb"` and
         `"delay-rb"` pair in randomized mode. `"mcm-rep"` and `"delay-rep"`
         are opt-in in randomized mode; `"delay-rep"` is opt-in in both modes.
-        The same generated Clifford and ancilla I/X180 sequences are shared
-        across protocols for each sequence length and seed.
+        The same per-target Clifford and ancilla I/X180 sequences are shared
+        across protocols for each sequence length and root seed.
     control_echo
-        Whether to insert an X-X echo on the control during every measurement
+        Whether to insert an X-X echo on every control during each measurement
         or duration-matched delay window. The X180 centers are placed at the
-        quarter and three-quarter points of the active readout interval after
-        trimming half a ramp duration from each end. Repetition protocols omit
-        randomized Cliffords but are not strictly idle when echo is enabled.
+        quarter and three-quarter points of the common ramp-trimmed active
+        readout interval. Repetition protocols omit randomized Cliffords but
+        are not strictly idle when echo is enabled.
     ancilla_mode
         Ancilla sequence mode. `"standard"` preserves the original suite.
         `"randomized"` inserts a seeded I/X180 before every measurement or
         reference delay, followed by an X180 for odd parity or a
         duration-matched blank for even parity.
     x90
-        Optional control X90 waveform override.
+        Optional control X90 override. Use a waveform for one control or a
+        target-keyed mapping for multiple controls. Omitted mapping entries use
+        calibrated defaults.
     measurement_waveform
-        Optional ancilla readout waveform override. With `control_echo=True`,
-        the active interval is inferred from its nonzero samples. At most one
-        FlatTop pulse may be present; other pulse shapes are treated as having
-        zero ramp duration.
+        Optional ancilla readout override. Use a waveform for one ancilla or a
+        target-keyed mapping for multiple ancillas. Multiple ancillas must have
+        identical ramp-trimmed active intervals, although their total slot
+        durations may differ. Omitted mapping entries use calibrated defaults.
+        Active intervals are inferred from nonzero samples; at most one FlatTop
+        pulse may be present in each waveform, and other shapes have zero
+        inferred ramp duration.
     echo_x180
-        Optional control X180 waveform override for echoed measurement blocks.
-        Ignored when `control_echo=False`.
+        Optional control X180 override for echoed measurement blocks. Use a
+        waveform for one control or a target-keyed mapping for multiple
+        controls. Omitted mapping entries use calibrated defaults. Ignored when
+        `control_echo=False`.
     ancilla_x180
-        Optional ancilla X180 waveform override used by randomized mode.
-        Ignored in standard mode.
+        Optional ancilla X180 override used by randomized mode. Use a waveform
+        for one ancilla or a target-keyed mapping for multiple ancillas. Omitted
+        mapping entries use calibrated defaults. Ignored in standard mode.
     n_shots
         Number of shots per schedule. Defaults to the experiment default.
     shot_interval
@@ -1099,21 +1441,26 @@ def mcm_randomized_benchmarking(
         control-delay ancilla estimates are stored as
         `measurement_induced_ancilla_population_error` and
         `measurement_induced_ancilla_population_error_with_idle_control`.
+        Each induced-error field contains one estimate for a single target, a
+        target-keyed mapping when that role contains multiple targets, or
+        `None` when its matched protocol pair was not run.
 
     Raises
     ------
     TypeError
-        Raised when a sweep value, seed, trial count, or shot count has an
-        invalid type.
+        Raised when a target, sweep value, seed, count, timing value, or
+        waveform override has an invalid type.
     ValueError
-        Raised when targets, sweep values, seeds, protocols, ancilla mode, or
-        pulse timing are invalid.
+        Raised when target groups, sweep values, seeds, protocols, ancilla
+        mode, waveform mappings, active readout intervals, or pulse timing are
+        invalid.
 
     Notes
     -----
-    Intermediate MCM outcomes are intentionally discarded. Only the terminal
-    capture for the control and ancilla is normalized and fitted. A matched
-    measurement/reference pair reports `(1 - p_measurement / p_reference) / 2`.
+    Intermediate MCM outcomes are intentionally discarded. Only terminal
+    captures are normalized and fitted independently for each control and
+    ancilla. A matched measurement/reference pair reports
+    `(1 - p_measurement / p_reference) / 2`.
     MCM-RB and delay-RB form the Clifford-driven pair. In randomized mode,
     MCM-repetition and delay-repetition form the control-delay pair.
     MCM-repetition without delay-repetition does not produce a ratio-based
@@ -1136,9 +1483,15 @@ def mcm_randomized_benchmarking(
     parameters as independent even though matched random sequences can
     correlate them.
 
-    The ancilla I/X180 choices are generated once per sequence length and
-    trial seed, then reused for every shot of that schedule. Randomization is
-    averaged across trials rather than varied shot by shot.
+    Independent control and ancilla random streams are assigned in resolved
+    input order. Ancilla I/X180 choices are generated once per sequence length
+    and trial root seed, then reused for every shot of that schedule.
+    Randomization is averaged across trials rather than varied shot by shot.
+
+    With multiple ancillas, the reported control error characterizes their
+    simultaneous combined readout and is not an attribution to any individual
+    ancilla. Per-target fits are marginal analyses of averaged terminal IQ;
+    they do not quantify correlated multi-qubit errors.
 
     The experiment synchronizes the global pulse-library sampling period with
     `exp.ctx.measurement.sampling_period` before constructing schedules.
@@ -1166,12 +1519,12 @@ def mcm_randomized_benchmarking(
     resolved_save_image = False if save_image is None else save_image
     resolved_xaxis_type = _validate_xaxis_type(xaxis_type)
 
-    control_qubit, ancilla_qubit = _resolve_qubit_pair(exp, control, ancilla)
-    exp.pulse.validate_rabi_params([control_qubit, ancilla_qubit])
+    control_qubits, ancilla_qubits = _resolve_target_groups(exp, control, ancilla)
+    exp.pulse.validate_rabi_params([*control_qubits, *ancilla_qubits])
     resources = _resolve_sequence_resources(
         exp,
-        control=control_qubit,
-        ancilla=ancilla_qubit,
+        controls=control_qubits,
+        ancillas=ancilla_qubits,
         control_echo=control_echo,
         ancilla_mode=resolved_ancilla_mode,
         x90=x90,
@@ -1204,16 +1557,16 @@ def mcm_randomized_benchmarking(
             "n_cliffords": resolved_n_cliffords,
             "seeds": resolved_seeds,
             "protocols": protocol_results,
-            "measurement_induced_control_error": _measurement_induced_error(
+            "measurement_induced_control_error": _measurement_induced_errors(
                 protocol_results,
-                target=control_qubit,
+                targets=control_qubits,
                 measurement_protocol=_MCM_RB,
                 reference_protocol=_DELAY_RB,
             ),
             "measurement_induced_ancilla_population_error": (
-                _measurement_induced_error(
+                _measurement_induced_errors(
                     protocol_results,
-                    target=ancilla_qubit,
+                    targets=ancilla_qubits,
                     measurement_protocol=_MCM_RB,
                     reference_protocol=_DELAY_RB,
                 )
@@ -1221,9 +1574,9 @@ def mcm_randomized_benchmarking(
                 else None
             ),
             "measurement_induced_ancilla_population_error_with_idle_control": (
-                _measurement_induced_error(
+                _measurement_induced_errors(
                     protocol_results,
-                    target=ancilla_qubit,
+                    targets=ancilla_qubits,
                     measurement_protocol=_MCM_REP,
                     reference_protocol=_DELAY_REP,
                 )
@@ -1231,8 +1584,10 @@ def mcm_randomized_benchmarking(
                 else None
             ),
             "metadata": {
-                "control": control_qubit,
-                "ancilla": ancilla_qubit,
+                "control": control_qubits[0] if len(control_qubits) == 1 else None,
+                "ancilla": ancilla_qubits[0] if len(ancilla_qubits) == 1 else None,
+                "controls": control_qubits,
+                "ancillas": ancilla_qubits,
                 "protocols": resolved_protocols,
                 "control_echo": control_echo,
                 "ancilla_mode": resolved_ancilla_mode,
@@ -1240,11 +1595,13 @@ def mcm_randomized_benchmarking(
                 "n_shots": resolved_n_shots,
                 "shot_interval": resolved_shot_interval,
                 "time_integration": time_integration,
-                "measurement_duration": resources.measurement.duration,
-                "ancilla_x180_duration": (
-                    resources.ancilla_x180.duration
-                    if resources.ancilla_x180 is not None
-                    else None
+                "measurement_duration": _waveform_duration_payload(
+                    resources.measurements,
+                    targets=ancilla_qubits,
+                ),
+                "ancilla_x180_duration": _waveform_duration_payload(
+                    resources.ancilla_x180s,
+                    targets=ancilla_qubits,
                 ),
             },
         },

--- a/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
+++ b/src/qubex/contrib/experiment/mcm_randomized_benchmarking.py
@@ -1,4 +1,4 @@
-"""Measurement-crosstalk randomized benchmarking experiments."""
+"""MCM randomized-benchmarking and repetition experiments."""
 
 from __future__ import annotations
 
@@ -22,18 +22,41 @@ from qubex.experiment.experiment_constants import (
 )
 from qubex.experiment.models import Result
 from qubex.measurement.models.measure_result import MultipleMeasureResult
-from qubex.pulse import Blank, FlatTop, PulseArray, PulseSchedule, VirtualZ, Waveform
+from qubex.pulse import (
+    Blank,
+    FlatTop,
+    PulseArray,
+    PulseSchedule,
+    VirtualZ,
+    Waveform,
+    set_sampling_period,
+)
 
-MCMRBProtocol = Literal["mcm-rb", "delay-rb", "mcm-rep"]
+MCMRBProtocol = Literal["mcm-rb", "delay-rb", "mcm-rep", "delay-rep"]
 _AncillaMode = Literal["standard", "randomized"]
 
 _MCM_RB: MCMRBProtocol = "mcm-rb"
 _DELAY_RB: MCMRBProtocol = "delay-rb"
 _MCM_REP: MCMRBProtocol = "mcm-rep"
-_MCM_RB_PROTOCOLS: tuple[MCMRBProtocol, ...] = (_MCM_RB, _DELAY_RB, _MCM_REP)
+_DELAY_REP: MCMRBProtocol = "delay-rep"
+# The suffix selects the control operation (Clifford or matched delay), while
+# the prefix selects the ancilla operation (readout or matched delay).
+_SUPPORTED_PROTOCOLS: tuple[MCMRBProtocol, ...] = (
+    _MCM_RB,
+    _DELAY_RB,
+    _MCM_REP,
+    _DELAY_REP,
+)
+_STANDARD_DEFAULT_PROTOCOLS: tuple[MCMRBProtocol, ...] = (
+    _MCM_RB,
+    _DELAY_RB,
+    _MCM_REP,
+)
+_RANDOMIZED_DEFAULT_PROTOCOLS: tuple[MCMRBProtocol, ...] = (_MCM_RB, _DELAY_RB)
+_CONTROL_DELAY_PROTOCOLS: tuple[MCMRBProtocol, ...] = (_MCM_REP, _DELAY_REP)
+_READOUT_DELAY_PROTOCOLS: tuple[MCMRBProtocol, ...] = (_DELAY_RB, _DELAY_REP)
 _STANDARD_ANCILLA: _AncillaMode = "standard"
 _RANDOMIZED_ANCILLA: _AncillaMode = "randomized"
-_RANDOMIZED_ANCILLA_PROTOCOLS: tuple[MCMRBProtocol, ...] = (_MCM_RB, _DELAY_RB)
 _ANCILLA_RANDOMIZATION_SPAWN_KEY = (1,)
 
 
@@ -100,9 +123,9 @@ _ProtocolResults = dict[MCMRBProtocol, dict[str, _TargetAnalysis]]
 
 def _validate_protocol(protocol: str) -> MCMRBProtocol:
     """Validate and narrow one protocol name."""
-    if protocol not in _MCM_RB_PROTOCOLS:
+    if protocol not in _SUPPORTED_PROTOCOLS:
         raise ValueError(
-            f"Invalid `protocol`: {protocol!r}. Expected one of {_MCM_RB_PROTOCOLS}."
+            f"Invalid `protocol`: {protocol!r}. Expected one of {_SUPPORTED_PROTOCOLS}."
         )
     return cast(MCMRBProtocol, protocol)
 
@@ -117,17 +140,11 @@ def _validate_ancilla_mode(ancilla_mode: str) -> _AncillaMode:
     return cast(_AncillaMode, ancilla_mode)
 
 
-def _validate_protocol_for_ancilla_mode(
-    protocol: MCMRBProtocol,
-    *,
-    ancilla_mode: _AncillaMode,
-) -> None:
-    """Reject protocols incompatible with randomized ancilla recovery."""
-    if ancilla_mode == _RANDOMIZED_ANCILLA and protocol == _MCM_REP:
-        raise ValueError(
-            "`mcm-rep` is not supported when `ancilla_mode='randomized'`; "
-            "use `mcm-rb` and `delay-rb` as a matched pair."
-        )
+def _validate_xaxis_type(xaxis_type: str) -> Literal["linear", "log"]:
+    """Validate and narrow the fit-figure x-axis scale."""
+    if xaxis_type not in ("linear", "log"):
+        raise ValueError("`xaxis_type` must be either `linear` or `log`.")
+    return cast(Literal["linear", "log"], xaxis_type)
 
 
 def _validate_nonnegative_integer(value: object, *, name: str) -> int:
@@ -345,6 +362,7 @@ def _resolve_sequence_resources(
     sampling_period = float(exp.ctx.measurement.sampling_period)
     if not np.isfinite(sampling_period) or sampling_period <= 0:
         raise ValueError("The experiment sampling period must be positive and finite.")
+    set_sampling_period(sampling_period)
 
     x90_waveform = x90 if x90 is not None else exp.pulse.x90(control)
     measurement = (
@@ -479,7 +497,7 @@ def _build_protocol_schedule(
     with PulseSchedule(schedule_labels) as schedule:
         for cycle_index, clifford in enumerate(clifford_sequence.cliffords):
             control_operation: Waveform
-            if protocol == _MCM_REP:
+            if protocol in _CONTROL_DELAY_PROTOCOLS:
                 control_operation = _blank(
                     clifford.duration,
                     resources.sampling_period,
@@ -497,7 +515,7 @@ def _build_protocol_schedule(
                 schedule.barrier()
 
             measurement_operation: Waveform
-            if protocol == _DELAY_RB:
+            if protocol in _READOUT_DELAY_PROTOCOLS:
                 measurement_operation = _blank(
                     resources.measurement.duration,
                     resources.sampling_period,
@@ -516,7 +534,7 @@ def _build_protocol_schedule(
             schedule.barrier()
 
         final_control_operation: Waveform
-        if protocol == _MCM_REP:
+        if protocol in _CONTROL_DELAY_PROTOCOLS:
             final_control_operation = _blank(
                 clifford_sequence.inverse.duration,
                 resources.sampling_period,
@@ -544,32 +562,41 @@ def mcm_rb_sequence(
     ancilla_x180: Waveform | None = None,
 ) -> PulseSchedule:
     """
-    Build one MCM-RB, delay-RB, or MCM-repetition pulse schedule.
+    Build one MCM-RB, delay-RB, MCM-repetition, or delay-repetition schedule.
 
     Parameters
     ----------
     exp
         Experiment instance that provides pulse and Clifford services.
     control
-        Qubit receiving the randomized Clifford sequence.
+        Control or spectator qubit. RB protocols apply randomized Cliffords
+        and their inverse; repetition protocols replace them with
+        duration-matched delays.
     ancilla
-        Qubit measured during every randomized-benchmarking cycle.
+        Ancilla or readout-target qubit. MCM protocols apply its intermediate
+        readout; delay protocols replace that readout with a duration-matched
+        delay.
     protocol
-        Sequence variant: `"mcm-rb"`, `"delay-rb"`, or `"mcm-rep"`.
+        Sequence variant: `"mcm-rb"`, `"delay-rb"`, `"mcm-rep"`, or
+        `"delay-rep"`. Repetition protocols replace the control Cliffords with
+        duration-matched delays. Delay protocols replace the intermediate
+        readout pulses with duration-matched delays.
     n_cliffords
-        Number of randomized cycles. Must be nonnegative.
+        Number of protocol cycles. Must be nonnegative.
     seed
-        Nonnegative seed used to generate the one-qubit Clifford sequence.
+        Nonnegative seed for the Clifford sequence and the independent
+        randomized-ancilla I/X180 stream. Repetition protocols use the
+        generated Clifford durations only.
     control_echo
         Whether to apply an X-X echo to the control during every measurement
         or reference-delay window. The X180 centers are placed at the quarter
         and three-quarter points of the active readout interval after trimming
-        half a ramp duration from each end.
+        half a ramp duration from each end. Repetition protocols therefore
+        contain control pulses during these windows when this option is `True`.
     ancilla_mode
         Ancilla sequence mode. `"standard"` preserves the original protocol.
         `"randomized"` inserts a seeded I/X180 before every measurement or
-        reference delay and applies a final parity recovery. Randomized mode
-        supports only `"mcm-rb"` and `"delay-rb"`.
+        reference delay and applies a final parity recovery.
     x90
         Optional control X90 waveform override.
     measurement_waveform
@@ -599,21 +626,21 @@ def mcm_rb_sequence(
 
     Notes
     -----
-    In standard mode, `mcm-rep` replaces every randomized Clifford and the
-    final inverse with duration-matched delays. All selected protocols have
-    equal total duration for the same Clifford sequence and seed.
+    The `mcm-rep` and `delay-rep` protocols replace every randomized Clifford
+    and the final inverse with duration-matched delays. All four protocols have
+    equal total duration when built with the same cycle count, seed, ancilla
+    mode, and echo options.
 
     In randomized mode, the seed determines both the Clifford sequence and a
     separate ancilla I/X180 random stream. The final ancilla recovery is X180
     exactly when the programmed sequence has odd parity. One static I/X180
     sequence is encoded in the returned schedule.
+
+    Construction synchronizes the global pulse-library sampling period with
+    `exp.ctx.measurement.sampling_period`.
     """
     resolved_protocol = _validate_protocol(protocol)
     resolved_ancilla_mode = _validate_ancilla_mode(ancilla_mode)
-    _validate_protocol_for_ancilla_mode(
-        resolved_protocol,
-        ancilla_mode=resolved_ancilla_mode,
-    )
     resolved_n_cliffords = _validate_nonnegative_integer(
         n_cliffords,
         name="n_cliffords",
@@ -700,11 +727,11 @@ def _resolve_protocols(
     *,
     ancilla_mode: _AncillaMode,
 ) -> tuple[MCMRBProtocol, ...]:
-    """Return unique protocol names in caller-specified order."""
+    """Return unique protocol names in input iteration order."""
     if protocols is None:
         if ancilla_mode == _RANDOMIZED_ANCILLA:
-            return _RANDOMIZED_ANCILLA_PROTOCOLS
-        return _MCM_RB_PROTOCOLS
+            return _RANDOMIZED_DEFAULT_PROTOCOLS
+        return _STANDARD_DEFAULT_PROTOCOLS
     candidates = [protocols] if isinstance(protocols, str) else list(protocols)
     if not candidates:
         raise ValueError("`protocols` must not be empty.")
@@ -714,11 +741,6 @@ def _resolve_protocols(
     )
     if len(resolved) != len(set(resolved)):
         raise ValueError("`protocols` must not contain duplicate values.")
-    for protocol in resolved:
-        _validate_protocol_for_ancilla_mode(
-            protocol,
-            ancilla_mode=ancilla_mode,
-        )
     return resolved
 
 
@@ -870,8 +892,8 @@ def _fit_protocol_target(
         y=mean,
         error_y=std if trials.shape[1] > 1 else None,
         bounds=((0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
-        title=f"{protocol} randomized benchmarking",
-        xlabel="Number of Clifford/measurement cycles",
+        title=f"{protocol} measurement-crosstalk benchmarking",
+        xlabel="Number of protocol cycles",
         ylabel="Ground-state probability",
         xaxis_type=xaxis_type,
         yaxis_type="linear",
@@ -941,28 +963,34 @@ def _measurement_induced_error(
     protocol_results: _ProtocolResults,
     *,
     target: str,
+    measurement_protocol: MCMRBProtocol,
+    reference_protocol: MCMRBProtocol,
 ) -> dict[str, float] | None:
-    """Calculate one target's MCM-induced error relative to delay-RB."""
-    if _MCM_RB not in protocol_results or _DELAY_RB not in protocol_results:
-        return None
-    mcm_result = protocol_results[_MCM_RB][target]
-    delay_result = protocol_results[_DELAY_RB][target]
-    p_mcm = mcm_result["decay_parameter"]
-    p_mcm_err = mcm_result["decay_parameter_err"]
-    p_delay = delay_result["decay_parameter"]
-    p_delay_err = delay_result["decay_parameter_err"]
+    """Calculate one target's induced error from a matched protocol pair."""
     if (
-        p_mcm is None
-        or p_mcm_err is None
-        or p_delay is None
-        or p_delay_err is None
-        or p_delay == 0.0
+        measurement_protocol not in protocol_results
+        or reference_protocol not in protocol_results
+    ):
+        return None
+    measurement_result = protocol_results[measurement_protocol][target]
+    reference_result = protocol_results[reference_protocol][target]
+    p_measurement = measurement_result["decay_parameter"]
+    p_measurement_err = measurement_result["decay_parameter_err"]
+    p_reference = reference_result["decay_parameter"]
+    p_reference_err = reference_result["decay_parameter_err"]
+    if (
+        p_measurement is None
+        or p_measurement_err is None
+        or p_reference is None
+        or p_reference_err is None
+        or p_reference == 0.0
     ):
         return None
 
-    value = 0.5 * (1.0 - p_mcm / p_delay)
+    value = 0.5 * (1.0 - p_measurement / p_reference)
     error = 0.5 * np.sqrt(
-        (p_mcm_err / p_delay) ** 2 + (p_mcm * p_delay_err / p_delay**2) ** 2
+        (p_measurement_err / p_reference) ** 2
+        + (p_measurement * p_reference_err / p_reference**2) ** 2
     )
     return {"value": float(value), "error": float(error)}
 
@@ -998,34 +1026,38 @@ def mcm_randomized_benchmarking(
     exp
         Experiment instance used to generate and execute the schedules.
     control
-        Qubit receiving randomized Cliffords.
+        Control or spectator qubit. RB protocols apply randomized Cliffords;
+        repetition protocols apply duration-matched delays instead.
     ancilla
-        Qubit measured during every randomized-benchmarking cycle.
+        Ancilla or readout-target qubit. MCM protocols apply its intermediate
+        readout; delay protocols replace that readout with a duration-matched
+        delay.
     n_cliffords_range
         Strictly increasing nonnegative cycle counts. Defaults to 0 followed
         by 14 geometrically spaced values from 1 through 150.
     n_trials
-        Number of random Clifford trials per cycle count. Defaults to 30.
+        Number of seed trials per cycle count. Defaults to 30.
     seeds
         One nonnegative integer seed for every trial. Defaults to generated
         seeds. Values must have integer types and fit in signed 64 bits.
     protocols
         Protocols to run. Defaults to all of `"mcm-rb"`, `"delay-rb"`, and
         `"mcm-rep"` in standard mode and to the matched `"mcm-rb"` and
-        `"delay-rb"` pair in randomized mode. The same generated Clifford and
-        ancilla I/X180 sequences are shared across protocols for each sequence
-        length and seed.
+        `"delay-rb"` pair in randomized mode. `"mcm-rep"` and `"delay-rep"`
+        are opt-in in randomized mode; `"delay-rep"` is opt-in in both modes.
+        The same generated Clifford and ancilla I/X180 sequences are shared
+        across protocols for each sequence length and seed.
     control_echo
         Whether to insert an X-X echo on the control during every measurement
         or duration-matched delay window. The X180 centers are placed at the
         quarter and three-quarter points of the active readout interval after
-        trimming half a ramp duration from each end.
+        trimming half a ramp duration from each end. Repetition protocols omit
+        randomized Cliffords but are not strictly idle when echo is enabled.
     ancilla_mode
         Ancilla sequence mode. `"standard"` preserves the original suite.
         `"randomized"` inserts a seeded I/X180 before every measurement or
         reference delay, followed by an X180 for odd parity or a
-        duration-matched blank for even parity. Randomized mode does not
-        support `"mcm-rep"`.
+        duration-matched blank for even parity.
     x90
         Optional control X90 waveform override.
     measurement_waveform
@@ -1059,9 +1091,14 @@ def mcm_randomized_benchmarking(
     -------
     Result
         Raw terminal probabilities, per-protocol statistics and fits, the
-        MCM-induced control error, optional randomized-ancilla population
-        error, metadata, and named fit figures. Protocol results are stored
-        under `result.data["protocols"][protocol][target]`.
+        optional MCM-induced control error, randomized-ancilla population
+        errors with Clifford-driven or delayed control, metadata, and named
+        fit figures.
+        Protocol results are stored under
+        `result.data["protocols"][protocol][target]`. The Clifford-driven and
+        control-delay ancilla estimates are stored as
+        `measurement_induced_ancilla_population_error` and
+        `measurement_induced_ancilla_population_error_with_idle_control`.
 
     Raises
     ------
@@ -1075,15 +1112,21 @@ def mcm_randomized_benchmarking(
     Notes
     -----
     Intermediate MCM outcomes are intentionally discarded. Only the terminal
-    capture for the control and ancilla is normalized and fitted. When both
-    MCM-RB and delay-RB succeed, the reported induced error is
-    `(1 - p_mcm / p_delay) / 2`.
+    capture for the control and ancilla is normalized and fitted. A matched
+    measurement/reference pair reports `(1 - p_measurement / p_reference) / 2`.
+    MCM-RB and delay-RB form the Clifford-driven pair. In randomized mode,
+    MCM-repetition and delay-repetition form the control-delay pair.
+    MCM-repetition without delay-repetition does not produce a ratio-based
+    induced-error estimate. With `control_echo=True`, the control-delay pair
+    still contains the requested X-X echoes.
 
     Control-qubit MCM-RB and delay-RB have the standard
     randomized-benchmarking exponential form under the usual assumptions.
-    MCM-repetition is fitted to the same form for comparison, but its decay is
-    not generally guaranteed to be exponential because the ancilla is not
-    Clifford twirled.
+    Every protocol/target pair is fitted to the same exponential form for
+    comparison. The repetition-protocol fit is not a standard RB fit: the
+    control is not Clifford twirled, and standard-mode ancilla population is
+    not I/X180 twirled. Its `error_per_cycle` is therefore a decay metric rather
+    than a general average gate error.
 
     Randomized mode benchmarks ancilla computational-basis population
     preservation, not general single-qubit or state-assignment fidelity. Its
@@ -1096,6 +1139,9 @@ def mcm_randomized_benchmarking(
     The ancilla I/X180 choices are generated once per sequence length and
     trial seed, then reused for every shot of that schedule. Randomization is
     averaged across trials rather than varied shot by shot.
+
+    The experiment synchronizes the global pulse-library sampling period with
+    `exp.ctx.measurement.sampling_period` before constructing schedules.
     """
     resolved_ancilla_mode = _validate_ancilla_mode(ancilla_mode)
     resolved_n_cliffords = _resolve_n_cliffords_range(n_cliffords_range)
@@ -1118,8 +1164,7 @@ def mcm_randomized_benchmarking(
     )
     resolved_plot = True if plot is None else plot
     resolved_save_image = False if save_image is None else save_image
-    if xaxis_type not in ("linear", "log"):
-        raise ValueError("`xaxis_type` must be either `linear` or `log`.")
+    resolved_xaxis_type = _validate_xaxis_type(xaxis_type)
 
     control_qubit, ancilla_qubit = _resolve_qubit_pair(exp, control, ancilla)
     exp.pulse.validate_rabi_params([control_qubit, ancilla_qubit])
@@ -1151,7 +1196,7 @@ def mcm_randomized_benchmarking(
         n_cliffords=resolved_n_cliffords,
         plot=resolved_plot,
         save_image=resolved_save_image,
-        xaxis_type=xaxis_type,
+        xaxis_type=resolved_xaxis_type,
     )
 
     return Result(
@@ -1162,11 +1207,25 @@ def mcm_randomized_benchmarking(
             "measurement_induced_control_error": _measurement_induced_error(
                 protocol_results,
                 target=control_qubit,
+                measurement_protocol=_MCM_RB,
+                reference_protocol=_DELAY_RB,
             ),
             "measurement_induced_ancilla_population_error": (
                 _measurement_induced_error(
                     protocol_results,
                     target=ancilla_qubit,
+                    measurement_protocol=_MCM_RB,
+                    reference_protocol=_DELAY_RB,
+                )
+                if resolved_ancilla_mode == _RANDOMIZED_ANCILLA
+                else None
+            ),
+            "measurement_induced_ancilla_population_error_with_idle_control": (
+                _measurement_induced_error(
+                    protocol_results,
+                    target=ancilla_qubit,
+                    measurement_protocol=_MCM_REP,
+                    reference_protocol=_DELAY_REP,
                 )
                 if resolved_ancilla_mode == _RANDOMIZED_ANCILLA
                 else None

--- a/tests/contrib/mcm_randomized_benchmarking/conftest.py
+++ b/tests/contrib/mcm_randomized_benchmarking/conftest.py
@@ -45,7 +45,7 @@ class FakePulseService:
 
     def __init__(self, *, measurement_duration: float = 64.0) -> None:
         self.measurement_duration = measurement_duration
-        self.rabi_params = {"Q0": FakeRabiParam(), "Q1": FakeRabiParam()}
+        self.rabi_params = {f"Q{index}": FakeRabiParam() for index in range(5)}
         self.validated_targets: list[str] | None = None
 
     def validate_rabi_params(self, targets: list[str]) -> None:

--- a/tests/contrib/mcm_randomized_benchmarking/conftest.py
+++ b/tests/contrib/mcm_randomized_benchmarking/conftest.py
@@ -1,0 +1,119 @@
+"""Test fixtures for measurement-crosstalk randomized benchmarking."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+
+from qubex.pulse import Rect
+
+
+class FakeCliffordGenerator:
+    """Return deterministic one-qubit Clifford decompositions."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[int, str, int | None]] = []
+
+    def create_rb_sequences(
+        self,
+        n: int,
+        type: str,
+        seed: int | None,
+    ) -> tuple[list[list[str]], list[str]]:
+        """Return a reproducible gate list with variable Clifford durations."""
+        self.calls.append((n, type, seed))
+        assert type == "1Q"
+        cliffords = [
+            ["X90"] if index % 2 == 0 else ["Z90", "X90", "X90"] for index in range(n)
+        ]
+        return cliffords, ["Z90", "X90"]
+
+
+class FakeRabiParam:
+    """Normalize a synthetic IQ value to a Bloch-Z expectation value."""
+
+    def normalize(self, iq: Any) -> float:
+        """Return twice the encoded ground-state probability minus one."""
+        return 2.0 * float(np.real(np.mean(np.asarray(iq)))) - 1.0
+
+
+class FakePulseService:
+    """Provide fixed-duration test pulses."""
+
+    def __init__(self, *, measurement_duration: float = 64.0) -> None:
+        self.measurement_duration = measurement_duration
+        self.rabi_params = {"Q0": FakeRabiParam(), "Q1": FakeRabiParam()}
+        self.validated_targets: list[str] | None = None
+
+    def validate_rabi_params(self, targets: list[str]) -> None:
+        """Record the validated targets."""
+        self.validated_targets = list(targets)
+
+    def x90(self, target: str) -> Rect:
+        """Return an 8 ns pi/2 pulse."""
+        del target
+        return Rect(duration=8.0, amplitude=0.5, sampling_period=2.0)
+
+    def x180(self, target: str) -> Rect:
+        """Return a 16 ns pi pulse."""
+        del target
+        return Rect(duration=16.0, amplitude=1.0, sampling_period=2.0)
+
+    def readout(self, target: str) -> Rect:
+        """Return a fixed-duration readout pulse."""
+        del target
+        return Rect(
+            duration=self.measurement_duration,
+            amplitude=0.25,
+            sampling_period=2.0,
+        )
+
+
+class FakeExperimentSystem:
+    """Resolve test qubit and readout labels."""
+
+    @staticmethod
+    def resolve_qubit_label(label: str) -> str:
+        """Return the qubit corresponding to a test label."""
+        return label.removeprefix("R")
+
+    @staticmethod
+    def resolve_read_label(label: str) -> str:
+        """Return the readout label corresponding to a test label."""
+        return label if label.startswith("R") else f"R{label}"
+
+
+class FakeContext:
+    """Provide the experiment context used by the public helpers."""
+
+    def __init__(self) -> None:
+        self.measurement = SimpleNamespace(sampling_period=2.0)
+        self.experiment_system = FakeExperimentSystem()
+        self.reset_calls: list[set[str]] = []
+
+    def resolve_qubit_label(self, label: str) -> str:
+        """Resolve a qubit label."""
+        return self.experiment_system.resolve_qubit_label(label)
+
+    def reset_awg_and_capunits(self, *, qubits: set[str]) -> None:
+        """Record one hardware-reset request."""
+        self.reset_calls.append(set(qubits))
+
+
+@pytest.fixture
+def fake_experiment() -> Any:
+    """Provide a hardware-free experiment double for sequence tests."""
+    pulse = FakePulseService()
+    context = FakeContext()
+    return SimpleNamespace(
+        pulse=pulse,
+        ctx=context,
+        experiment_system=context.experiment_system,
+        benchmarking_service=SimpleNamespace(
+            clifford_generator=FakeCliffordGenerator()
+        ),
+        measurement_service=SimpleNamespace(),
+    )

--- a/tests/contrib/mcm_randomized_benchmarking/conftest.py
+++ b/tests/contrib/mcm_randomized_benchmarking/conftest.py
@@ -63,11 +63,11 @@ class FakePulseService:
         return Rect(duration=16.0, amplitude=1.0, sampling_period=2.0)
 
     def readout(self, target: str) -> Rect:
-        """Return a fixed-duration readout pulse."""
-        del target
+        """Return a target-specific fixed-duration readout pulse."""
+        target_index = int(target.removeprefix("Q"))
         return Rect(
             duration=self.measurement_duration,
-            amplitude=0.25,
+            amplitude=0.1 * (target_index + 1),
             sampling_period=2.0,
         )
 

--- a/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
@@ -124,6 +124,10 @@ def test_experiment_uses_terminal_captures_and_reports_induced_error(
         abs=1e-12,
     )
     assert result.data["measurement_induced_ancilla_population_error"] is None
+    assert (
+        result.data["measurement_induced_ancilla_population_error_with_idle_control"]
+        is None
+    )
     assert fake_experiment.ctx.reset_calls == [{"Q0", "Q1"}]
     assert len(measurement_service.calls) == 18
     assert all(
@@ -207,23 +211,106 @@ def test_randomized_ancilla_analyzes_both_targets_with_matched_references(
         )
 
 
-def test_randomized_ancilla_experiment_rejects_mcm_repetition(
+def test_randomized_ancilla_reports_active_and_idle_control_induced_errors(
+    monkeypatch: pytest.MonkeyPatch,
     fake_experiment: Any,
 ) -> None:
-    """Randomized mode should reject an incompatible MCM-repetition request."""
-    with pytest.raises(ValueError, match="mcm-rep"):
-        mcm_randomized_benchmarking(
-            fake_experiment,
-            "Q0",
-            "Q1",
-            n_cliffords_range=[0, 1, 2],
-            n_trials=1,
-            seeds=[3],
-            protocols=("mcm-rb", "mcm-rep"),
-            ancilla_mode="randomized",
-            plot=False,
-            save_image=False,
+    """Matched RB and repetition pairs should report their ancilla errors."""
+    measurement_service = ConstantMeasurementService()
+    fake_experiment.measurement_service = measurement_service
+
+    def fake_fit_rb(*, target: str, title: str, **options: Any) -> FitResult:
+        del options
+        protocol = title.split()[0]
+        p = {
+            ("mcm-rb", "Q0"): 0.96,
+            ("delay-rb", "Q0"): 0.98,
+            ("mcm-rb", "Q1"): 0.90,
+            ("delay-rb", "Q1"): 0.95,
+            ("mcm-rep", "Q0"): 0.97,
+            ("delay-rep", "Q0"): 0.99,
+            ("mcm-rep", "Q1"): 0.88,
+            ("delay-rep", "Q1"): 0.92,
+        }[(protocol, target)]
+        return FitResult(
+            status=FitStatus.SUCCESS,
+            data={"p": p, "p_err": 0.01},
+            figure=go.Figure(),
         )
+
+    monkeypatch.setattr(mcm_module.fitting, "fit_rb", fake_fit_rb)
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols=("mcm-rb", "delay-rb", "mcm-rep", "delay-rep"),
+        ancilla_mode="randomized",
+        plot=False,
+        save_image=False,
+    )
+
+    assert tuple(result.data["protocols"]) == (
+        "mcm-rb",
+        "delay-rb",
+        "mcm-rep",
+        "delay-rep",
+    )
+    assert result.data["measurement_induced_control_error"]["value"] == pytest.approx(
+        0.5 * (1.0 - 0.96 / 0.98), rel=1e-12, abs=1e-12
+    )
+    assert result.data["measurement_induced_ancilla_population_error"][
+        "value"
+    ] == pytest.approx(0.5 * (1.0 - 0.90 / 0.95), rel=1e-12, abs=1e-12)
+    assert result.data[
+        "measurement_induced_ancilla_population_error_with_idle_control"
+    ]["value"] == pytest.approx(
+        0.5 * (1.0 - 0.88 / 0.92),
+        rel=1e-12,
+        abs=1e-12,
+    )
+    assert len(measurement_service.calls) == 12
+
+
+def test_randomized_mcm_repetition_does_not_report_unmatched_induced_error(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """MCM repetition alone should expose its fit without an induced error."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+    monkeypatch.setattr(
+        mcm_module.fitting,
+        "fit_rb",
+        lambda **options: FitResult(
+            status=FitStatus.SUCCESS,
+            data={"p": 0.95, "p_err": 0.01},
+            figure=go.Figure(),
+        ),
+    )
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols="mcm-rep",
+        ancilla_mode="randomized",
+        plot=False,
+        save_image=False,
+    )
+
+    assert result.data["protocols"]["mcm-rep"]["Q1"]["decay_parameter"] == 0.95
+    assert result.data["measurement_induced_control_error"] is None
+    assert result.data["measurement_induced_ancilla_population_error"] is None
+    assert (
+        result.data["measurement_induced_ancilla_population_error_with_idle_control"]
+        is None
+    )
 
 
 def test_experiment_rejects_mismatched_trial_and_seed_counts(
@@ -243,6 +330,22 @@ def test_experiment_rejects_mismatched_trial_and_seed_counts(
         )
 
 
+def test_experiment_rejects_invalid_xaxis_type(fake_experiment: Any) -> None:
+    """The workflow should reject unsupported fit-axis scales."""
+    with pytest.raises(ValueError, match="xaxis_type"):
+        mcm_randomized_benchmarking(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            n_cliffords_range=[0, 1, 2],
+            n_trials=1,
+            seeds=[1],
+            xaxis_type="symlog",  # type: ignore[arg-type]
+            plot=False,
+            save_image=False,
+        )
+
+
 @pytest.mark.parametrize("seed", [1.0, "1", 1 + 0j])
 def test_experiment_rejects_noninteger_seeds(
     fake_experiment: Any,
@@ -256,7 +359,7 @@ def test_experiment_rejects_noninteger_seeds(
             "Q1",
             n_cliffords_range=[0, 1, 2],
             n_trials=1,
-            seeds=[seed],
+            seeds=[seed],  # type: ignore[arg-type]
             protocols="mcm-rep",
             plot=False,
             save_image=False,

--- a/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
@@ -61,10 +61,7 @@ class ConstantMeasurementService:
             return SimpleNamespace(kerneled=np.asarray([value + 0.0j]))
 
         return SimpleNamespace(
-            data={
-                "RQ0": [capture(0.9)],
-                "RQ1": [capture(0.8)],
-            }
+            data={f"RQ{index}": [capture(0.9 - 0.05 * index)] for index in range(5)}
         )
 
 
@@ -211,6 +208,62 @@ def test_randomized_ancilla_analyzes_both_targets_with_matched_references(
         )
 
 
+def test_multiple_controls_and_ancillas_report_per_target_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """Multiple controls and ancillas should be acquired and analyzed together."""
+    measurement_service = ConstantMeasurementService()
+    fake_experiment.measurement_service = measurement_service
+
+    def fake_fit_rb(*, target: str, title: str, **options: Any) -> FitResult:
+        del options
+        protocol = title.split()[0]
+        base = {"Q0": 0.96, "Q1": 0.92, "Q2": 0.94, "Q3": 0.90}[target]
+        p = base if protocol == "mcm-rb" else base + 0.02
+        return FitResult(
+            status=FitStatus.SUCCESS,
+            data={"p": p, "p_err": 0.01},
+            figure=go.Figure(),
+        )
+
+    monkeypatch.setattr(mcm_module.fitting, "fit_rb", fake_fit_rb)
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        ["Q0", "Q2"],
+        ["Q1", "Q3"],
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        ancilla_mode="randomized",
+        plot=False,
+        save_image=False,
+    )
+
+    assert set(result.data["protocols"]["mcm-rb"]) == {"Q0", "Q1", "Q2", "Q3"}
+    assert set(result.data["measurement_induced_control_error"]) == {"Q0", "Q2"}
+    assert set(result.data["measurement_induced_ancilla_population_error"]) == {
+        "Q1",
+        "Q3",
+    }
+    assert result.data["measurement_induced_control_error"]["Q0"][
+        "value"
+    ] == pytest.approx(0.5 * (1.0 - 0.96 / 0.98), rel=1e-12, abs=1e-12)
+    assert result.data["metadata"]["controls"] == ("Q0", "Q2")
+    assert result.data["metadata"]["ancillas"] == ("Q1", "Q3")
+    assert result.data["metadata"]["control"] is None
+    assert result.data["metadata"]["ancilla"] is None
+    assert fake_experiment.pulse.validated_targets == ["Q0", "Q2", "Q1", "Q3"]
+    assert fake_experiment.ctx.reset_calls == [{"Q0", "Q1", "Q2", "Q3"}]
+    assert len(measurement_service.calls) == 6
+    assert set(result.figures or {}) == {
+        f"{protocol}:{target}"
+        for protocol in ("mcm-rb", "delay-rb")
+        for target in ("Q0", "Q2", "Q1", "Q3")
+    }
+
+
 def test_randomized_ancilla_reports_active_and_idle_control_induced_errors(
     monkeypatch: pytest.MonkeyPatch,
     fake_experiment: Any,
@@ -305,6 +358,43 @@ def test_randomized_mcm_repetition_does_not_report_unmatched_induced_error(
     )
 
     assert result.data["protocols"]["mcm-rep"]["Q1"]["decay_parameter"] == 0.95
+    assert result.data["measurement_induced_control_error"] is None
+    assert result.data["measurement_induced_ancilla_population_error"] is None
+    assert (
+        result.data["measurement_induced_ancilla_population_error_with_idle_control"]
+        is None
+    )
+
+
+def test_multiple_targets_do_not_report_unmatched_induced_errors(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """Unmatched protocols should return no induced-error field for any group size."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+    monkeypatch.setattr(
+        mcm_module.fitting,
+        "fit_rb",
+        lambda **options: FitResult(
+            status=FitStatus.SUCCESS,
+            data={"p": 0.95, "p_err": 0.01},
+            figure=go.Figure(),
+        ),
+    )
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        ["Q0", "Q2"],
+        ["Q1", "Q3"],
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols="mcm-rep",
+        ancilla_mode="randomized",
+        plot=False,
+        save_image=False,
+    )
+
     assert result.data["measurement_induced_control_error"] is None
     assert result.data["measurement_induced_ancilla_population_error"] is None
     assert (

--- a/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
@@ -50,10 +50,12 @@ class FakeMeasurementService:
 class ConstantMeasurementService:
     """Return fixed terminal captures for real pulse schedules."""
 
-    @staticmethod
-    def execute(sequence: Any, **options: Any) -> Any:
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, dict[str, Any]]] = []
+
+    def execute(self, sequence: Any, **options: Any) -> Any:
         """Return one terminal capture for each test qubit."""
-        del sequence, options
+        self.calls.append((sequence, options))
 
         def capture(value: float) -> Any:
             return SimpleNamespace(kerneled=np.asarray([value + 0.0j]))
@@ -121,6 +123,7 @@ def test_experiment_uses_terminal_captures_and_reports_induced_error(
         rel=1e-12,
         abs=1e-12,
     )
+    assert result.data["measurement_induced_ancilla_population_error"] is None
     assert fake_experiment.ctx.reset_calls == [{"Q0", "Q1"}]
     assert len(measurement_service.calls) == 18
     assert all(
@@ -139,6 +142,90 @@ def test_experiment_uses_terminal_captures_and_reports_induced_error(
     }
 
 
+def test_randomized_ancilla_analyzes_both_targets_with_matched_references(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """Randomized mode should fit both targets and compare matched MCM and delays."""
+    measurement_service = ConstantMeasurementService()
+    fake_experiment.measurement_service = measurement_service
+
+    def fake_fit_rb(*, target: str, title: str, **options: Any) -> FitResult:
+        del options
+        protocol = title.split()[0]
+        p = {
+            ("mcm-rb", "Q0"): 0.96,
+            ("delay-rb", "Q0"): 0.98,
+            ("mcm-rb", "Q1"): 0.90,
+            ("delay-rb", "Q1"): 0.95,
+        }[(protocol, target)]
+        return FitResult(
+            status=FitStatus.SUCCESS,
+            data={"p": p, "p_err": 0.01},
+            figure=go.Figure(),
+        )
+
+    monkeypatch.setattr(mcm_module.fitting, "fit_rb", fake_fit_rb)
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        ancilla_mode="randomized",
+        plot=False,
+        save_image=False,
+    )
+
+    assert tuple(result.data["protocols"]) == ("mcm-rb", "delay-rb")
+    assert set(result.data["protocols"]["mcm-rb"]) == {"Q0", "Q1"}
+    assert result.data["measurement_induced_control_error"]["value"] == pytest.approx(
+        0.5 * (1.0 - 0.96 / 0.98),
+        rel=1e-12,
+        abs=1e-12,
+    )
+    assert result.data["measurement_induced_ancilla_population_error"][
+        "value"
+    ] == pytest.approx(
+        0.5 * (1.0 - 0.90 / 0.95),
+        rel=1e-12,
+        abs=1e-12,
+    )
+    assert result.data["metadata"]["ancilla_mode"] == "randomized"
+    assert result.data["metadata"]["ancilla_x180_duration"] == 16.0
+    assert len(measurement_service.calls) == 6
+    for mcm_call, delay_call in zip(
+        measurement_service.calls[::2],
+        measurement_service.calls[1::2],
+        strict=True,
+    ):
+        assert (
+            mcm_call[0].get_sequence("Q1").values.tolist()
+            == delay_call[0].get_sequence("Q1").values.tolist()
+        )
+
+
+def test_randomized_ancilla_experiment_rejects_mcm_repetition(
+    fake_experiment: Any,
+) -> None:
+    """Randomized mode should reject an incompatible MCM-repetition request."""
+    with pytest.raises(ValueError, match="mcm-rep"):
+        mcm_randomized_benchmarking(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            n_cliffords_range=[0, 1, 2],
+            n_trials=1,
+            seeds=[3],
+            protocols=("mcm-rb", "mcm-rep"),
+            ancilla_mode="randomized",
+            plot=False,
+            save_image=False,
+        )
+
+
 def test_experiment_rejects_mismatched_trial_and_seed_counts(
     fake_experiment: Any,
 ) -> None:
@@ -154,6 +241,57 @@ def test_experiment_rejects_mismatched_trial_and_seed_counts(
             plot=False,
             save_image=False,
         )
+
+
+@pytest.mark.parametrize("seed", [1.0, "1", 1 + 0j])
+def test_experiment_rejects_noninteger_seeds(
+    fake_experiment: Any,
+    seed: object,
+) -> None:
+    """Seed arrays should contain integer values, not coercible values."""
+    with pytest.raises(TypeError, match=r"seeds.*integers"):
+        mcm_randomized_benchmarking(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            n_cliffords_range=[0, 1, 2],
+            n_trials=1,
+            seeds=[seed],
+            protocols="mcm-rep",
+            plot=False,
+            save_image=False,
+        )
+
+
+def test_experiment_preserves_large_integer_seed(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """Seed validation should not lose precision through floating-point conversion."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+    monkeypatch.setattr(
+        mcm_module.fitting,
+        "fit_rb",
+        lambda **options: FitResult(
+            status=FitStatus.ERROR,
+            message=f"Skipped fit for {options['target']}",
+        ),
+    )
+    seed = 2**53 + 1
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[seed],
+        protocols="mcm-rep",
+        plot=False,
+        save_image=False,
+    )
+
+    assert result.data["seeds"].tolist() == [seed]
 
 
 @pytest.mark.parametrize("shot_interval", [0.0, -1.0, np.nan, np.inf])

--- a/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
@@ -1,0 +1,229 @@
+"""Tests for the MCM randomized benchmarking experiment workflow."""
+
+from __future__ import annotations
+
+import importlib
+from types import SimpleNamespace
+from typing import Any
+
+import numpy as np
+import pytest
+from plotly import graph_objects as go
+
+from qubex.analysis import FitResult, FitStatus
+from qubex.contrib.experiment.mcm_randomized_benchmarking import (
+    mcm_randomized_benchmarking,
+)
+
+mcm_module = importlib.import_module(
+    "qubex.contrib.experiment.mcm_randomized_benchmarking"
+)
+
+
+class FakeMeasurementService:
+    """Return distinct intermediate and final capture values."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, dict[str, Any]]] = []
+
+    def execute(self, sequence: Any, **options: Any) -> Any:
+        """Encode the terminal probability in the last capture."""
+        self.calls.append((sequence, options))
+        call_index = len(self.calls) - 1
+        n_cliffords = (0, 1, 2)[call_index // 6]
+        seed = (3, 5)[call_index % 6 // 3]
+        protocol_offset = (0.00, 0.05, 0.10)[call_index % 3]
+        control_probability = 0.90 - 0.02 * n_cliffords + 0.001 * seed
+        ancilla_probability = control_probability - protocol_offset
+
+        def capture(value: float) -> Any:
+            return SimpleNamespace(kerneled=np.asarray([value + 0.0j]))
+
+        return SimpleNamespace(
+            data={
+                "RQ0": [capture(-10.0), capture(control_probability)],
+                "Q1": [capture(-20.0), capture(ancilla_probability)],
+            }
+        )
+
+
+class ConstantMeasurementService:
+    """Return fixed terminal captures for real pulse schedules."""
+
+    @staticmethod
+    def execute(sequence: Any, **options: Any) -> Any:
+        """Return one terminal capture for each test qubit."""
+        del sequence, options
+
+        def capture(value: float) -> Any:
+            return SimpleNamespace(kerneled=np.asarray([value + 0.0j]))
+
+        return SimpleNamespace(
+            data={
+                "RQ0": [capture(0.9)],
+                "RQ1": [capture(0.8)],
+            }
+        )
+
+
+def test_experiment_uses_terminal_captures_and_reports_induced_error(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """The workflow should analyze final captures and compare MCM-RB with delay-RB."""
+    measurement_service = FakeMeasurementService()
+    fake_experiment.measurement_service = measurement_service
+
+    def fake_fit_rb(*, target: str, title: str, **options: Any) -> FitResult:
+        del options
+        protocol = title.split()[0]
+        p = {
+            ("mcm-rb", "Q0"): 0.96,
+            ("delay-rb", "Q0"): 0.98,
+        }.get((protocol, target), 0.90)
+        return FitResult(
+            status=FitStatus.SUCCESS,
+            data={"p": p, "p_err": 0.01},
+            figure=go.Figure(),
+        )
+
+    monkeypatch.setattr(mcm_module.fitting, "fit_rb", fake_fit_rb)
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=2,
+        seeds=[3, 5],
+        n_shots=64,
+        shot_interval=1_000.0,
+        plot=False,
+        save_image=False,
+    )
+
+    mcm_control = result.data["protocols"]["mcm-rb"]["Q0"]
+    induced = result.data["measurement_induced_control_error"]
+
+    np.testing.assert_allclose(
+        mcm_control["trials"],
+        [[0.903, 0.905], [0.883, 0.885], [0.863, 0.865]],
+        rtol=0.0,
+        atol=1e-12,
+    )
+    assert induced["value"] == pytest.approx(
+        0.5 * (1.0 - 0.96 / 0.98),
+        rel=1e-12,
+        abs=1e-12,
+    )
+    assert induced["error"] == pytest.approx(
+        0.5 * np.sqrt((0.01 / 0.98) ** 2 + (0.96 * 0.01 / 0.98**2) ** 2),
+        rel=1e-12,
+        abs=1e-12,
+    )
+    assert fake_experiment.ctx.reset_calls == [{"Q0", "Q1"}]
+    assert len(measurement_service.calls) == 18
+    assert all(
+        call[1]["final_measurement"] is True for call in measurement_service.calls
+    )
+    assert all(
+        call[1]["reset_awg_and_capunits"] is False for call in measurement_service.calls
+    )
+    assert set(result.figures or {}) == {
+        "mcm-rb:Q0",
+        "mcm-rb:Q1",
+        "delay-rb:Q0",
+        "delay-rb:Q1",
+        "mcm-rep:Q0",
+        "mcm-rep:Q1",
+    }
+
+
+def test_experiment_rejects_mismatched_trial_and_seed_counts(
+    fake_experiment: Any,
+) -> None:
+    """The workflow should require exactly one seed per trial."""
+    with pytest.raises(ValueError, match="number of seeds"):
+        mcm_randomized_benchmarking(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            n_cliffords_range=[0, 1, 2],
+            n_trials=2,
+            seeds=[1],
+            plot=False,
+            save_image=False,
+        )
+
+
+def test_experiment_generates_each_random_clifford_sequence_once(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """All selected protocols should share one generated sequence per length and seed."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+
+    def fake_fit_rb(**options: Any) -> FitResult:
+        del options
+        return FitResult(
+            status=FitStatus.SUCCESS,
+            data={"p": 0.95, "p_err": 0.01},
+            figure=go.Figure(),
+        )
+
+    monkeypatch.setattr(mcm_module.fitting, "fit_rb", fake_fit_rb)
+
+    mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=2,
+        seeds=[3, 5],
+        plot=False,
+        save_image=False,
+    )
+
+    generator = fake_experiment.benchmarking_service.clifford_generator
+    assert generator.calls == [
+        (0, "1Q", 3),
+        (0, "1Q", 5),
+        (1, "1Q", 3),
+        (1, "1Q", 5),
+        (2, "1Q", 3),
+        (2, "1Q", 5),
+    ]
+
+
+def test_single_protocol_fit_failure_returns_raw_data_without_figures(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """A failed single-protocol fit should retain data without an IRB estimate."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+    monkeypatch.setattr(
+        mcm_module.fitting,
+        "fit_rb",
+        lambda **options: FitResult(
+            status=FitStatus.ERROR,
+            message=f"Failed fit for {options['target']}",
+        ),
+    )
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols="mcm-rep",
+        plot=False,
+        save_image=False,
+    )
+
+    target_result = result.data["protocols"]["mcm-rep"]["Q0"]
+    assert target_result["trials"].shape == (3, 1)
+    assert target_result["decay_parameter"] is None
+    assert result.data["measurement_induced_control_error"] is None
+    assert result.figures is None

--- a/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
@@ -156,6 +156,44 @@ def test_experiment_rejects_mismatched_trial_and_seed_counts(
         )
 
 
+@pytest.mark.parametrize("shot_interval", [0.0, -1.0, np.nan, np.inf])
+def test_experiment_rejects_nonpositive_or_nonfinite_shot_interval(
+    fake_experiment: Any,
+    shot_interval: float,
+) -> None:
+    """The workflow should reject a nonpositive or nonfinite shot interval."""
+    with pytest.raises(ValueError, match="shot_interval"):
+        mcm_randomized_benchmarking(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            n_cliffords_range=[0, 1, 2],
+            n_trials=1,
+            seeds=[3],
+            protocols="mcm-rep",
+            shot_interval=shot_interval,
+            plot=False,
+            save_image=False,
+        )
+
+
+def test_experiment_rejects_boolean_shot_interval(fake_experiment: Any) -> None:
+    """A boolean shot interval should not be interpreted as a number."""
+    with pytest.raises(TypeError, match="shot_interval"):
+        mcm_randomized_benchmarking(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            n_cliffords_range=[0, 1, 2],
+            n_trials=1,
+            seeds=[3],
+            protocols="mcm-rep",
+            shot_interval=True,
+            plot=False,
+            save_image=False,
+        )
+
+
 def test_experiment_generates_each_random_clifford_sequence_once(
     monkeypatch: pytest.MonkeyPatch,
     fake_experiment: Any,

--- a/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
@@ -3,12 +3,15 @@
 from __future__ import annotations
 
 import importlib
+from collections.abc import Callable
+from io import StringIO
 from types import SimpleNamespace
 from typing import Any
 
 import numpy as np
 import pytest
 from plotly import graph_objects as go
+from rich.console import Console
 
 from qubex.analysis import FitResult, FitStatus
 from qubex.contrib.experiment.mcm_randomized_benchmarking import (
@@ -65,6 +68,82 @@ class ConstantMeasurementService:
         )
 
 
+class PairedBootstrapMeasurementService:
+    """Return protocol-paired trial fluctuations for bootstrap tests."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, dict[str, Any]]] = []
+
+    def execute(self, sequence: Any, **options: Any) -> Any:
+        """Encode a shared trial offset in both matched protocols."""
+        self.calls.append((sequence, options))
+        call_index = len(self.calls) - 1
+        n_index = call_index // 6
+        trial_index = call_index % 6 // 2
+        protocol_index = call_index % 2
+        shared_trial_offset = (-0.06, 0.0, 0.09)[trial_index]
+        protocol_base = (0.72, 0.84)[protocol_index]
+        probability = protocol_base + 0.01 * n_index + shared_trial_offset
+
+        def capture(value: float) -> Any:
+            return SimpleNamespace(kerneled=np.asarray([value + 0.0j]))
+
+        return SimpleNamespace(
+            data={"RQ0": [capture(probability)], "RQ1": [capture(probability)]}
+        )
+
+
+class ExponentialMeasurementService:
+    """Return exact trial-dependent exponential decay curves."""
+
+    def __init__(self) -> None:
+        self.calls: list[tuple[Any, dict[str, Any]]] = []
+
+    def execute(self, sequence: Any, **options: Any) -> Any:
+        """Encode a bounded exponential for each protocol and trial."""
+        self.calls.append((sequence, options))
+        call_index = len(self.calls) - 1
+        n_cliffords = (0, 1, 2, 4, 8)[call_index // 6]
+        trial_index = call_index % 6 // 2
+        protocol_index = call_index % 2
+        central_decay = (0.94, 0.97)[protocol_index]
+        decay_parameter = central_decay + (-0.01, 0.0, 0.01)[trial_index]
+        probability = 0.4 * decay_parameter**n_cliffords + 0.5
+
+        def capture(value: float) -> Any:
+            return SimpleNamespace(kerneled=np.asarray([value + 0.0j]))
+
+        return SimpleNamespace(
+            data={"RQ0": [capture(probability)], "RQ1": [capture(probability)]}
+        )
+
+
+def _run_analysis_option_validation(
+    fake_experiment: Any,
+    *,
+    n_bootstrap: int = 0,
+    bootstrap_seed: int | None = 0,
+    bootstrap_confidence_level: float = 0.95,
+    min_fit_r_squared: float | None = 0.9,
+) -> Any:
+    """Call the public workflow with explicit analysis-option types."""
+    return mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols="mcm-rep",
+        n_bootstrap=n_bootstrap,
+        bootstrap_seed=bootstrap_seed,
+        bootstrap_confidence_level=bootstrap_confidence_level,
+        min_fit_r_squared=min_fit_r_squared,
+        plot=False,
+        save_image=False,
+    )
+
+
 def test_experiment_uses_terminal_captures_and_reports_induced_error(
     monkeypatch: pytest.MonkeyPatch,
     fake_experiment: Any,
@@ -101,8 +180,9 @@ def test_experiment_uses_terminal_captures_and_reports_induced_error(
         save_image=False,
     )
 
-    mcm_control = result.data["protocols"]["mcm-rb"]["Q0"]
-    induced = result.data["measurement_induced_control_error"]
+    mcm_control = result.data["protocol_results"]["mcm-rb"]["Q0"]
+    induced_errors = result.data["measurement_induced_errors"]
+    induced = induced_errors["control"]["Q0"]
 
     np.testing.assert_allclose(
         mcm_control["trials"],
@@ -110,21 +190,57 @@ def test_experiment_uses_terminal_captures_and_reports_induced_error(
         rtol=0.0,
         atol=1e-12,
     )
+    assert set(mcm_control) == {
+        "trials",
+        "mean",
+        "std",
+        "fit",
+        "decay_parameter",
+        "decay_parameter_uncertainty",
+        "uncertainty_method",
+        "error_per_cycle",
+        "error_per_cycle_uncertainty",
+        "bootstrap",
+        "fit_validity",
+    }
     assert induced["value"] == pytest.approx(
         0.5 * (1.0 - 0.96 / 0.98),
         rel=1e-12,
         abs=1e-12,
     )
-    assert induced["error"] == pytest.approx(
+    assert induced["uncertainty"] == pytest.approx(
         0.5 * np.sqrt((0.01 / 0.98) ** 2 + (0.96 * 0.01 / 0.98**2) ** 2),
         rel=1e-12,
         abs=1e-12,
     )
-    assert result.data["measurement_induced_ancilla_population_error"] is None
-    assert (
-        result.data["measurement_induced_ancilla_population_error_with_idle_control"]
-        is None
+    assert induced["uncertainty_method"] == "independent_fit_propagation"
+    assert induced["bootstrap"]["confidence_interval"] is None
+    assert induced["bootstrap"]["unavailable_reason"] == (
+        "at_least_four_sequence_lengths_required"
     )
+    assert set(induced) == {
+        "value",
+        "uncertainty",
+        "uncertainty_method",
+        "bootstrap",
+        "fit_validity",
+    }
+    assert set(induced["bootstrap"]) == {
+        "successful_resamples",
+        "success_rate",
+        "standard_error",
+        "confidence_interval",
+        "unavailable_reason",
+    }
+    assert induced_errors["ancilla_population_with_cliffords"] == {"Q1": None}
+    assert induced_errors["ancilla_population_with_control_delay"] == {"Q1": None}
+    assert set(result.data) == {
+        "n_cliffords",
+        "seeds",
+        "protocol_results",
+        "measurement_induced_errors",
+        "metadata",
+    }
     assert fake_experiment.ctx.reset_calls == [{"Q0", "Q1"}]
     assert len(measurement_service.calls) == 18
     assert all(
@@ -141,6 +257,461 @@ def test_experiment_uses_terminal_captures_and_reports_induced_error(
         "mcm-rep:Q0",
         "mcm-rep:Q1",
     }
+
+
+def test_paired_bootstrap_preserves_trial_pairing_in_induced_error(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """Bootstrap ratios should resample matched protocol trial columns together."""
+    fake_experiment.measurement_service = PairedBootstrapMeasurementService()
+
+    def fake_fit_rb(*, target: str, title: str, **options: Any) -> FitResult:
+        del target, options
+        protocol = title.split()[0]
+        p = {"mcm-rb": 0.75, "delay-rb": 0.87}[protocol]
+        return FitResult(
+            status=FitStatus.SUCCESS,
+            data={
+                "A": 0.4,
+                "A_err": 0.01,
+                "p": p,
+                "p_err": 0.01,
+                "C": 0.5,
+                "C_err": 0.01,
+                "r2": 0.99,
+            },
+            figure=go.Figure(),
+        )
+
+    monkeypatch.setattr(mcm_module.fitting, "fit_rb", fake_fit_rb)
+    monkeypatch.setattr(
+        mcm_module,
+        "_fit_decay_parameter",
+        lambda n_cliffords, probabilities: float(probabilities[-1]),
+    )
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2, 4],
+        n_trials=3,
+        seeds=[3, 5, 7],
+        protocols=("mcm-rb", "delay-rb"),
+        n_bootstrap=20,
+        bootstrap_seed=7,
+        bootstrap_confidence_level=0.8,
+        plot=False,
+        save_image=False,
+    )
+
+    bootstrap_indices = np.random.default_rng(7).integers(0, 3, size=(20, 3))
+    trial_offsets = np.asarray([-0.06, 0.0, 0.09])
+    offset_means = np.mean(trial_offsets[bootstrap_indices], axis=1)
+    p_measurement = 0.75 + offset_means
+    p_reference = 0.87 + offset_means
+    bootstrap_errors = 0.5 * (1.0 - p_measurement / p_reference)
+    expected_interval = tuple(np.quantile(bootstrap_errors, [0.1, 0.9]))
+
+    estimate = result.data["measurement_induced_errors"]["control"]["Q0"]
+    assert estimate["uncertainty_method"] == "paired_bootstrap"
+    assert estimate["uncertainty"] == pytest.approx(
+        np.std(bootstrap_errors, ddof=1), rel=1e-12, abs=1e-12
+    )
+    assert estimate["bootstrap"]["confidence_interval"] == pytest.approx(
+        expected_interval, rel=1e-12, abs=1e-12
+    )
+    assert estimate["bootstrap"]["successful_resamples"] == 20
+    assert estimate["fit_validity"]["is_valid"] is True
+    target_result = result.data["protocol_results"]["mcm-rb"]["Q0"]
+    assert target_result["uncertainty_method"] == "paired_bootstrap"
+    assert target_result["bootstrap"]["successful_resamples"] == 20
+
+
+def test_induced_error_retains_value_when_uncertainty_is_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """A matched decay ratio should not disappear only because uncertainty is absent."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+
+    def fake_fit_rb(*, title: str, **_: Any) -> FitResult:
+        protocol = title.split()[0]
+        return FitResult(
+            status=FitStatus.SUCCESS,
+            data={"p": {"mcm-rb": 0.96, "delay-rb": 0.98}[protocol]},
+            figure=go.Figure(),
+        )
+
+    monkeypatch.setattr(mcm_module.fitting, "fit_rb", fake_fit_rb)
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols=("mcm-rb", "delay-rb"),
+        n_bootstrap=0,
+        plot=False,
+        save_image=False,
+    )
+
+    estimate = result.data["measurement_induced_errors"]["control"]["Q0"]
+    assert estimate["value"] == pytest.approx(
+        0.5 * (1.0 - 0.96 / 0.98), rel=1e-12, abs=1e-12
+    )
+    assert estimate["uncertainty"] is None
+    assert estimate["uncertainty_method"] == "unavailable"
+
+
+def test_bootstrap_fits_exponential_resamples_through_the_public_workflow(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """Bootstrap should fit every well-conditioned exponential resample."""
+    fake_experiment.measurement_service = ExponentialMeasurementService()
+
+    def fake_fit_rb(*, target: str, title: str, **options: Any) -> FitResult:
+        del target, options
+        protocol = title.split()[0]
+        p = {"mcm-rb": 0.94, "delay-rb": 0.97}[protocol]
+        return FitResult(
+            status=FitStatus.SUCCESS,
+            data={
+                "A": 0.4,
+                "A_err": 0.01,
+                "p": p,
+                "p_err": 0.01,
+                "C": 0.5,
+                "C_err": 0.01,
+                "r2": 0.999,
+            },
+            figure=go.Figure(),
+        )
+
+    monkeypatch.setattr(mcm_module.fitting, "fit_rb", fake_fit_rb)
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2, 4, 8],
+        n_trials=3,
+        seeds=[3, 5, 7],
+        protocols=("mcm-rb", "delay-rb"),
+        n_bootstrap=12,
+        bootstrap_seed=11,
+        plot=False,
+        save_image=False,
+    )
+
+    bootstrap = result.data["protocol_results"]["mcm-rb"]["Q0"]["bootstrap"]
+    assert bootstrap["successful_resamples"] == 12
+    assert bootstrap["success_rate"] == pytest.approx(1.0, rel=0.0, abs=0.0)
+    assert bootstrap["unavailable_reason"] is None
+    assert bootstrap["confidence_interval"] is not None
+
+
+def test_failed_primary_fit_does_not_report_an_orphaned_bootstrap_uncertainty(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """A failed primary fit should not expose uncertainty without a fitted value."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+    monkeypatch.setattr(
+        mcm_module.fitting,
+        "fit_rb",
+        lambda **_: FitResult(status=FitStatus.ERROR),
+    )
+    monkeypatch.setattr(
+        mcm_module,
+        "_fit_decay_parameter",
+        lambda *_: 0.9,
+    )
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2, 4],
+        n_trials=2,
+        seeds=[3, 5],
+        protocols="mcm-rep",
+        n_bootstrap=8,
+        plot=False,
+        print_summary=False,
+        enable_tqdm=False,
+    )
+
+    target_result = result.data["protocol_results"]["mcm-rep"]["Q0"]
+    assert target_result["decay_parameter"] is None
+    assert target_result["decay_parameter_uncertainty"] is None
+    assert target_result["uncertainty_method"] == "unavailable"
+    assert target_result["bootstrap"]["successful_resamples"] == 8
+
+
+def test_fit_validity_reports_insufficient_points_and_low_r_squared(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """Fit diagnostics should distinguish convergence from a valid decay fit."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+    monkeypatch.setattr(
+        mcm_module.fitting,
+        "fit_rb",
+        lambda **_: FitResult(
+            status=FitStatus.SUCCESS,
+            data={"p": 0.95, "p_err": 0.01, "r2": 0.2},
+            figure=go.Figure(),
+        ),
+    )
+
+    insufficient = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols="mcm-rep",
+        n_bootstrap=0,
+        plot=False,
+        save_image=False,
+    )
+    low_r_squared = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2, 4],
+        n_trials=1,
+        seeds=[3],
+        protocols="mcm-rep",
+        n_bootstrap=0,
+        min_fit_r_squared=0.9,
+        plot=False,
+        save_image=False,
+    )
+
+    insufficient_validity = insufficient.data["protocol_results"]["mcm-rep"]["Q0"][
+        "fit_validity"
+    ]
+    low_r_squared_validity = low_r_squared.data["protocol_results"]["mcm-rep"]["Q0"][
+        "fit_validity"
+    ]
+    assert insufficient_validity["is_valid"] is False
+    assert "insufficient_sequence_lengths" in insufficient_validity["reasons"]
+    assert low_r_squared_validity["is_valid"] is False
+    assert "r_squared_below_threshold" in low_r_squared_validity["reasons"]
+
+
+def test_measurement_scale_metadata_records_the_applied_intermediate_readout(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """Metadata should identify scaled intermediate and calibrated terminal pulses."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+    monkeypatch.setattr(
+        mcm_module.fitting,
+        "fit_rb",
+        lambda **_: FitResult(
+            status=FitStatus.SUCCESS,
+            data={"p": 0.95, "p_err": 0.01, "r2": 0.99},
+            figure=go.Figure(),
+        ),
+    )
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols="mcm-rb",
+        measurement_scale=2.0,
+        n_bootstrap=0,
+        plot=False,
+        save_image=False,
+    )
+
+    readout_metadata = result.data["metadata"]["pulses"]["intermediate_measurements"][
+        "Q1"
+    ]
+    assert readout_metadata == {
+        "source": "scaled_calibrated",
+        "scale": 2.0,
+        "duration_ns": 64.0,
+        "peak_amplitude": pytest.approx(0.4, rel=0.0, abs=1e-12),
+        "integrated_power": pytest.approx(10.24, rel=0.0, abs=1e-12),
+        "integrated_power_units": "amplitude_squared_ns",
+        "ramp_trimmed_active_interval_ns": (0.0, 64.0),
+    }
+    assert result.data["metadata"]["pulses"]["terminal_measurements"] == {
+        "targets": ("Q0", "Q1"),
+        "source": "calibrated_default",
+    }
+    assert result.data["metadata"]["pulses"]["ancilla_x180_durations_ns"] == {}
+    assert set(result.data["metadata"]["pulses"]) == {
+        "intermediate_measurements",
+        "terminal_measurements",
+        "ancilla_x180_durations_ns",
+    }
+    assert set(result.data["metadata"]) == {
+        "controls",
+        "ancillas",
+        "control_echo",
+        "ancilla_mode",
+        "acquisition",
+        "analysis",
+        "pulses",
+    }
+    assert result.data["metadata"]["acquisition"] == {
+        "n_trials": 1,
+        "n_shots": 1024,
+        "shot_interval_ns": 153_600.0,
+        "time_integration": True,
+    }
+    assert result.data["metadata"]["analysis"] == {
+        "n_bootstrap": 0,
+        "bootstrap_seed": 0,
+        "bootstrap_confidence_level": 0.95,
+        "min_bootstrap_success_rate": 0.8,
+        "min_fit_r_squared": 0.9,
+    }
+
+
+def test_experiment_prints_summary_by_default_independently_of_plot(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """The workflow should print fit and induced-error tables by default."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+    output = StringIO()
+    monkeypatch.setattr(
+        mcm_module,
+        "console",
+        Console(file=output, force_terminal=False, width=160),
+        raising=False,
+    )
+
+    def fake_fit_rb(*, title: str, **_: Any) -> FitResult:
+        protocol = title.split()[0]
+        return FitResult(
+            status=FitStatus.SUCCESS,
+            data={
+                "A": 0.4,
+                "A_err": 0.01,
+                "p": {"mcm-rb": 0.96, "delay-rb": 0.98}[protocol],
+                "p_err": 0.01,
+                "C": 0.5,
+                "C_err": 0.01,
+                "r2": 0.99,
+            },
+            figure=go.Figure(),
+        )
+
+    monkeypatch.setattr(mcm_module.fitting, "fit_rb", fake_fit_rb)
+
+    mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols=("mcm-rb", "delay-rb"),
+        n_bootstrap=0,
+        plot=False,
+        enable_tqdm=False,
+    )
+
+    rendered = output.getvalue()
+    assert "MCM randomized benchmarking: protocol fits" in rendered
+    assert "MCM randomized benchmarking: measurement-induced errors" in rendered
+    assert "mcm-rb" in rendered
+    assert "control" in rendered
+
+
+def test_experiment_can_disable_summary_printing(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """An explicit false value should suppress all summary-table output."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+    output = StringIO()
+    monkeypatch.setattr(
+        mcm_module,
+        "console",
+        Console(file=output, force_terminal=False),
+        raising=False,
+    )
+    monkeypatch.setattr(
+        mcm_module.fitting,
+        "fit_rb",
+        lambda **_: FitResult(status=FitStatus.ERROR),
+    )
+
+    mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols="mcm-rep",
+        n_bootstrap=0,
+        plot=False,
+        print_summary=False,
+        enable_tqdm=False,
+    )
+
+    assert output.getvalue() == ""
+
+
+def test_experiment_enables_progress_bar_by_default(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """The workflow should pass an enabled default to its progress bar."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+    progress_options: list[dict[str, Any]] = []
+
+    class FakeProgress:
+        def update(self) -> None:
+            """Accept one simulated completed schedule."""
+
+        def close(self) -> None:
+            """Accept progress cleanup."""
+
+    def fake_tqdm(**options: Any) -> FakeProgress:
+        progress_options.append(options)
+        return FakeProgress()
+
+    monkeypatch.setattr(mcm_module, "tqdm", fake_tqdm)
+    monkeypatch.setattr(
+        mcm_module.fitting,
+        "fit_rb",
+        lambda **_: FitResult(status=FitStatus.ERROR),
+    )
+
+    mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols="mcm-rep",
+        n_bootstrap=0,
+        plot=False,
+        print_summary=False,
+    )
+
+    assert len(progress_options) == 1
+    assert progress_options[0]["disable"] is False
 
 
 def test_randomized_ancilla_analyzes_both_targets_with_matched_references(
@@ -180,14 +751,15 @@ def test_randomized_ancilla_analyzes_both_targets_with_matched_references(
         save_image=False,
     )
 
-    assert tuple(result.data["protocols"]) == ("mcm-rb", "delay-rb")
-    assert set(result.data["protocols"]["mcm-rb"]) == {"Q0", "Q1"}
-    assert result.data["measurement_induced_control_error"]["value"] == pytest.approx(
+    assert tuple(result.data["protocol_results"]) == ("mcm-rb", "delay-rb")
+    assert set(result.data["protocol_results"]["mcm-rb"]) == {"Q0", "Q1"}
+    induced_errors = result.data["measurement_induced_errors"]
+    assert induced_errors["control"]["Q0"]["value"] == pytest.approx(
         0.5 * (1.0 - 0.96 / 0.98),
         rel=1e-12,
         abs=1e-12,
     )
-    assert result.data["measurement_induced_ancilla_population_error"][
+    assert induced_errors["ancilla_population_with_cliffords"]["Q1"][
         "value"
     ] == pytest.approx(
         0.5 * (1.0 - 0.90 / 0.95),
@@ -195,7 +767,9 @@ def test_randomized_ancilla_analyzes_both_targets_with_matched_references(
         abs=1e-12,
     )
     assert result.data["metadata"]["ancilla_mode"] == "randomized"
-    assert result.data["metadata"]["ancilla_x180_duration"] == 16.0
+    assert result.data["metadata"]["pulses"]["ancilla_x180_durations_ns"] == {
+        "Q1": 16.0
+    }
     assert len(measurement_service.calls) == 6
     for mcm_call, delay_call in zip(
         measurement_service.calls[::2],
@@ -241,19 +815,23 @@ def test_multiple_controls_and_ancillas_report_per_target_errors(
         save_image=False,
     )
 
-    assert set(result.data["protocols"]["mcm-rb"]) == {"Q0", "Q1", "Q2", "Q3"}
-    assert set(result.data["measurement_induced_control_error"]) == {"Q0", "Q2"}
-    assert set(result.data["measurement_induced_ancilla_population_error"]) == {
+    assert set(result.data["protocol_results"]["mcm-rb"]) == {
+        "Q0",
+        "Q1",
+        "Q2",
+        "Q3",
+    }
+    induced_errors = result.data["measurement_induced_errors"]
+    assert set(induced_errors["control"]) == {"Q0", "Q2"}
+    assert set(induced_errors["ancilla_population_with_cliffords"]) == {
         "Q1",
         "Q3",
     }
-    assert result.data["measurement_induced_control_error"]["Q0"][
-        "value"
-    ] == pytest.approx(0.5 * (1.0 - 0.96 / 0.98), rel=1e-12, abs=1e-12)
+    assert induced_errors["control"]["Q0"]["value"] == pytest.approx(
+        0.5 * (1.0 - 0.96 / 0.98), rel=1e-12, abs=1e-12
+    )
     assert result.data["metadata"]["controls"] == ("Q0", "Q2")
     assert result.data["metadata"]["ancillas"] == ("Q1", "Q3")
-    assert result.data["metadata"]["control"] is None
-    assert result.data["metadata"]["ancilla"] is None
     assert fake_experiment.pulse.validated_targets == ["Q0", "Q2", "Q1", "Q3"]
     assert fake_experiment.ctx.reset_calls == [{"Q0", "Q1", "Q2", "Q3"}]
     assert len(measurement_service.calls) == 6
@@ -264,7 +842,7 @@ def test_multiple_controls_and_ancillas_report_per_target_errors(
     }
 
 
-def test_randomized_ancilla_reports_active_and_idle_control_induced_errors(
+def test_randomized_ancilla_reports_clifford_and_control_delay_induced_errors(
     monkeypatch: pytest.MonkeyPatch,
     fake_experiment: Any,
 ) -> None:
@@ -301,31 +879,75 @@ def test_randomized_ancilla_reports_active_and_idle_control_induced_errors(
         n_trials=1,
         seeds=[3],
         protocols=("mcm-rb", "delay-rb", "mcm-rep", "delay-rep"),
+        control_echo=True,
         ancilla_mode="randomized",
         plot=False,
         save_image=False,
     )
 
-    assert tuple(result.data["protocols"]) == (
+    assert tuple(result.data["protocol_results"]) == (
         "mcm-rb",
         "delay-rb",
         "mcm-rep",
         "delay-rep",
     )
-    assert result.data["measurement_induced_control_error"]["value"] == pytest.approx(
+    induced_errors = result.data["measurement_induced_errors"]
+    assert induced_errors["control"]["Q0"]["value"] == pytest.approx(
         0.5 * (1.0 - 0.96 / 0.98), rel=1e-12, abs=1e-12
     )
-    assert result.data["measurement_induced_ancilla_population_error"][
+    assert induced_errors["ancilla_population_with_cliffords"]["Q1"][
         "value"
     ] == pytest.approx(0.5 * (1.0 - 0.90 / 0.95), rel=1e-12, abs=1e-12)
-    assert result.data[
-        "measurement_induced_ancilla_population_error_with_idle_control"
-    ]["value"] == pytest.approx(
+    assert induced_errors["ancilla_population_with_control_delay"]["Q1"][
+        "value"
+    ] == pytest.approx(
         0.5 * (1.0 - 0.88 / 0.92),
         rel=1e-12,
         abs=1e-12,
     )
+    assert set(induced_errors) == {
+        "control",
+        "ancilla_population_with_cliffords",
+        "ancilla_population_with_control_delay",
+    }
     assert len(measurement_service.calls) == 12
+
+
+@pytest.mark.parametrize(
+    ("run", "message"),
+    [
+        (
+            lambda exp: _run_analysis_option_validation(exp, n_bootstrap=-1),
+            "n_bootstrap",
+        ),
+        (
+            lambda exp: _run_analysis_option_validation(exp, bootstrap_seed=-1),
+            "bootstrap_seed",
+        ),
+        (
+            lambda exp: _run_analysis_option_validation(
+                exp,
+                bootstrap_confidence_level=1.0,
+            ),
+            "bootstrap_confidence_level",
+        ),
+        (
+            lambda exp: _run_analysis_option_validation(
+                exp,
+                min_fit_r_squared=1.1,
+            ),
+            "min_fit_r_squared",
+        ),
+    ],
+)
+def test_experiment_rejects_invalid_bootstrap_and_fit_diagnostic_options(
+    fake_experiment: Any,
+    run: Callable[[Any], Any],
+    message: str,
+) -> None:
+    """Bootstrap and fit-diagnostic options should reject invalid bounds."""
+    with pytest.raises((TypeError, ValueError), match=message):
+        run(fake_experiment)
 
 
 def test_randomized_mcm_repetition_does_not_report_unmatched_induced_error(
@@ -334,10 +956,16 @@ def test_randomized_mcm_repetition_does_not_report_unmatched_induced_error(
 ) -> None:
     """MCM repetition alone should expose its fit without an induced error."""
     fake_experiment.measurement_service = ConstantMeasurementService()
+    output = StringIO()
+    monkeypatch.setattr(
+        mcm_module,
+        "console",
+        Console(file=output, force_terminal=False),
+    )
     monkeypatch.setattr(
         mcm_module.fitting,
         "fit_rb",
-        lambda **options: FitResult(
+        lambda **_: FitResult(
             status=FitStatus.SUCCESS,
             data={"p": 0.95, "p_err": 0.01},
             figure=go.Figure(),
@@ -357,25 +985,25 @@ def test_randomized_mcm_repetition_does_not_report_unmatched_induced_error(
         save_image=False,
     )
 
-    assert result.data["protocols"]["mcm-rep"]["Q1"]["decay_parameter"] == 0.95
-    assert result.data["measurement_induced_control_error"] is None
-    assert result.data["measurement_induced_ancilla_population_error"] is None
-    assert (
-        result.data["measurement_induced_ancilla_population_error_with_idle_control"]
-        is None
-    )
+    assert result.data["protocol_results"]["mcm-rep"]["Q1"]["decay_parameter"] == 0.95
+    assert result.data["measurement_induced_errors"] == {
+        "control": {"Q0": None},
+        "ancilla_population_with_cliffords": {"Q1": None},
+        "ancilla_population_with_control_delay": {"Q1": None},
+    }
+    assert "measurement-induced errors" not in output.getvalue()
 
 
 def test_multiple_targets_do_not_report_unmatched_induced_errors(
     monkeypatch: pytest.MonkeyPatch,
     fake_experiment: Any,
 ) -> None:
-    """Unmatched protocols should return no induced-error field for any group size."""
+    """Unmatched protocols should retain target keys with unavailable estimates."""
     fake_experiment.measurement_service = ConstantMeasurementService()
     monkeypatch.setattr(
         mcm_module.fitting,
         "fit_rb",
-        lambda **options: FitResult(
+        lambda **_: FitResult(
             status=FitStatus.SUCCESS,
             data={"p": 0.95, "p_err": 0.01},
             figure=go.Figure(),
@@ -395,12 +1023,11 @@ def test_multiple_targets_do_not_report_unmatched_induced_errors(
         save_image=False,
     )
 
-    assert result.data["measurement_induced_control_error"] is None
-    assert result.data["measurement_induced_ancilla_population_error"] is None
-    assert (
-        result.data["measurement_induced_ancilla_population_error_with_idle_control"]
-        is None
-    )
+    assert result.data["measurement_induced_errors"] == {
+        "control": {"Q0": None, "Q2": None},
+        "ancilla_population_with_cliffords": {"Q1": None, "Q3": None},
+        "ancilla_population_with_control_delay": {"Q1": None, "Q3": None},
+    }
 
 
 def test_experiment_rejects_mismatched_trial_and_seed_counts(
@@ -591,8 +1218,8 @@ def test_single_protocol_fit_failure_returns_raw_data_without_figures(
         save_image=False,
     )
 
-    target_result = result.data["protocols"]["mcm-rep"]["Q0"]
+    target_result = result.data["protocol_results"]["mcm-rep"]["Q0"]
     assert target_result["trials"].shape == (3, 1)
     assert target_result["decay_parameter"] is None
-    assert result.data["measurement_induced_control_error"] is None
+    assert result.data["measurement_induced_errors"]["control"] == {"Q0": None}
     assert result.figures is None

--- a/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_experiment.py
@@ -453,6 +453,88 @@ def test_failed_primary_fit_does_not_report_an_orphaned_bootstrap_uncertainty(
     assert target_result["bootstrap"]["successful_resamples"] == 8
 
 
+def test_nonfinite_probabilities_retain_acquired_trial_data(
+    fake_experiment: Any,
+) -> None:
+    """Nonfinite probabilities should return acquired data with a failed fit."""
+
+    def execute_nonfinite(sequence: Any, **options: Any) -> Any:
+        del sequence, options
+        capture = SimpleNamespace(kerneled=np.asarray([complex(np.nan)]))
+        return SimpleNamespace(data={"RQ0": [capture], "RQ1": [capture]})
+
+    fake_experiment.measurement_service = SimpleNamespace(execute=execute_nonfinite)
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols="mcm-rep",
+        n_bootstrap=0,
+        plot=False,
+        print_summary=False,
+        enable_tqdm=False,
+    )
+
+    target_result = result.data["protocol_results"]["mcm-rep"]["Q0"]
+    assert target_result["trials"].shape == (3, 1)
+    assert target_result["fit"].status is FitStatus.ERROR
+    assert target_result["decay_parameter"] is None
+    assert "non-finite" in target_result["fit"].message
+    assert result.figures is None
+
+
+def test_negative_fit_uncertainty_is_not_reported(
+    monkeypatch: pytest.MonkeyPatch,
+    fake_experiment: Any,
+) -> None:
+    """A negative covariance uncertainty should be treated as unavailable."""
+    fake_experiment.measurement_service = ConstantMeasurementService()
+
+    def fake_fit_rb(*, title: str, **_: Any) -> FitResult:
+        protocol = title.split()[0]
+        return FitResult(
+            status=FitStatus.SUCCESS,
+            data={
+                "A": 0.4,
+                "A_err": 0.01,
+                "p": {"mcm-rb": 0.96, "delay-rb": 0.98}[protocol],
+                "p_err": -0.01,
+                "C": 0.5,
+                "C_err": 0.01,
+                "r2": 0.99,
+            },
+            figure=go.Figure(),
+        )
+
+    monkeypatch.setattr(mcm_module.fitting, "fit_rb", fake_fit_rb)
+
+    result = mcm_randomized_benchmarking(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        n_cliffords_range=[0, 1, 2],
+        n_trials=1,
+        seeds=[3],
+        protocols=("mcm-rb", "delay-rb"),
+        n_bootstrap=0,
+        plot=False,
+        print_summary=False,
+        enable_tqdm=False,
+    )
+
+    target_result = result.data["protocol_results"]["mcm-rb"]["Q0"]
+    induced_error = result.data["measurement_induced_errors"]["control"]["Q0"]
+    assert target_result["decay_parameter_uncertainty"] is None
+    assert target_result["error_per_cycle_uncertainty"] is None
+    assert target_result["uncertainty_method"] == "unavailable"
+    assert induced_error["uncertainty"] is None
+    assert induced_error["uncertainty_method"] == "unavailable"
+
+
 def test_fit_validity_reports_insufficient_points_and_low_r_squared(
     monkeypatch: pytest.MonkeyPatch,
     fake_experiment: Any,

--- a/tests/contrib/mcm_randomized_benchmarking/test_function_api.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_function_api.py
@@ -1,0 +1,11 @@
+"""Tests for MCM randomized benchmarking public exports."""
+
+from __future__ import annotations
+
+from qubex.contrib import mcm_randomized_benchmarking, mcm_rb_sequence
+
+
+def test_mcm_randomized_benchmarking_functions_are_exported() -> None:
+    """The contrib package should export the sequence and experiment helpers."""
+    assert callable(mcm_rb_sequence)
+    assert callable(mcm_randomized_benchmarking)

--- a/tests/contrib/mcm_randomized_benchmarking/test_sequence.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_sequence.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from typing import Any
 
+import numpy as np
 import pytest
 
 from qubex.contrib.experiment.mcm_randomized_benchmarking import (
@@ -267,6 +268,115 @@ def test_multiple_ancillas_require_matching_ramp_trimmed_active_windows(
                 "Q1": Rect(duration=64.0, amplitude=0.25, sampling_period=2.0),
                 "Q2": Rect(duration=80.0, amplitude=0.25, sampling_period=2.0),
             },
+        )
+
+
+def test_measurement_scale_uses_each_ancillas_own_calibrated_readout(
+    fake_experiment: Any,
+) -> None:
+    """A scalar scale should multiply each selected ancilla's own readout pulse."""
+    schedule = mcm_rb_sequence(
+        fake_experiment,
+        "Q0",
+        ["Q1", "Q2"],
+        protocol="mcm-rb",
+        n_cliffords=1,
+        seed=17,
+        measurement_scale=2.0,
+    )
+
+    assert np.max(np.abs(schedule.get_sequence("RQ1").values)) == pytest.approx(
+        0.4, rel=0.0, abs=1e-12
+    )
+    assert np.max(np.abs(schedule.get_sequence("RQ2").values)) == pytest.approx(
+        0.6, rel=0.0, abs=1e-12
+    )
+
+
+def test_measurement_scale_mapping_defaults_unlisted_ancillas_to_one(
+    fake_experiment: Any,
+) -> None:
+    """A partial scale mapping should leave unlisted ancillas calibrated."""
+    schedule = mcm_rb_sequence(
+        fake_experiment,
+        "Q0",
+        ["Q1", "Q2"],
+        protocol="mcm-rb",
+        n_cliffords=1,
+        seed=17,
+        measurement_scale={"Q1": 1.5},
+    )
+
+    assert np.max(np.abs(schedule.get_sequence("RQ1").values)) == pytest.approx(
+        0.3, rel=0.0, abs=1e-12
+    )
+    assert np.max(np.abs(schedule.get_sequence("RQ2").values)) == pytest.approx(
+        0.3, rel=0.0, abs=1e-12
+    )
+
+
+def test_measurement_scale_and_waveform_override_are_mutually_exclusive(
+    fake_experiment: Any,
+) -> None:
+    """Scaling and replacing the intermediate readout should be unambiguous."""
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            measurement_scale=2.0,
+            measurement_waveform=Rect(
+                duration=64.0,
+                amplitude=0.25,
+                sampling_period=2.0,
+            ),
+        )
+
+
+def test_measurement_scale_rejects_unselected_or_duplicate_targets(
+    fake_experiment: Any,
+) -> None:
+    """Scale mappings should refer uniquely to selected ancillas."""
+    with pytest.raises(ValueError, match="unselected target"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            measurement_scale={"Q2": 2.0},
+        )
+    with pytest.raises(ValueError, match="duplicate values"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            measurement_scale={"Q1": 1.5, "RQ1": 2.0},
+        )
+
+
+@pytest.mark.parametrize("scale", [True, 0.0, -1.0, np.nan, np.inf])
+def test_measurement_scale_rejects_invalid_values(
+    fake_experiment: Any,
+    scale: object,
+) -> None:
+    """Measurement scales should be positive finite real numbers."""
+    with pytest.raises((TypeError, ValueError), match="measurement_scale"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            measurement_scale=scale,  # type: ignore[arg-type]
         )
 
 

--- a/tests/contrib/mcm_randomized_benchmarking/test_sequence.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_sequence.py
@@ -7,7 +7,7 @@ from typing import Any
 import pytest
 
 from qubex.contrib.experiment.mcm_randomized_benchmarking import mcm_rb_sequence
-from qubex.pulse import Blank, Rect
+from qubex.pulse import Blank, FlatTop, PulseArray, Rect
 
 
 def test_protocols_match_duration_for_the_same_random_sequence(
@@ -86,6 +86,117 @@ def test_control_echo_places_two_pi_pulses_symmetrically_in_each_measurement(
     assert isinstance(measurement_block[4], Blank)
 
 
+def test_control_echo_uses_quarters_of_ramp_trimmed_active_readout(
+    fake_experiment: Any,
+) -> None:
+    """Echo pulse centers should quarter the ramp-trimmed active interval."""
+    measurement = PulseArray(
+        [
+            Blank(duration=16.0, sampling_period=2.0),
+            FlatTop(
+                duration=64.0,
+                amplitude=0.25,
+                tau=16.0,
+                sampling_period=2.0,
+            ).padded(total_duration=80.0),
+        ]
+    )
+
+    schedule = mcm_rb_sequence(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        protocol="mcm-rep",
+        n_cliffords=1,
+        seed=17,
+        control_echo=True,
+        measurement_waveform=measurement,
+    )
+
+    measurement_block = schedule.get_sequence("Q0").flattened_elements[1:6]
+
+    assert [element.duration for element in measurement_block] == [
+        28.0,
+        16.0,
+        8.0,
+        16.0,
+        28.0,
+    ]
+
+
+def test_control_echo_rejects_all_zero_measurement_waveform(
+    fake_experiment: Any,
+) -> None:
+    """Echo construction should require an identifiable active readout interval."""
+    with pytest.raises(ValueError, match="active readout interval"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            control_echo=True,
+            measurement_waveform=Blank(duration=64.0, sampling_period=2.0),
+        )
+
+
+def test_control_echo_rejects_ramp_off_sampling_grid(fake_experiment: Any) -> None:
+    """Echo construction should require a readout ramp on the sampling grid."""
+    measurement = FlatTop(
+        duration=64.0,
+        amplitude=0.25,
+        tau=3.0,
+        sampling_period=2.0,
+    )
+
+    with pytest.raises(ValueError, match="ramp duration"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            control_echo=True,
+            measurement_waveform=measurement,
+        )
+
+
+def test_control_echo_rejects_multiple_active_flat_top_pulses(
+    fake_experiment: Any,
+) -> None:
+    """Echo construction should reject an ambiguous multi-pulse active interval."""
+    measurement = PulseArray(
+        [
+            FlatTop(
+                duration=32.0,
+                amplitude=0.25,
+                tau=4.0,
+                sampling_period=2.0,
+            ),
+            FlatTop(
+                duration=32.0,
+                amplitude=0.25,
+                tau=4.0,
+                sampling_period=2.0,
+            ),
+        ]
+    )
+
+    with pytest.raises(ValueError, match="at most one FlatTop"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            control_echo=True,
+            measurement_waveform=measurement,
+        )
+
+
 def test_control_echo_rejects_measurements_shorter_than_two_pi_pulses(
     fake_experiment: Any,
 ) -> None:
@@ -105,10 +216,10 @@ def test_control_echo_rejects_measurements_shorter_than_two_pi_pulses(
 
 
 def test_control_echo_rejects_asymmetric_sampling_grid(fake_experiment: Any) -> None:
-    """Echo construction should reject free time that cannot split into quarters."""
+    """Echo construction should reject centers off the pulse sampling grid."""
     fake_experiment.pulse.measurement_duration = 66.0
 
-    with pytest.raises(ValueError, match="four equal"):
+    with pytest.raises(ValueError, match="sampling grid"):
         mcm_rb_sequence(
             fake_experiment,
             "Q0",
@@ -117,6 +228,24 @@ def test_control_echo_rejects_asymmetric_sampling_grid(fake_experiment: Any) -> 
             n_cliffords=1,
             seed=17,
             control_echo=True,
+        )
+
+
+def test_sequence_rejects_nested_waveform_sampling_period_mismatch(
+    fake_experiment: Any,
+) -> None:
+    """Sequence construction should validate every physical pulse sampling grid."""
+    measurement = PulseArray([Rect(duration=64.0, amplitude=0.25, sampling_period=1.0)])
+
+    with pytest.raises(ValueError, match="sampling period"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            measurement_waveform=measurement,
         )
 
 

--- a/tests/contrib/mcm_randomized_benchmarking/test_sequence.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_sequence.py
@@ -7,11 +7,20 @@ from typing import Any
 import pytest
 
 from qubex.contrib.experiment.mcm_randomized_benchmarking import mcm_rb_sequence
-from qubex.pulse import Blank, FlatTop, PulseArray, Rect
+from qubex.pulse import (
+    Blank,
+    FlatTop,
+    PulseArray,
+    Rect,
+    get_sampling_period,
+    set_sampling_period,
+)
 
 
+@pytest.mark.parametrize("control_echo", [False, True])
 def test_protocols_match_duration_for_the_same_random_sequence(
     fake_experiment: Any,
+    control_echo: bool,
 ) -> None:
     """All protocols should preserve the same total duration for one seed and length."""
     schedules = {
@@ -22,8 +31,9 @@ def test_protocols_match_duration_for_the_same_random_sequence(
             protocol=protocol,
             n_cliffords=2,
             seed=17,
+            control_echo=control_echo,
         )
-        for protocol in ("mcm-rb", "delay-rb", "mcm-rep")
+        for protocol in ("mcm-rb", "delay-rb", "mcm-rep", "delay-rep")
     }
 
     assert {schedule.duration for schedule in schedules.values()} == {160.0}
@@ -47,6 +57,37 @@ def test_protocols_match_duration_for_the_same_random_sequence(
         )
         == 2
     )
+    assert all(
+        isinstance(element, Blank)
+        for element in schedules["delay-rep"].get_sequence("RQ1").elements
+    )
+
+
+def test_sequence_synchronizes_the_global_pulse_sampling_period(
+    fake_experiment: Any,
+) -> None:
+    """Sequence construction should use the experiment sampling period globally."""
+    original_sampling_period = get_sampling_period()
+    try:
+        set_sampling_period(1.0)
+
+        schedule = mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+        )
+
+        assert get_sampling_period() == 2.0
+        assert schedule.duration == 80.0
+        assert schedule.is_valid()
+        assert {
+            schedule.get_sequence(label).sampling_period for label in schedule.labels
+        } == {2.0}
+    finally:
+        set_sampling_period(original_sampling_period)
 
 
 def test_randomized_ancilla_uses_seeded_flips_and_parity_recovery(
@@ -68,6 +109,7 @@ def test_randomized_ancilla_uses_seeded_flips_and_parity_recovery(
     recovery = None
     elapsed = 0.0
     for element in ancilla_elements:
+        assert isinstance(element, (Blank, Rect))
         if elapsed == 456.0:
             recovery = element
         if isinstance(element, Rect):
@@ -99,6 +141,7 @@ def test_randomized_ancilla_uses_blank_recovery_for_even_parity(
     recovery = None
     elapsed = 0.0
     for element in ancilla_elements:
+        assert isinstance(element, (Blank, Rect))
         if elapsed == 456.0:
             recovery = element
         elapsed += element.duration
@@ -108,10 +151,10 @@ def test_randomized_ancilla_uses_blank_recovery_for_even_parity(
     assert recovery.duration == 16.0
 
 
-def test_randomized_ancilla_pattern_is_shared_by_mcm_and_delay_protocols(
+def test_randomized_ancilla_pattern_is_shared_by_all_protocols(
     fake_experiment: Any,
 ) -> None:
-    """MCM and delay references should share the same randomized ancilla gates."""
+    """All protocols should share ancilla gates, recovery, and total duration."""
     schedules = {
         protocol: mcm_rb_sequence(
             fake_experiment,
@@ -122,28 +165,43 @@ def test_randomized_ancilla_pattern_is_shared_by_mcm_and_delay_protocols(
             seed=3,
             ancilla_mode="randomized",
         )
-        for protocol in ("mcm-rb", "delay-rb")
+        for protocol in ("mcm-rb", "delay-rb", "mcm-rep", "delay-rep")
     }
 
-    assert schedules["mcm-rb"].duration == schedules["delay-rb"].duration
+    assert len({schedule.duration for schedule in schedules.values()}) == 1
     assert (
-        schedules["mcm-rb"].get_sequence("Q1").values.tolist()
-        == schedules["delay-rb"].get_sequence("Q1").values.tolist()
-    )
-
-
-def test_randomized_ancilla_rejects_mcm_repetition(fake_experiment: Any) -> None:
-    """Randomized ancilla mode should require a Clifford-bearing protocol."""
-    with pytest.raises(ValueError, match="mcm-rep"):
-        mcm_rb_sequence(
-            fake_experiment,
-            "Q0",
-            "Q1",
-            protocol="mcm-rep",
-            n_cliffords=1,
-            seed=3,
-            ancilla_mode="randomized",
+        len(
+            {
+                tuple(schedule.get_sequence("Q1").values.tolist())
+                for schedule in schedules.values()
+            }
         )
+        == 1
+    )
+    expected_control_durations = [
+        duration
+        for clifford_duration in (8.0, 16.0, 8.0, 16.0, 8.0)
+        for duration in (clifford_duration, 16.0, 64.0)
+    ] + [16.0, 8.0]
+    for protocol in ("mcm-rep", "delay-rep"):
+        control_elements = schedules[protocol].get_sequence("Q0").flattened_elements
+        assert all(isinstance(element, Blank) for element in control_elements)
+        assert [
+            element.duration
+            for element in control_elements
+            if isinstance(element, Blank)
+        ] == expected_control_durations
+    assert all(
+        isinstance(element, Blank)
+        for element in schedules["delay-rep"].get_sequence("RQ1").elements
+    )
+    assert (
+        sum(
+            isinstance(element, Rect)
+            for element in schedules["mcm-rep"].get_sequence("RQ1").elements
+        )
+        == 5
+    )
 
 
 def test_randomized_ancilla_validates_x180_override(fake_experiment: Any) -> None:
@@ -249,6 +307,35 @@ def test_control_echo_places_two_pi_pulses_symmetrically_in_each_measurement(
     assert isinstance(measurement_block[4], Blank)
 
 
+def test_delay_repetition_keeps_control_echo_in_reference_windows(
+    fake_experiment: Any,
+) -> None:
+    """Delay repetition should retain control echo while blanking readout pulses."""
+    schedule = mcm_rb_sequence(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        protocol="delay-rep",
+        n_cliffords=2,
+        seed=17,
+        control_echo=True,
+        ancilla_mode="randomized",
+    )
+
+    control_elements = schedule.get_sequence("Q0").flattened_elements
+
+    assert (
+        sum(
+            isinstance(element, Rect) and element.duration == 16.0
+            for element in control_elements
+        )
+        == 4
+    )
+    assert all(
+        isinstance(element, Blank) for element in schedule.get_sequence("RQ1").elements
+    )
+
+
 def test_control_echo_uses_quarters_of_ramp_trimmed_active_readout(
     fake_experiment: Any,
 ) -> None:
@@ -278,7 +365,12 @@ def test_control_echo_uses_quarters_of_ramp_trimmed_active_readout(
 
     measurement_block = schedule.get_sequence("Q0").flattened_elements[1:6]
 
-    assert [element.duration for element in measurement_block] == [
+    assert all(isinstance(element, (Blank, Rect)) for element in measurement_block)
+    assert [
+        element.duration
+        for element in measurement_block
+        if isinstance(element, (Blank, Rect))
+    ] == [
         28.0,
         16.0,
         8.0,

--- a/tests/contrib/mcm_randomized_benchmarking/test_sequence.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_sequence.py
@@ -1,0 +1,169 @@
+"""Tests for MCM randomized benchmarking sequence construction."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from qubex.contrib.experiment.mcm_randomized_benchmarking import mcm_rb_sequence
+from qubex.pulse import Blank, Rect
+
+
+def test_protocols_match_duration_for_the_same_random_sequence(
+    fake_experiment: Any,
+) -> None:
+    """All protocols should preserve the same total duration for one seed and length."""
+    schedules = {
+        protocol: mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol=protocol,
+            n_cliffords=2,
+            seed=17,
+        )
+        for protocol in ("mcm-rb", "delay-rb", "mcm-rep")
+    }
+
+    assert {schedule.duration for schedule in schedules.values()} == {160.0}
+    assert all(schedule.labels == ["Q0", "RQ1"] for schedule in schedules.values())
+
+    assert (
+        sum(
+            isinstance(element, Rect)
+            for element in schedules["mcm-rb"].get_sequence("RQ1").elements
+        )
+        == 2
+    )
+    assert all(
+        isinstance(element, Blank)
+        for element in schedules["delay-rb"].get_sequence("RQ1").elements
+    )
+    assert (
+        sum(
+            isinstance(element, Rect)
+            for element in schedules["mcm-rep"].get_sequence("RQ1").elements
+        )
+        == 2
+    )
+
+
+def test_control_echo_places_two_pi_pulses_symmetrically_in_each_measurement(
+    fake_experiment: Any,
+) -> None:
+    """Echoed MCM repetition should place X pulses at one and three quarters."""
+    schedule = mcm_rb_sequence(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        protocol="mcm-rep",
+        n_cliffords=1,
+        seed=17,
+        control_echo=True,
+    )
+
+    control_elements = schedule.get_sequence("Q0").flattened_elements
+    echo_pulses = [
+        element
+        for element in control_elements
+        if isinstance(element, Rect) and element.duration == 16.0
+    ]
+    measurement_block = control_elements[1:6]
+
+    assert len(echo_pulses) == 2
+    assert [getattr(element, "duration", None) for element in measurement_block] == [
+        8.0,
+        16.0,
+        16.0,
+        16.0,
+        8.0,
+    ]
+    assert isinstance(measurement_block[0], Blank)
+    assert isinstance(measurement_block[1], Rect)
+    assert isinstance(measurement_block[2], Blank)
+    assert isinstance(measurement_block[3], Rect)
+    assert isinstance(measurement_block[4], Blank)
+
+
+def test_control_echo_rejects_measurements_shorter_than_two_pi_pulses(
+    fake_experiment: Any,
+) -> None:
+    """Echo construction should reject a measurement window shorter than two pi pulses."""
+    fake_experiment.pulse.measurement_duration = 24.0
+
+    with pytest.raises(ValueError, match="at least twice"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            control_echo=True,
+        )
+
+
+def test_control_echo_rejects_asymmetric_sampling_grid(fake_experiment: Any) -> None:
+    """Echo construction should reject free time that cannot split into quarters."""
+    fake_experiment.pulse.measurement_duration = 66.0
+
+    with pytest.raises(ValueError, match="four equal"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            control_echo=True,
+        )
+
+
+def test_unused_echo_override_is_ignored(fake_experiment: Any) -> None:
+    """An echo override should not be validated while control echo is disabled."""
+    incompatible_echo = Rect(
+        duration=16.0,
+        amplitude=1.0,
+        sampling_period=1.0,
+    )
+
+    schedule = mcm_rb_sequence(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        protocol="mcm-rb",
+        n_cliffords=1,
+        seed=17,
+        control_echo=False,
+        echo_x180=incompatible_echo,
+    )
+
+    assert schedule.duration == 80.0
+
+
+def test_boolean_clifford_count_is_rejected(fake_experiment: Any) -> None:
+    """A boolean should not be accepted as a randomized Clifford count."""
+    with pytest.raises(TypeError, match="nonnegative integer"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=True,
+            seed=17,
+        )
+
+
+@pytest.mark.parametrize("protocol", ["unknown", "mcm_rb"])
+def test_invalid_protocol_is_rejected(fake_experiment: Any, protocol: str) -> None:
+    """Sequence construction should reject protocol names outside the public literals."""
+    with pytest.raises(ValueError, match="protocol"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol=protocol,  # type: ignore[arg-type]
+            n_cliffords=1,
+            seed=17,
+        )

--- a/tests/contrib/mcm_randomized_benchmarking/test_sequence.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_sequence.py
@@ -6,7 +6,10 @@ from typing import Any
 
 import pytest
 
-from qubex.contrib.experiment.mcm_randomized_benchmarking import mcm_rb_sequence
+from qubex.contrib.experiment.mcm_randomized_benchmarking import (
+    MCMRBProtocol,
+    mcm_rb_sequence,
+)
 from qubex.pulse import (
     Blank,
     FlatTop,
@@ -88,6 +91,324 @@ def test_sequence_synchronizes_the_global_pulse_sampling_period(
         } == {2.0}
     finally:
         set_sampling_period(original_sampling_period)
+
+
+@pytest.mark.parametrize("protocol", ["mcm-rb", "delay-rb", "mcm-rep", "delay-rep"])
+def test_one_ancilla_with_multiple_controls_builds_matched_schedules(
+    fake_experiment: Any,
+    protocol: MCMRBProtocol,
+) -> None:
+    """One ancilla should support simultaneous independently randomized controls."""
+    schedule = mcm_rb_sequence(
+        fake_experiment,
+        ["Q0", "Q2"],
+        "Q1",
+        protocol=protocol,
+        n_cliffords=2,
+        seed=17,
+    )
+
+    assert schedule.labels == ["Q0", "Q2", "RQ1"]
+    assert schedule.duration == 160.0
+    assert schedule.is_valid()
+    for control in ("Q0", "Q2"):
+        control_elements = schedule.get_sequence(control).flattened_elements
+        if protocol.endswith("rep"):
+            assert all(isinstance(element, Blank) for element in control_elements)
+        else:
+            assert any(isinstance(element, Rect) for element in control_elements)
+
+
+def test_multiple_controls_use_reproducible_independent_clifford_seeds(
+    fake_experiment: Any,
+) -> None:
+    """Each simultaneous control should receive a reproducible independent seed."""
+    generator = fake_experiment.benchmarking_service.clifford_generator
+
+    mcm_rb_sequence(
+        fake_experiment,
+        ["Q0", "Q2"],
+        "Q1",
+        protocol="mcm-rb",
+        n_cliffords=2,
+        seed=17,
+    )
+    first_calls = list(generator.calls)
+    generator.calls.clear()
+    mcm_rb_sequence(
+        fake_experiment,
+        ["Q0", "Q2"],
+        "Q1",
+        protocol="mcm-rb",
+        n_cliffords=2,
+        seed=17,
+    )
+
+    assert generator.calls == first_calls
+    assert len(first_calls) == 2
+    assert first_calls[0][2] != first_calls[1][2]
+
+
+def test_protocols_match_when_controls_have_different_clifford_durations(
+    fake_experiment: Any,
+) -> None:
+    """Protocol matching should use the longest simultaneous control layer."""
+
+    class SeedDependentCliffordGenerator:
+        """Generate a seed-dependent physical Clifford duration."""
+
+        @staticmethod
+        def create_rb_sequences(
+            n: int,
+            type: str,
+            seed: int | None,
+        ) -> tuple[list[list[str]], list[str]]:
+            assert type == "1Q"
+            assert seed is not None
+            clifford = ["X90"] * (seed % 5 + 1)
+            return [clifford for _ in range(n)], ["X90"]
+
+    fake_experiment.benchmarking_service.clifford_generator = (
+        SeedDependentCliffordGenerator()
+    )
+
+    schedules = {
+        protocol: mcm_rb_sequence(
+            fake_experiment,
+            ["Q0", "Q2"],
+            "Q1",
+            protocol=protocol,
+            n_cliffords=1,
+            seed=17,
+        )
+        for protocol in ("mcm-rb", "delay-rb", "mcm-rep", "delay-rep")
+    }
+
+    assert {schedule.duration for schedule in schedules.values()} == {112.0}
+    assert all(schedule.is_valid() for schedule in schedules.values())
+
+
+def test_multiple_randomized_ancillas_use_independent_recoverable_streams(
+    fake_experiment: Any,
+) -> None:
+    """Each simultaneous ancilla should use an independent seeded I/X stream."""
+    schedule = mcm_rb_sequence(
+        fake_experiment,
+        "Q0",
+        ["Q1", "Q2"],
+        protocol="mcm-rb",
+        n_cliffords=12,
+        seed=3,
+        ancilla_mode="randomized",
+    )
+
+    assert schedule.labels == ["Q0", "Q1", "Q2", "RQ1", "RQ2"]
+    assert schedule.is_valid()
+    assert (
+        schedule.get_sequence("Q1").values.tolist()
+        != schedule.get_sequence("Q2").values.tolist()
+    )
+    for ancilla in ("Q1", "Q2"):
+        assert schedule.get_sequence(ancilla).duration == schedule.duration
+        assert (
+            sum(
+                isinstance(element, Rect)
+                for element in schedule.get_sequence(ancilla).flattened_elements
+            )
+            % 2
+            == 0
+        )
+
+
+def test_multiple_controls_and_ancillas_preserve_duration_with_echo(
+    fake_experiment: Any,
+) -> None:
+    """Many-to-many schedules should match duration and echo every control."""
+    schedules = {
+        protocol: mcm_rb_sequence(
+            fake_experiment,
+            ["Q0", "Q2"],
+            ["Q1", "Q3"],
+            protocol=protocol,
+            n_cliffords=2,
+            seed=17,
+            control_echo=True,
+            ancilla_mode="randomized",
+        )
+        for protocol in ("mcm-rb", "delay-rb", "mcm-rep", "delay-rep")
+    }
+
+    assert len({schedule.duration for schedule in schedules.values()}) == 1
+    assert all(schedule.is_valid() for schedule in schedules.values())
+    for schedule in schedules.values():
+        for control in ("Q0", "Q2"):
+            assert (
+                sum(
+                    isinstance(element, Rect) and element.duration == 16.0
+                    for element in schedule.get_sequence(control).flattened_elements
+                )
+                >= 4
+            )
+
+
+def test_multiple_ancillas_require_matching_ramp_trimmed_active_windows(
+    fake_experiment: Any,
+) -> None:
+    """Multiple ancillas should reject mismatched ramp-trimmed active windows."""
+    with pytest.raises(ValueError, match="ramp-trimmed active intervals"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            ["Q1", "Q2"],
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            measurement_waveform={
+                "Q1": Rect(duration=64.0, amplitude=0.25, sampling_period=2.0),
+                "Q2": Rect(duration=80.0, amplitude=0.25, sampling_period=2.0),
+            },
+        )
+
+
+def test_multiple_ancillas_reject_shifted_active_windows_with_equal_duration(
+    fake_experiment: Any,
+) -> None:
+    """Equal readout durations should not hide shifted ancilla active windows."""
+    measurement_waveforms = {
+        "Q1": PulseArray(
+            [
+                Blank(duration=8.0, sampling_period=2.0),
+                Rect(duration=64.0, amplitude=0.25, sampling_period=2.0),
+                Blank(duration=24.0, sampling_period=2.0),
+            ]
+        ),
+        "Q2": PulseArray(
+            [
+                Blank(duration=16.0, sampling_period=2.0),
+                Rect(duration=64.0, amplitude=0.25, sampling_period=2.0),
+                Blank(duration=16.0, sampling_period=2.0),
+            ]
+        ),
+    }
+
+    with pytest.raises(ValueError, match=r"Q1.*8\.0.*72\.0.*Q2.*16\.0.*80\.0"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            ["Q1", "Q2"],
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            measurement_waveform=measurement_waveforms,
+        )
+
+
+def test_matching_active_windows_allow_different_readout_slot_durations(
+    fake_experiment: Any,
+) -> None:
+    """Matching active windows should allow different trailing readout margins."""
+    original_sampling_period = get_sampling_period()
+    try:
+        set_sampling_period(2.0)
+        common_active_pulse = FlatTop(
+            duration=64.0,
+            amplitude=0.25,
+            tau=8.0,
+            sampling_period=2.0,
+        )
+        measurement_waveforms = {
+            "Q1": PulseArray(
+                [
+                    Blank(duration=8.0, sampling_period=2.0),
+                    common_active_pulse,
+                    Blank(duration=8.0, sampling_period=2.0),
+                ]
+            ),
+            "Q2": PulseArray(
+                [
+                    Blank(duration=8.0, sampling_period=2.0),
+                    common_active_pulse,
+                    Blank(duration=24.0, sampling_period=2.0),
+                ]
+            ),
+        }
+
+        schedule = mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            ["Q1", "Q2"],
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            control_echo=True,
+            measurement_waveform=measurement_waveforms,
+        )
+
+        assert schedule.duration == 112.0
+        assert schedule.is_valid()
+        assert schedule.get_sequence("RQ1").duration == 112.0
+        assert schedule.get_sequence("RQ2").duration == 112.0
+    finally:
+        set_sampling_period(original_sampling_period)
+
+
+def test_multiple_targets_require_target_keyed_waveform_overrides(
+    fake_experiment: Any,
+) -> None:
+    """A scalar override should be rejected for a multiple-target role."""
+    with pytest.raises(ValueError, match=r"x90.*mapping"):
+        mcm_rb_sequence(
+            fake_experiment,
+            ["Q0", "Q2"],
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            x90=Rect(duration=8.0, amplitude=0.5, sampling_period=2.0),
+        )
+
+
+@pytest.mark.parametrize(
+    ("control", "ancilla", "message"),
+    [
+        ([], ["Q1"], "control.*at least one"),
+        (["Q0", "RQ0"], ["Q1"], "control.*duplicate"),
+        (["Q0"], ["Q0", "Q1"], "disjoint"),
+    ],
+)
+def test_multiple_target_validation_rejects_ambiguous_groups(
+    fake_experiment: Any,
+    control: list[str],
+    ancilla: list[str],
+    message: str,
+) -> None:
+    """Multiple-target inputs should be nonempty, unique, and role-disjoint."""
+    with pytest.raises(ValueError, match=message):
+        mcm_rb_sequence(
+            fake_experiment,
+            control,
+            ancilla,
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+        )
+
+
+def test_target_validation_rejects_shared_terminal_readout_labels(
+    fake_experiment: Any,
+) -> None:
+    """Simultaneous targets should require distinct terminal readout labels."""
+    fake_experiment.experiment_system.resolve_read_label = lambda target: "RSHARED"
+
+    with pytest.raises(ValueError, match="distinct readout labels"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+        )
 
 
 def test_randomized_ancilla_uses_seeded_flips_and_parity_recovery(

--- a/tests/contrib/mcm_randomized_benchmarking/test_sequence.py
+++ b/tests/contrib/mcm_randomized_benchmarking/test_sequence.py
@@ -49,6 +49,169 @@ def test_protocols_match_duration_for_the_same_random_sequence(
     )
 
 
+def test_randomized_ancilla_uses_seeded_flips_and_parity_recovery(
+    fake_experiment: Any,
+) -> None:
+    """Randomized ancilla should follow a seeded I/X pattern and recover its parity."""
+    schedule = mcm_rb_sequence(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        protocol="mcm-rb",
+        n_cliffords=5,
+        seed=3,
+        ancilla_mode="randomized",
+    )
+
+    ancilla_elements = schedule.get_sequence("Q1").flattened_elements
+    pulse_starts: list[float] = []
+    recovery = None
+    elapsed = 0.0
+    for element in ancilla_elements:
+        if elapsed == 456.0:
+            recovery = element
+        if isinstance(element, Rect):
+            pulse_starts.append(elapsed)
+        elapsed += element.duration
+
+    assert schedule.labels == ["Q0", "Q1", "RQ1"]
+    assert schedule.duration == 480.0
+    assert schedule.is_valid()
+    assert pulse_starts == [8.0, 104.0, 288.0, 456.0]
+    assert isinstance(recovery, Rect)
+
+
+def test_randomized_ancilla_uses_blank_recovery_for_even_parity(
+    fake_experiment: Any,
+) -> None:
+    """An even randomized flip parity should end with a duration-matched blank."""
+    schedule = mcm_rb_sequence(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        protocol="mcm-rb",
+        n_cliffords=5,
+        seed=18,
+        ancilla_mode="randomized",
+    )
+
+    ancilla_elements = schedule.get_sequence("Q1").flattened_elements
+    recovery = None
+    elapsed = 0.0
+    for element in ancilla_elements:
+        if elapsed == 456.0:
+            recovery = element
+        elapsed += element.duration
+
+    assert sum(isinstance(element, Rect) for element in ancilla_elements) == 2
+    assert isinstance(recovery, Blank)
+    assert recovery.duration == 16.0
+
+
+def test_randomized_ancilla_pattern_is_shared_by_mcm_and_delay_protocols(
+    fake_experiment: Any,
+) -> None:
+    """MCM and delay references should share the same randomized ancilla gates."""
+    schedules = {
+        protocol: mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol=protocol,
+            n_cliffords=5,
+            seed=3,
+            ancilla_mode="randomized",
+        )
+        for protocol in ("mcm-rb", "delay-rb")
+    }
+
+    assert schedules["mcm-rb"].duration == schedules["delay-rb"].duration
+    assert (
+        schedules["mcm-rb"].get_sequence("Q1").values.tolist()
+        == schedules["delay-rb"].get_sequence("Q1").values.tolist()
+    )
+
+
+def test_randomized_ancilla_rejects_mcm_repetition(fake_experiment: Any) -> None:
+    """Randomized ancilla mode should require a Clifford-bearing protocol."""
+    with pytest.raises(ValueError, match="mcm-rep"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rep",
+            n_cliffords=1,
+            seed=3,
+            ancilla_mode="randomized",
+        )
+
+
+def test_randomized_ancilla_validates_x180_override(fake_experiment: Any) -> None:
+    """Randomized ancilla mode should validate its X180 pulse sampling grid."""
+    with pytest.raises(ValueError, match="ancilla_x180"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=3,
+            ancilla_mode="randomized",
+            ancilla_x180=Rect(
+                duration=16.0,
+                amplitude=1.0,
+                sampling_period=1.0,
+            ),
+        )
+
+
+def test_randomized_ancilla_uses_x180_override(fake_experiment: Any) -> None:
+    """Randomized ancilla gates and recovery should use the X180 override."""
+    schedule = mcm_rb_sequence(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        protocol="mcm-rb",
+        n_cliffords=1,
+        seed=3,
+        ancilla_mode="randomized",
+        ancilla_x180=Rect(
+            duration=12.0,
+            amplitude=0.8,
+            sampling_period=2.0,
+        ),
+    )
+
+    ancilla_pulses = [
+        element
+        for element in schedule.get_sequence("Q1").flattened_elements
+        if isinstance(element, Rect)
+    ]
+
+    assert [pulse.duration for pulse in ancilla_pulses] == [12.0, 12.0]
+    assert schedule.duration == 104.0
+
+
+def test_standard_ancilla_ignores_x180_override(fake_experiment: Any) -> None:
+    """Standard mode should not resolve or validate an unused ancilla X180."""
+    schedule = mcm_rb_sequence(
+        fake_experiment,
+        "Q0",
+        "Q1",
+        protocol="mcm-rb",
+        n_cliffords=1,
+        seed=3,
+        ancilla_x180=Rect(
+            duration=16.0,
+            amplitude=1.0,
+            sampling_period=1.0,
+        ),
+    )
+
+    assert schedule.labels == ["Q0", "RQ1"]
+    assert schedule.duration == 80.0
+
+
 def test_control_echo_places_two_pi_pulses_symmetrically_in_each_measurement(
     fake_experiment: Any,
 ) -> None:
@@ -295,4 +458,18 @@ def test_invalid_protocol_is_rejected(fake_experiment: Any, protocol: str) -> No
             protocol=protocol,  # type: ignore[arg-type]
             n_cliffords=1,
             seed=17,
+        )
+
+
+def test_invalid_ancilla_mode_is_rejected(fake_experiment: Any) -> None:
+    """Sequence construction should reject unknown ancilla modes."""
+    with pytest.raises(ValueError, match="ancilla_mode"):
+        mcm_rb_sequence(
+            fake_experiment,
+            "Q0",
+            "Q1",
+            protocol="mcm-rb",
+            n_cliffords=1,
+            seed=17,
+            ancilla_mode="unknown",  # type: ignore[arg-type]
         )


### PR DESCRIPTION
## Summary

This PR adds a mid-circuit measurement randomized benchmarking (MCM-RB) workflow for characterizing measurement-induced errors on measured ancilla qubits and unmeasured control/spectator qubits.

The core protocol structure follows Govia et al., *A randomized benchmarking suite for mid-circuit measurements*, New J. Phys. 25, 123016 (2023).

The following public functions are added:

- `mcm_rb_sequence()`
- `mcm_randomized_benchmarking()`

Both functions are exported from `qubex.contrib`.

## Background

Mid-circuit measurements can disturb not only the measured ancilla but also nearby spectator qubits through effects such as measurement-induced phase shifts, dephasing, transitions, leakage, and correlated errors.

This implementation is based on the MCM-RB suite proposed by Govia et al.:

- `mcm-rb`: interleave ancilla measurements with randomized Cliffords on the control
- `delay-rb`: replace each ancilla measurement with a duration-matched delay
- `mcm-rep`: replace control Cliffords with duration-matched delays while repeating ancilla measurements

Comparing the decay parameters of `mcm-rb` and `delay-rb` gives the IRB-style estimate

$$
\epsilon_{\mathrm{MCM}} = \frac{1}{2} \left(1-\frac{p_{\mathrm{mcm-rb}}}{p_{\mathrm{delay-rb}}}\right).
$$

As discussed in the paper, this estimate should be interpreted under the usual RB/IRB assumptions, including approximately Markovian and weakly gate-dependent errors. Its quantitative accuracy can also depend strongly on the error of the `delay-rb` reference.

## Implemented protocols

The implementation supports:

- `mcm-rb`
- `delay-rb`
- `mcm-rep`
- `delay-rep`

`delay-rep` is an additional matched reference in which both the control Clifford and ancilla measurement are replaced by duration-matched delays. It is used together with `mcm-rep` to estimate measurement-induced ancilla population error under the control-idle condition.

Default protocols are:

- standard ancilla mode:
  - `mcm-rb`
  - `delay-rb`
  - `mcm-rep`
- randomized ancilla mode:
  - `mcm-rb`
  - `delay-rb`

`mcm-rep` and `delay-rep` can be explicitly requested through `protocols`.

## Ancilla modes

Two ancilla modes are supported.

### Standard mode

```python
ancilla_mode="standard"
```

This follows the original MCM-RB suite: intermediate measurement outcomes are discarded, and only terminal control and ancilla measurements are analyzed.

### Randomized mode

```python
ancilla_mode="randomized"
```

Before each intermediate measurement or matched delay, each ancilla independently receives either an identity or X180 operation with equal probability.

A final parity-recovery operation returns the ancilla to its expected state before terminal measurement.

This extension allows the terminal ancilla population decay to be compared between matched measurement and delay protocols.

## Control echo

The optional

```python
control_echo=True
```

inserts two X180 pulses on every control during each intermediate measurement or matched delay window.

The X180 pulse centers are placed at the quarter and three-quarter points of the ramp-trimmed active readout interval. The interval is obtained by removing half of the readout ramp duration from each side of the active interval.

The same echo is retained in the corresponding delay protocols so that protocol durations and control conditions remain matched.

## Intermediate readout overrides

Intermediate ancilla readouts can be changed using either:

```python
measurement_scale=2.0
```

or:

```python
measurement_waveform=custom_readout
```

Both scalar and target-keyed mappings are supported.

`measurement_scale` scales each selected ancilla's own calibrated readout pulse. It affects only the intermediate measurements; terminal measurements continue to use the calibrated default readout.

The result metadata records, for each ancilla:

- waveform source
- applied scale
- duration
- peak amplitude
- integrated power
- ramp-trimmed active interval

## Multi-qubit support

The workflow supports:

- one ancilla and multiple controls
- multiple ancillas and one control
- multiple ancillas and multiple controls

Each control receives an independent reproducible Clifford stream, and each randomized ancilla receives an independent reproducible I/X180 stream.

For simultaneous measurements of multiple ancillas, all ramp-trimmed active readout intervals are required to match. A `ValueError` is raised when they do not.

The control error reported for multiple ancillas characterizes their simultaneous combined readout and does not attribute the error to an individual ancilla.

## Analysis

For each protocol and terminal-measurement target, the workflow returns:

- trial-resolved terminal ground-state probabilities
- mean and standard deviation
- exponential-fit result
- decay parameter
- error or decay metric per cycle
- uncertainty estimate
- bootstrap diagnostics
- fit-validity diagnostics

Paired bootstrap resampling uses the same resampled trial/root-seed columns across sequence lengths, protocols, and targets. This preserves correlations when calculating decay-parameter ratios.

Fit validity checks include:

- optimizer success
- sufficient sequence lengths
- finite fit parameters and uncertainties
- parameters at fit bounds
- optional minimum R-squared

Non-finite terminal probabilities and numerical bootstrap-fit failures are retained as unavailable/failed fits without discarding the acquired raw trial data.

When requested, compact protocol-fit and measurement-induced-error summary tables are printed after analysis.

## Measurement-induced error results

The returned result contains target-keyed estimates under:

```python
result.data["measurement_induced_errors"]
```

with the following groups:

- `control`
  - `mcm-rb` compared with `delay-rb`
- `ancilla_population_with_cliffords`
  - randomized-ancilla `mcm-rb` compared with `delay-rb`
- `ancilla_population_with_control_delay`
  - randomized-ancilla `mcm-rep` compared with `delay-rep`

An estimate is `None` when its matched protocol pair was not executed or its decay ratio cannot be evaluated.

The repetition-protocol fits should be interpreted as population-decay metrics rather than general average gate errors because the control is not Clifford twirled and, in standard mode, the ancilla is not I/X180 randomized.

## API impact

This PR only adds new public APIs and does not change existing experiment APIs.

No compatibility aliases or migration steps are required because the functionality has not previously been released.

## Validation

The following checks pass:

```text
uv run ruff check
uv run pyright
uv run pytest tests/contrib/mcm_randomized_benchmarking -q
```

MCM-RB test result:

```text
83 passed
```

The tests cover:

- all protocol schedules and duration matching
- randomized ancilla parity recovery
- control blanking and echo placement
- ramp-trimmed active-window validation
- measurement scaling and waveform overrides
- one-to-many and many-to-many target configurations
- terminal-capture analysis
- paired bootstrap behavior
- fit-validity diagnostics
- measurement-induced error calculation
- metadata and summary output
- invalid input handling

The complete repository test suite was not completed locally because an unrelated QuEL-1 backend async test hangs in the current environment. Full static checks and all MCM-RB-specific tests pass.

## Reference

L. C. G. Govia, P. Jurcevic, C. J. Wood, N. Kanazawa, S. T. Merkel, and D. C. McKay,  
“A randomized benchmarking suite for mid-circuit measurements,”  
*New Journal of Physics* **25**, 123016 (2023).  
https://doi.org/10.1088/1367-2630/ad0e19
