### PR TITLE
fix: enable time integration in measure_state by default

### DIFF
--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -2073,6 +2073,7 @@ class Experiment:
         mode: MeasurementMode | None = None,
         n_shots: int | None = None,
         shot_interval: float | None = None,
+        time_integration: bool | None = None,
         readout_amplitudes: dict[str, float] | None = None,
         readout_duration: float | None = None,
         readout_pre_margin: float | None = None,
@@ -2094,6 +2095,9 @@ class Experiment:
             Number of shots.
         shot_interval : float, optional
             Interval between shots in ns.
+        time_integration : bool, optional
+            Whether to integrate captured waveforms over time. Defaults to True when
+            omitted or None.
         readout_amplitudes : dict[str, float], optional
             Readout amplitude for each target.
         readout_duration : float, optional
@@ -2127,6 +2131,7 @@ class Experiment:
             mode=mode,
             n_shots=n_shots,
             shot_interval=shot_interval,
+            time_integration=time_integration,
             readout_amplitudes=readout_amplitudes,
             readout_duration=readout_duration,
             readout_pre_margin=readout_pre_margin,

--- a/src/qubex/experiment/services/measurement_service.py
+++ b/src/qubex/experiment/services/measurement_service.py
@@ -887,6 +887,7 @@ class MeasurementService:
         mode: MeasurementMode | None = None,
         n_shots: int | None = None,
         shot_interval: float | None = None,
+        time_integration: bool | None = None,
         readout_amplitudes: dict[str, float] | None = None,
         readout_duration: float | None = None,
         readout_pre_margin: float | None = None,
@@ -898,6 +899,8 @@ class MeasurementService:
         """Prepare given states and measure readout results."""
         if mode is None:
             mode = "single"
+        if time_integration is None:
+            time_integration = True
         if plot is None:
             plot = False
 
@@ -927,6 +930,7 @@ class MeasurementService:
             mode=mode,
             n_shots=n_shots,
             shot_interval=shot_interval,
+            time_integration=time_integration,
             readout_amplitudes=readout_amplitudes,
             readout_duration=readout_duration,
             readout_pre_margin=readout_pre_margin,

--- a/src/qubex/experiment/services/measurement_service.py
+++ b/src/qubex/experiment/services/measurement_service.py
@@ -899,7 +899,10 @@ class MeasurementService:
         """Prepare given states and measure readout results."""
         if mode is None:
             mode = "single"
-        if time_integration is None:
+        if (
+            time_integration is None
+            and deprecated_options.get("enable_dsp_sum") is None
+        ):
             time_integration = True
         if plot is None:
             plot = False

--- a/tests/experiment/test_experiment_facade_delegation.py
+++ b/tests/experiment/test_experiment_facade_delegation.py
@@ -63,6 +63,10 @@ class _MeasurementServiceStub:
         self.calls.append(("measure", {"sequence": sequence, **kwargs}))
         return "measure_result"
 
+    def measure_state(self, states: object, **kwargs: Any) -> str:
+        self.calls.append(("measure_state", {"states": states, **kwargs}))
+        return "measure_state_result"
+
     def capture_loopback(self, schedule: object, **kwargs: Any) -> str:
         self.calls.append(("capture_loopback", {"schedule": schedule, **kwargs}))
         return "capture_loopback_result"
@@ -628,6 +632,32 @@ def test_measure_delegates_time_integration_to_measurement_service() -> None:
             },
         )
     ]
+
+
+def test_measure_state_delegates_unset_time_integration_by_default() -> None:
+    """Given no integration option, measure_state should delegate it as unset."""
+    exp = object.__new__(Experiment)
+    measurement_stub = _MeasurementServiceStub()
+    exp.__dict__["_measurement_service"] = measurement_stub
+
+    result = exp.measure_state(states={"Q00": "g"})
+
+    assert result == "measure_state_result"
+    assert measurement_stub.calls[0][0] == "measure_state"
+    assert measurement_stub.calls[0][1]["time_integration"] is None
+
+
+def test_measure_state_delegates_disabled_time_integration() -> None:
+    """Given integration disabled, measure_state should delegate the waveform opt-out."""
+    exp = object.__new__(Experiment)
+    measurement_stub = _MeasurementServiceStub()
+    exp.__dict__["_measurement_service"] = measurement_stub
+
+    result = exp.measure_state(states={"Q00": "g"}, time_integration=False)
+
+    assert result == "measure_state_result"
+    assert measurement_stub.calls[0][0] == "measure_state"
+    assert measurement_stub.calls[0][1]["time_integration"] is False
 
 
 def test_build_measurement_schedule_delegates_to_measurement_service() -> None:

--- a/tests/experiment/test_measurement_service_registry_resolution.py
+++ b/tests/experiment/test_measurement_service_registry_resolution.py
@@ -458,3 +458,17 @@ def test_measure_state_can_disable_time_integration() -> None:
 
     measure_calls = cast(list[dict[str, object]], captured["measure_calls"])
     assert measure_calls[0]["time_integration"] is False
+
+
+def test_measure_state_preserves_legacy_time_integration_opt_out() -> None:
+    """Given legacy integration disabled, measure_state should defer alias resolution."""
+    service, captured = _make_service()
+
+    service.measure_state(
+        states={"custom-target": "g"},
+        enable_dsp_sum=False,
+    )
+
+    measure_calls = cast(list[dict[str, object]], captured["measure_calls"])
+    assert measure_calls[0]["time_integration"] is None
+    assert measure_calls[0]["enable_dsp_sum"] is False

--- a/tests/experiment/test_measurement_service_registry_resolution.py
+++ b/tests/experiment/test_measurement_service_registry_resolution.py
@@ -422,3 +422,39 @@ def test_measure_state_resolves_ef_labels_via_target_registry() -> None:
     )
 
     assert captured["labels"] == ["custom-target", "Q17-ef"]
+
+
+def test_measure_state_enables_time_integration_by_default() -> None:
+    """Given no integration option, measure_state should enable time integration."""
+    service, captured = _make_service()
+
+    service.measure_state(states={"custom-target": "g"})
+
+    measure_calls = cast(list[dict[str, object]], captured["measure_calls"])
+    assert measure_calls[0]["time_integration"] is True
+
+
+def test_measure_state_enables_time_integration_for_none() -> None:
+    """Given integration unset, measure_state should enable time integration."""
+    service, captured = _make_service()
+
+    service.measure_state(
+        states={"custom-target": "g"},
+        time_integration=None,
+    )
+
+    measure_calls = cast(list[dict[str, object]], captured["measure_calls"])
+    assert measure_calls[0]["time_integration"] is True
+
+
+def test_measure_state_can_disable_time_integration() -> None:
+    """Given integration disabled, measure_state should preserve the waveform opt-out."""
+    service, captured = _make_service()
+
+    service.measure_state(
+        states={"custom-target": "g"},
+        time_integration=False,
+    )
+
+    measure_calls = cast(list[dict[str, object]], captured["measure_calls"])
+    assert measure_calls[0]["time_integration"] is False


### PR DESCRIPTION
## Background

`MeasurementService.measure_state()` previously delegated to `measure()` without enabling time integration. State measurements normally need one integrated IQ value per shot, so using available DSP integration reduces waveform transfer and client-side processing.

Closes #365.

## Summary

- add `time_integration: bool | None = None` to `MeasurementService.measure_state()`
- resolve an omitted or `None` value to `True` inside `MeasurementService`
- expose and document the option through the thin `Experiment.measure_state()` facade
- preserve `time_integration=False` for callers that need full waveform data
- cover omitted, explicit `None`, and explicit `False` behavior at the service and facade layers

## API and compatibility

The effective default for `measure_state()` is now time integration enabled. Existing waveform callers can preserve the previous behavior by passing `time_integration=False` explicitly.

## Validation

- `uv run ruff check --fix` — passed
- `uv run ruff format` — 543 files unchanged
- `uv run pyright` — 0 errors
- focused experiment tests — 52 passed
- `uv run pytest` — 1,536 passed
- `uv run mkdocs build` — passed with existing repository warnings
