### PR TITLE
feat: add dictionary-configured Tukey windows to SQUAD

### DIFF
--- a/packages/qxpulse/src/qxpulse/library/flat_top.py
+++ b/packages/qxpulse/src/qxpulse/library/flat_top.py
@@ -17,7 +17,7 @@ from .multi_derivative import MultiDerivative
 from .raised_cosine import RaisedCosine
 from .ramp_type import RampType
 from .sintegral import Sintegral
-from .squad import Squad
+from .squad import Squad, _resolve_window
 
 
 class FlatTop(Pulse):
@@ -35,6 +35,15 @@ class FlatTop(Pulse):
     beta : float, optional
         DRAG correction coefficient. Default is None.
 
+    Notes
+    -----
+    flat-top period = duration - 2 * tau
+
+    For `type="Squad"`, `window` accepts the string or dictionary settings
+    documented by `Squad`, for example
+    `window={"type": "tukey", "rise_end": 0.2, "fall_start": 0.7}`.
+    Window dictionaries are validated and copied on construction.
+
     Examples
     --------
     >>> pulse = FlatTop(
@@ -43,9 +52,6 @@ class FlatTop(Pulse):
     ...     tau=10,
     ... )
 
-    Notes
-    -----
-    flat-top period = duration - 2 * tau
     """
 
     def __init__(
@@ -69,6 +75,14 @@ class FlatTop(Pulse):
         shape_kwargs = {
             key: value for key, value in kwargs.items() if key not in pulse_kwargs
         }
+        window = shape_kwargs.get("window")
+        if type == "Squad" and isinstance(window, dict):
+            _resolve_window(
+                window,
+                shape_kwargs.get("beta_mode", 1.0 / 3.0),
+                shape_kwargs.get("beta_sum", 5.0),
+            )
+            shape_kwargs["window"] = window.copy()
         super().__init__(
             duration=duration,
             **pulse_kwargs,

--- a/packages/qxpulse/src/qxpulse/library/squad.py
+++ b/packages/qxpulse/src/qxpulse/library/squad.py
@@ -2,15 +2,117 @@
 
 from __future__ import annotations
 
-from typing import Final, Literal
+from numbers import Real
+from typing import Final, Literal, TypeAlias, TypedDict, cast
 
 import numpy as np
 from numpy.typing import ArrayLike, NDArray
-from typing_extensions import override
+from typing_extensions import NotRequired, override
 
 from qxpulse.pulse import Pulse
 
-SmoothingType = Literal["none", "hann", "beta"]
+SmoothingType = Literal["none", "hann", "tukey", "beta"]
+
+
+class SimpleWindowConfig(TypedDict):
+    """Parameter-free SQUAD ramp window configuration."""
+
+    type: Literal["none", "hann"]
+
+
+class TukeyWindowConfig(TypedDict):
+    """Tukey window positions in normalized ramp time, each defaulting to 0.5."""
+
+    type: Literal["tukey"]
+    rise_end: NotRequired[float]
+    fall_start: NotRequired[float]
+
+
+class BetaWindowConfig(TypedDict):
+    """Beta window mode and parameter sum, defaulting to 1/3 and 5 respectively."""
+
+    type: Literal["beta"]
+    mode: NotRequired[float]
+    sum: NotRequired[float]
+
+
+WindowConfig: TypeAlias = SimpleWindowConfig | TukeyWindowConfig | BetaWindowConfig
+WindowSpec: TypeAlias = SmoothingType | WindowConfig
+
+
+def _real_window_parameter(value: object, name: str) -> float:
+    if isinstance(value, bool) or not isinstance(value, Real):
+        raise TypeError(f"window {name} must be a real number.")
+    return float(value)
+
+
+def _resolve_window(
+    window: object,
+    beta_mode: float = 1.0 / 3.0,
+    beta_sum: float = 5.0,
+) -> tuple[SmoothingType, float, float, float, float]:
+    """Resolve a window without modifying the caller's configuration."""
+    if window is None:
+        return "hann", beta_mode, beta_sum, 0.5, 0.5
+    if isinstance(window, str):
+        if window not in ("none", "hann", "tukey", "beta"):
+            raise ValueError(f"Invalid window type: {window}")
+        return cast(SmoothingType, window), beta_mode, beta_sum, 0.5, 0.5
+    if not isinstance(window, dict):
+        raise TypeError("window must be a string or dictionary.")
+
+    kind = window.get("type")
+    if not isinstance(kind, str) or kind not in ("none", "hann", "tukey", "beta"):
+        raise ValueError("window dictionary requires a valid 'type'.")
+    allowed = {"type"}
+    if kind == "tukey":
+        allowed.update(("rise_end", "fall_start"))
+    elif kind == "beta":
+        allowed.update(("mode", "sum"))
+    if any(key not in allowed for key in window):
+        raise ValueError(f"Unexpected window keys for {kind}: {set(window) - allowed}")
+    if beta_mode != 1.0 / 3.0 or beta_sum != 5.0:
+        raise ValueError(
+            "A window dictionary cannot be combined with nondefault beta_mode or beta_sum."
+        )
+
+    rise_end = fall_start = 0.5
+    if kind == "tukey":
+        rise_end = _real_window_parameter(window.get("rise_end", 0.5), "rise_end")
+        fall_start = _real_window_parameter(window.get("fall_start", 0.5), "fall_start")
+        if not (0.0 <= rise_end <= fall_start <= 1.0):
+            raise ValueError(
+                "window positions must satisfy 0 <= rise_end <= fall_start <= 1."
+            )
+    elif kind == "beta":
+        beta_mode = _real_window_parameter(window.get("mode", 1.0 / 3.0), "mode")
+        beta_sum = _real_window_parameter(window.get("sum", 5.0), "sum")
+        if not (0.0 <= beta_mode <= 1.0 and np.isfinite(beta_sum) and beta_sum > 2.0):
+            raise ValueError(
+                "window beta mode must be in [0, 1] and sum must be finite and > 2."
+            )
+
+    return cast(SmoothingType, kind), beta_mode, beta_sum, rise_end, fall_start
+
+
+def _integrated_tukey(u: NDArray, *, rise_end: float, fall_start: float) -> NDArray:
+    """Return the normalized Tukey integral for normalized times in [0, 1]."""
+    # The unit-height window has area a/2 + (b-a) + (1-b)/2.
+    area = (1.0 + fall_start - rise_end) / 2.0
+    integral = u - rise_end / 2.0
+
+    if rise_end > 0.0:
+        rising = u < rise_end
+        x = u[rising]
+        integral[rising] = (x - rise_end / np.pi * np.sin(np.pi * x / rise_end)) / 2.0
+
+    if fall_start < 1.0:
+        falling = u > fall_start
+        x = 1.0 - u[falling]
+        width = 1.0 - fall_start
+        integral[falling] = area - (x - width / np.pi * np.sin(np.pi * x / width)) / 2.0
+
+    return integral / area
 
 
 class Squad(Pulse):
@@ -27,6 +129,8 @@ class Squad(Pulse):
     - "none" : constant-adiabatic ramp (FAQUAD-like, ε(t) = const)
     - "hann" : smooth adiabatic ramp using a sin^2(pi u) window
                (integrated to g(u) = u - sin(2πu)/(2π)).
+    - "tukey" : normalized integral of a Tukey window with independent
+                rise-end and fall-start positions within each ramp.
     - "beta" : smooth adiabatic ramp using the regularized incomplete
                beta function I_u(α, β) with fixed shape parameters.
 
@@ -37,22 +141,55 @@ class Squad(Pulse):
     amplitude : float
         Flat-top amplitude of the pulse.
     delta : float
-        Detuning parameter for Counter-Diabatic term in GHz.
+        Signed detuning parameter in the same units as `amplitude`.
+        For qxsimulator, both are angular rates in rad/ns. The caller is
+        responsible for mapping the detuning and quadrature sign conventions.
     tau : float
         Rise and fall time (each side) in ns.
     factor : float, optional
         Strength of the quadrature (Q) component. If 0, no CD term.
         If None, defaults to 1.0.
-    window : {"none", "hann", "beta"}, optional
-        Window type for the SQUAD ramp. Default is "hann".
+    window : str or WindowConfig, optional
+        Window type or dictionary with a required `type` key. Default is
+        "hann". String choices are "none", "hann", "tukey", and "beta".
+        Tukey dictionaries accept `rise_end` and `fall_start`, both defaulting
+        to 0.5, with `0 <= rise_end <= fall_start <= 1`. These normalized
+        positions end the window's rise and begin its fall. Both at 0.5
+        reproduce Hann; (0, 1) reproduces "none". Beta dictionaries accept
+        `mode` (default 1/3, range [0, 1]) and `sum` (default 5, finite and > 2).
+        Other windows accept only `type`. Unknown keys are rejected.
+        Dictionaries are copied on construction and cannot be combined with
+        nondefault `beta_mode` or `beta_sum` arguments.
     beta_mode : float, optional
         Mode of the beta distribution for window="beta". Default is 1/3.
     beta_sum : float, optional
         Sum of alpha and beta parameters for window="beta". Default is 5.0.
 
+    Raises
+    ------
+    TypeError
+        If a dictionary's numeric settings are not real numbers.
+    ValueError
+        If a window dictionary has missing/unknown keys, invalid values,
+        or conflicts with separate beta arguments.
+
     Notes
     -----
     flat-top period = duration - 2 * tau
+
+    Window positions refer to normalized time `u=t/tau` inside the rising
+    SQUAD ramp, not to the full pulse. The falling SQUAD ramp is its time
+    reverse, including the window. Thus an asymmetric Tukey window does not
+    change the equal outer ramp durations `tau` or the pulse's flat top.
+    The window is integrated and normalized before the SQUAD mapping; it
+    does not multiply the final I/Q envelope.
+
+    Examples
+    --------
+    >>> pulse = Squad(
+    ...     duration=40, amplitude=0.6, delta=0.8, tau=12,
+    ...     window={"type": "tukey", "rise_end": 0.2, "fall_start": 0.7},
+    ... )
     """
 
     def __init__(
@@ -63,11 +200,17 @@ class Squad(Pulse):
         delta: float,
         tau: float,
         factor: float | None = None,
-        window: SmoothingType | None = None,
+        window: WindowSpec | None = None,
         beta_mode: float = 1.0 / 3.0,
         beta_sum: float = 5.0,
         **kwargs,
     ):
+        removed = {"tukey_rise_end", "tukey_fall_start"}.intersection(kwargs)
+        if removed:
+            raise TypeError(
+                f"Unexpected SQUAD options {sorted(removed)}; use a window dictionary."
+            )
+        _resolve_window(window, beta_mode, beta_sum)
         super().__init__(
             duration=duration,
             **kwargs,
@@ -77,7 +220,7 @@ class Squad(Pulse):
         self.delta: Final = delta
         self.tau: Final = tau
         self.factor: Final = factor
-        self.window: Final = window
+        self.window: Final = window.copy() if isinstance(window, dict) else window
         self.beta_mode: Final = beta_mode
         self.beta_sum: Final = beta_sum
         self._finalize_initialization()
@@ -110,7 +253,7 @@ class Squad(Pulse):
         tau: float,
         amplitude: float,
         delta: float,
-        window: SmoothingType | None = None,
+        window: WindowSpec | None = None,
         beta_mode: float = 1.0 / 3.0,
         beta_sum: float = 5.0,
     ) -> NDArray:
@@ -121,8 +264,9 @@ class Squad(Pulse):
             sin θ(t) = sin θ_max * g(u),   u = t / tau ∈ [0,1],
         for each window type.
         """
-        if window is None:
-            window = "hann"
+        window, beta_mode, beta_sum, rise_end, fall_start = _resolve_window(
+            window, beta_mode, beta_sum
+        )
 
         t = np.asarray(t, dtype=float)
         values = np.zeros_like(t, dtype=float)
@@ -157,6 +301,9 @@ class Squad(Pulse):
             # Smooth ε(t) ∝ sin^2(πu) → g(u) = ∫ ε ∝ u - sin(2πu)/(2π)
             g_u = u_sel - np.sin(2.0 * np.pi * u_sel) / (2.0 * np.pi)
 
+        elif window == "tukey":
+            g_u = _integrated_tukey(u_sel, rise_end=rise_end, fall_start=fall_start)
+
         elif window == "beta":
             # Beta-shaped smooth ramp:
             # use regularized incomplete beta I_u(α,β) as g(u)
@@ -186,7 +333,7 @@ class Squad(Pulse):
         amplitude: float,
         delta: float,
         tau: float,
-        window: SmoothingType | None = None,
+        window: WindowSpec | None = None,
         beta_mode: float = 1.0 / 3.0,
         beta_sum: float = 5.0,
     ) -> NDArray:
@@ -252,7 +399,7 @@ class Squad(Pulse):
         tau: float,
         delta: float,
         factor: float | None = None,
-        window: SmoothingType | None = None,
+        window: WindowSpec | None = None,
         beta_mode: float = 1.0 / 3.0,
         beta_sum: float = 5.0,
     ) -> NDArray:
@@ -261,7 +408,13 @@ class Squad(Pulse):
 
         Returns `I(t) + i Q(t)`, where `I(t)` is the flat-top envelope with
         chosen SQUAD ramps and `Q(t)` is the scaled counter-diabatic quadrature.
+
+        A window dictionary such as
+        `{"type": "tukey", "rise_end": 0.2, "fall_start": 0.7}` sets the
+        normalized positions within each ramp. Omitted positions default to
+        0.5 (Hann). See `Squad` for validation and time-reversal conventions.
         """
+        _resolve_window(window, beta_mode, beta_sum)
         t = np.asarray(t, dtype=float)
 
         if duration <= 0:

--- a/tests/pulse/test_squad.py
+++ b/tests/pulse/test_squad.py
@@ -1,0 +1,357 @@
+"""Tests for SQUAD ramp windows and sampled CD conventions."""
+
+from typing import Any
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from qxpulse import FlatTop
+from qxpulse.library.squad import Squad, TukeyWindowConfig
+from scipy.integrate import quad
+
+
+@pytest.mark.parametrize("sampling_period", [0.1, 2.0])
+@pytest.mark.parametrize("delta", [-0.8, 0.8])
+@pytest.mark.parametrize("factor", [None, 0.0, 1.0, -1.0])
+def test_tukey_midpoints_match_hann(sampling_period, delta, factor):
+    """Tukey positions (0.5, 0.5) reproduce the full sampled Hann I/Q pulse."""
+    kwargs: dict[str, Any] = dict(
+        duration=40.0,
+        amplitude=0.6,
+        delta=delta,
+        tau=12.0,
+        factor=factor,
+    )
+    hann = Squad(**kwargs, window="hann", sampling_period=sampling_period)
+    tukey = Squad(
+        **kwargs,
+        window={"type": "tukey", "rise_end": 0.5, "fall_start": 0.5},
+        sampling_period=sampling_period,
+    )
+
+    assert_allclose(tukey.values, hann.values, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("window", ["tukey", {"type": "tukey"}])
+def test_tukey_defaults_match_hann(window):
+    """Selecting Tukey without positions defaults to the Hann limit."""
+    kwargs: dict[str, Any] = dict(duration=40.0, amplitude=0.6, delta=0.8, tau=12.0)
+    assert_allclose(
+        Squad(**kwargs, window=window).values,
+        Squad(**kwargs).values,
+        rtol=1e-12,
+        atol=1e-14,
+    )
+
+
+@pytest.mark.parametrize(
+    ("rise_end", "fall_start"),
+    [
+        (0.2, 0.7),
+        (0.1, 0.4),
+        (0.7, 0.9),
+        (0.3, 0.3),
+        (0, 0.7),
+        (0.2, 1),
+        (0, 0),
+        (1, 1),
+        (0, 1),
+    ],
+)
+def test_tukey_matches_independent_window_integral(rise_end, fall_start):
+    """SQUAD uses the normalized integral of the specified asymmetric Tukey window."""
+
+    def window(u):
+        if u < rise_end:
+            return 0.5 * (1 - np.cos(np.pi * u / rise_end))
+        if u > fall_start:
+            return 0.5 * (1 - np.cos(np.pi * (1 - u) / (1 - fall_start)))
+        return 1.0
+
+    u = np.unique(np.r_[np.linspace(0, 1, 17), rise_end, fall_start])
+    area = quad(window, 0, 1, points=[rise_end, fall_start], epsabs=1e-13)[0]
+    g = np.array(
+        [
+            quad(
+                window,
+                0,
+                x,
+                points=[p for p in (rise_end, fall_start) if p < x],
+                epsabs=1e-13,
+            )[0]
+            / area
+            for x in u
+        ]
+    )
+    s = np.sin(np.arctan(0.6 / 0.8)) * g
+    expected = 0.8 * s / np.sqrt(1 - s**2)
+
+    actual = Squad.func(
+        12 * u,
+        duration=40,
+        amplitude=0.6,
+        delta=0.8,
+        tau=12,
+        factor=0,
+        window={"type": "tukey", "rise_end": rise_end, "fall_start": fall_start},
+    )
+
+    assert_allclose(actual, expected, rtol=1e-12, atol=1e-14)
+    assert np.all(np.diff(actual.real) >= -1e-14)
+
+
+def test_tukey_rectangle_matches_constant_adiabatic_ramp():
+    """Tukey positions (0, 1) reproduce the existing constant-adiabatic window."""
+    kwargs: dict[str, Any] = dict(duration=40, amplitude=0.6, delta=0.8, tau=12)
+    assert_allclose(
+        Squad(
+            **kwargs, window={"type": "tukey", "rise_end": 0, "fall_start": 1}
+        ).values,
+        Squad(**kwargs, window="none").values,
+        rtol=1e-12,
+        atol=1e-14,
+    )
+
+
+@pytest.mark.parametrize("lazy", [False, True])
+def test_tukey_constructor_matches_func_and_preserves_pulse_symmetry(lazy):
+    """An asymmetric ramp window is reversed on the falling side of the pulse."""
+    kwargs: dict[str, Any] = dict(
+        duration=40,
+        amplitude=0.6,
+        delta=0.8,
+        tau=12,
+        factor=0.7,
+        window={"type": "tukey", "rise_end": 0.2, "fall_start": 0.6},
+    )
+    pulse = Squad(**kwargs, sampling_period=0.1, lazy=lazy)
+    t = (np.arange(pulse.length) + 0.5) * pulse.sampling_period
+    values = pulse.values
+
+    assert_allclose(values, Squad.func(t, **kwargs), rtol=1e-12, atol=1e-14)
+    assert_allclose(values.real, values.real[::-1], rtol=1e-12, atol=1e-14)
+    assert_allclose(values.imag, -values.imag[::-1], rtol=1e-12, atol=1e-14)
+    assert_allclose(values[(t >= 12) & (t <= 28)].real, 0.6, rtol=0, atol=1e-14)
+
+
+@pytest.mark.parametrize("delta", [-0.8, 0.8])
+@pytest.mark.parametrize("factor", [-1.0, 0.0, 1.0])
+def test_tukey_preserves_direct_cd_sign(delta, factor):
+    """Direct SQUAD keeps Q = factor * delta * dI/dt / (delta**2 + I**2)."""
+    t = np.linspace(0, 40, 401)
+    values = Squad.func(
+        t,
+        duration=40,
+        amplitude=0.6,
+        delta=delta,
+        tau=12,
+        factor=factor,
+        window={"type": "tukey", "rise_end": 0.2, "fall_start": 0.7},
+    )
+    expected_q = (
+        factor * delta * np.gradient(values.real, t) / (delta**2 + values.real**2)
+    )
+    assert_allclose(values.imag, expected_q, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("sampling_period", [0.1, 2.0])
+def test_flat_top_forwards_tukey_positions_with_existing_cd_mapping(sampling_period):
+    """FlatTop forwards the window positions and retains its opposite CD factor convention."""
+    kwargs: dict[str, Any] = dict(
+        duration=40,
+        amplitude=0.6,
+        delta=0.8,
+        tau=12,
+        window={"type": "tukey", "rise_end": 0.2, "fall_start": 0.7},
+    )
+    direct = Squad(**kwargs, factor=1, sampling_period=sampling_period)
+    flat = FlatTop(
+        **kwargs,
+        type="Squad",
+        correction_type="CD",
+        correction_factor=-1,
+        sampling_period=sampling_period,
+    )
+    assert_allclose(flat.values, direct.values, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize(
+    ("rise_end", "fall_start"),
+    [
+        (-0.1, 0.5),
+        (0.2, 1.1),
+        (0.8, 0.2),
+        (np.nan, 0.5),
+        (0.5, np.nan),
+        (np.inf, 1),
+        (0, np.inf),
+        (-np.inf, 1),
+    ],
+)
+@pytest.mark.parametrize("duration", [0, 40])
+def test_tukey_rejects_invalid_positions_at_public_entry_points(
+    rise_end, fall_start, duration
+):
+    """Nonfinite, out-of-range, or reversed Tukey positions fail even for lazy or empty pulses."""
+    kwargs: dict[str, Any] = dict(
+        duration=duration,
+        amplitude=0.6,
+        delta=0.8,
+        tau=0,
+        factor=0,
+        window={"type": "tukey", "rise_end": rise_end, "fall_start": fall_start},
+    )
+    message = r"0 <= rise_end <= fall_start <= 1"
+    with pytest.raises(ValueError, match=message):
+        Squad(**kwargs)
+    with pytest.raises(ValueError, match=message):
+        Squad.func([0.0], **kwargs)
+
+
+@pytest.mark.parametrize("window", ["none", "hann", "beta"])
+def test_window_dict_matches_existing_string(window):
+    """A dictionary with only type reproduces the corresponding string defaults."""
+    kwargs: dict[str, Any] = dict(duration=40, amplitude=0.6, delta=0.8, tau=12)
+    assert_allclose(
+        Squad(**kwargs, window={"type": window}).values,
+        Squad(**kwargs, window=window).values,
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize("lazy", [True, False])
+@pytest.mark.parametrize("wrapper", [False, True])
+def test_window_dict_is_detached_from_caller(lazy, wrapper):
+    """Changing the caller's dictionary cannot change either pulse's sampled waveform."""
+    window = {"type": "tukey", "rise_end": 0.2, "fall_start": 0.7}
+    kwargs: dict[str, Any] = dict(
+        duration=40, amplitude=0.6, delta=0.8, tau=12, window=window, lazy=lazy
+    )
+    if wrapper:
+        pulse = FlatTop(**kwargs, type="Squad")
+        expected = FlatTop(**kwargs, type="Squad").values.copy()
+    else:
+        pulse = Squad(**kwargs)
+        expected = Squad(**kwargs).values.copy()
+    assert window == {"type": "tukey", "rise_end": 0.2, "fall_start": 0.7}
+    window["rise_end"] = 0.6
+    window["fall_start"] = 0.9
+    assert_allclose(pulse.values, expected, rtol=0, atol=0)
+
+
+@pytest.mark.parametrize(
+    "window",
+    [
+        {},
+        {"rise_end": 0.2},
+        {"type": "unknown"},
+        {"type": []},
+        {"type": "hann", "rise_end": 0.2},
+        {"type": "tukey", "rise_edn": 0.2},
+        {"type": "tukey", "mode": 0.2},
+        {"type": "beta", "rise_end": 0.2},
+    ],
+)
+def test_window_dict_rejects_invalid_schema(window):
+    """Missing types, unknown windows, misspellings, and unrelated keys are rejected."""
+    kwargs: dict[str, Any] = dict(
+        duration=0, amplitude=0.6, delta=0.8, tau=0, window=window
+    )
+    with pytest.raises(ValueError, match="window"):
+        Squad(**kwargs)
+    with pytest.raises(ValueError, match="window"):
+        Squad.func([], **kwargs)
+    with pytest.raises(ValueError, match="window"):
+        FlatTop(**kwargs, type="Squad")
+
+
+@pytest.mark.parametrize("bad_value", ["0.2", None, True, [0.2], 0.2j])
+def test_tukey_dict_requires_real_positions(bad_value):
+    """Position values must be real numbers rather than strings, booleans, or containers."""
+    with pytest.raises(TypeError, match="rise_end"):
+        Squad(
+            duration=40,
+            amplitude=0.6,
+            delta=0.8,
+            tau=12,
+            window={"type": "tukey", "rise_end": bad_value},
+        )
+
+
+@pytest.mark.parametrize("position", ["rise_end", "fall_start"])
+def test_single_tukey_position_defaults_the_other_to_half(position):
+    """Either omitted Tukey position independently defaults to 0.5."""
+    value = 0.2 if position == "rise_end" else 0.7
+    kwargs: dict[str, Any] = dict(duration=40, amplitude=0.6, delta=0.8, tau=12)
+    supplied: TukeyWindowConfig = {"type": "tukey"}
+    expected: TukeyWindowConfig = {"type": "tukey", "rise_end": 0.5, "fall_start": 0.5}
+    if position == "rise_end":
+        supplied["rise_end"] = expected["rise_end"] = value
+    else:
+        supplied["fall_start"] = expected["fall_start"] = value
+    assert_allclose(
+        Squad(**kwargs, window=supplied).values,
+        Squad(**kwargs, window=expected).values,
+        rtol=0,
+        atol=0,
+    )
+
+
+def test_beta_dict_matches_legacy_parameters():
+    """Beta dictionary settings reproduce the existing beta_mode and beta_sum API."""
+    kwargs: dict[str, Any] = dict(duration=40, amplitude=0.6, delta=0.8, tau=12)
+    assert_allclose(
+        Squad(**kwargs, window={"type": "beta", "mode": 0.4, "sum": 6.0}).values,
+        Squad(**kwargs, window="beta", beta_mode=0.4, beta_sum=6.0).values,
+        rtol=0,
+        atol=0,
+    )
+
+
+@pytest.mark.parametrize("options", [{"beta_mode": 0.4}, {"beta_sum": 6.0}])
+def test_dictionary_rejects_conflicting_legacy_beta_options(options):
+    """Dictionary settings cannot silently override separate nondefault beta arguments."""
+    kwargs: dict[str, Any] = dict(
+        duration=40,
+        amplitude=0.6,
+        delta=0.8,
+        tau=12,
+        window={"type": "beta", "mode": 0.2},
+        **options,
+    )
+    with pytest.raises(ValueError, match=r"beta_mode.*beta_sum"):
+        Squad(**kwargs)
+
+
+@pytest.mark.parametrize(
+    "window",
+    [
+        {"type": "beta", "mode": np.nan},
+        {"type": "beta", "sum": np.inf},
+        {"type": "beta", "mode": -0.1},
+        {"type": "beta", "mode": 1.1},
+        {"type": "beta", "sum": 2.0},
+    ],
+)
+def test_beta_dict_rejects_invalid_shape(window):
+    """Beta dictionaries require a finite mode in [0, 1] and a finite sum above two."""
+    with pytest.raises(ValueError, match="window"):
+        Squad(duration=40, amplitude=0.6, delta=0.8, tau=12, window=window)
+
+
+@pytest.mark.parametrize("option", ["tukey_rise_end", "tukey_fall_start"])
+def test_tukey_positions_are_not_separate_pulse_options(option):
+    """The withdrawn unpublished Tukey keywords must not be silently accepted."""
+    kwargs: dict[str, Any] = dict(
+        duration=40,
+        amplitude=0.6,
+        delta=0.8,
+        tau=12,
+        window={"type": "tukey"},
+        **{option: 0.2},
+    )
+    with pytest.raises(TypeError, match=option):
+        Squad(**kwargs)
+    with pytest.raises(TypeError, match=option):
+        Squad.func([0.0], **kwargs)


### PR DESCRIPTION
## Summary

Add an independently positioned, two-edge Tukey window to SQUAD, configured through `window` rather than adding Tukey-specific pulse arguments:

```python
from qxpulse.library.squad import Squad

pulse = Squad(
    duration=40,
    amplitude=0.6,
    delta=0.8,
    tau=12,
    window={"type": "tukey", "rise_end": 0.2, "fall_start": 0.7},
)
```

- Both positions default to 0.5, reproducing the existing Hann I/Q waveform. Positions (0, 1) reproduce the constant-adiabatic window.
- Use the normalized analytic integral of the Tukey window inside each SQUAD ramp. The falling ramp remains the time reverse of the rising ramp; outer ramp duration `tau` is unchanged.
- Accept typed dictionaries with required `type`, validate keys and values, and copy caller dictionaries for both direct `Squad` and `FlatTop(type="Squad")`, including lazy sampling.
- Preserve string settings, the Hann default, legacy string-based `beta_mode`/`beta_sum`, and existing CD sign conventions. Beta dictionaries accept `mode`/`sum`; nondefault legacy beta arguments cannot be mixed with dictionary settings.
- Do not introduce the unpublished `tukey_rise_end`/`tukey_fall_start` constructor options. Reject those options rather than silently ignoring them.
- Document the dictionary API and clarify that `delta` and amplitude share units (angular rates for qxsimulator).

## Scope and compatibility

One feature commit on `develop`, touching only SQUAD, the FlatTop dictionary boundary, and focused pulse tests. No experiment-task documentation, dependencies, release metadata, hardware execution, or simulator-study results are included.

This is an additive window/configuration API. It does not claim improved physical-Z fidelity or exact multilevel counterdiabatic control.

## Validation

Using the existing repository environment with `uv run --no-sync`:

- `pytest tests/pulse/test_squad.py tests/pulse/test_flat_top.py tests/pulse/test_lazy_sampling.py -q`: **106 passed**.
- `pytest tests/pulse/test_squad.py --collect-only -q`: **86 collected**.
- `pytest -q`: **1623 passed**.
- `ruff check --fix`, `ruff format`, and `pyright`: passed; **0 type errors**.
- `mkdocs build --site-dir <temporary-output-directory>`: succeeded; warnings remain in unrelated, unchanged documentation.
- `git diff --check`: passed.

Tests include independent numerical integration, Hann/constant limits, 0.1 ns and 2 ns sampling, both detuning signs, CD-factor mapping, asymmetric windows, input validation, and caller-dictionary mutation isolation.
