### PR TITLE
refactor: require dictionary SQUAD windows and clarify pulse units

### DIFF
--- a/docs/release-notes/v1-5-0-migration.ja.md
+++ b/docs/release-notes/v1-5-0-migration.ja.md
@@ -31,6 +31,36 @@
 - simulator の `Control` 補間を、明示的に sample した waveform へ置き換える
 - sweep、plot、timing utility で固定 `2 ns` を使わないようにする
 
+## SQUAD の window 引数と単位
+
+`Squad`、`Squad.func`、および `FlatTop` / `FlatTop.func` の SQUAD 経路から、
+単独の `beta_mode` / `beta_sum` 引数を削除しました。
+旧デフォルト値を明示した場合も `TypeError` になります。
+非推奨期間は設けません。window 辞書へ置き換えてください。
+
+```python
+pulse = Squad(
+    duration=40, amplitude=0.6, delta=-0.8, tau=12, factor=0,
+    window={"type": "beta", "mode": 0.4, "sum": 6.0},
+)
+```
+
+文字列 `window="beta"` は引き続き mode=1/3、sum=5 を使います。
+Tukey の設定も従来どおり辞書で渡します。
+
+amplitude は包絡線の振幅であり、carrier 周波数ではありません。
+amplitude と設計 delta（遷移周波数 − drive 周波数）は同じ単位で渡します。
+delta は carrier を設定しません。時間を ns とすると、解析的な CD 係数の大きさは、
+角周波数単位（rad/ns）なら 1、通常の周波数単位（GHz）なら `1/(2*pi)`、
+制御振幅単位なら Rabi 換算 r（GHz/command）に対して `1/(2*pi*r)` です。
+最後の場合は `delta=(f_transition-f_drive)/r` を渡します。
+同じ CD 直交成分を得るには、直接の `Squad.factor` と
+`FlatTop.correction_factor` の符号を反転します。波形の計算式・符号規約は変更していません。
+
+drive 周波数に追従して SQUAD を設計する場合は各周波数で delta を再計算します。
+delta を固定する場合は、意図的に同じ波形の carrier のみを掃引する実験です。
+波形を再生成する場合は chevron の解釈も変わります。詳細は API docstring を参照してください。
+
 ## インストールと実行環境の変更
 
 `v1.5.0` の repository workflow は `uv` 管理環境を前提にしています。

--- a/docs/release-notes/v1-5-0-migration.md
+++ b/docs/release-notes/v1-5-0-migration.md
@@ -33,6 +33,37 @@ imports, the upgrade is usually straightforward.
 - Replace simulator `Control` interpolation with explicitly sampled waveforms
 - Remove hardcoded `2 ns` assumptions from sweeps, plots, and timing utilities
 
+## SQUAD window arguments and units
+
+Standalone `beta_mode` and `beta_sum` arguments have been removed from
+`Squad`, `Squad.func`, and the SQUAD paths of `FlatTop` and `FlatTop.func`.
+They now raise `TypeError`, including explicitly supplied former defaults.
+There is no deprecation period. Replace them with a window dictionary:
+
+```python
+pulse = Squad(
+    duration=40, amplitude=0.6, delta=-0.8, tau=12, factor=0,
+    window={"type": "beta", "mode": 0.4, "sum": 6.0},
+)
+```
+
+The string `window="beta"` still uses mode 1/3 and sum 5.
+Tukey settings continue to use the same dictionary interface.
+
+Amplitude is an envelope level, not the carrier frequency. Amplitude and
+design delta (transition minus drive) must use the same units. Delta does not
+set the carrier. For time in ns, the analytic CD coefficient magnitude is 1
+with angular-rate inputs (rad/ns), `1/(2*pi)` with cyclic-rate inputs (GHz),
+or `1/(2*pi*r)` with command amplitudes and Rabi conversion r in GHz/command.
+In the last case, pass `delta=(f_transition-f_drive)/r`.
+Direct `Squad.factor` has the opposite sign to `FlatTop.correction_factor`
+for the same CD quadrature. Pulse arithmetic and sign conventions are unchanged.
+
+Recompute delta per drive frequency for carrier-adaptive SQUAD design.
+Holding delta fixed instead deliberately scans one waveform's carrier;
+regenerating the waveform changes the interpretation of a chevron.
+See the API docstrings for the complete conventions.
+
 ## Installation and environment changes
 
 The `v1.5.0` repository workflow assumes a `uv`-managed environment.

--- a/packages/qxpulse/src/qxpulse/library/flat_top.py
+++ b/packages/qxpulse/src/qxpulse/library/flat_top.py
@@ -17,23 +17,35 @@ from .multi_derivative import MultiDerivative
 from .raised_cosine import RaisedCosine
 from .ramp_type import RampType
 from .sintegral import Sintegral
-from .squad import Squad, _resolve_window
+from .squad import Squad, _reject_removed_window_options, _resolve_window
 
 
 class FlatTop(Pulse):
     """
-    A class to represent a raised cosine flat-top pulse.
+    Flat-top pulse with configurable ramps and optional quadrature correction.
 
     Parameters
     ----------
     duration : float
         Duration of the pulse in ns.
     amplitude : float
-        Amplitude of the pulse.
+        Flat-top in-phase envelope level, not a carrier frequency. For SQUAD
+        or delta-based correction, use the same units as `delta`.
     tau : float
         Rise and fall time of the pulse in ns.
     beta : float, optional
         DRAG correction coefficient. Default is None.
+    delta : float, optional
+        Transition frequency minus drive frequency, in the same units as
+        `amplitude`. Required for SQUAD ramps or delta-based correction.
+        Shapes the waveform; does not set or shift its carrier frequency.
+    type : RampType, optional
+        Ramp shape, default "RaisedCosine". Use "Squad" for SQUAD.
+    correction_type : {"DRAG", "CD"}, optional
+        Quadrature correction. None (default) disables delta-based correction.
+    correction_factor : float, optional
+        Signed coefficient for delta-based correction. None defaults to 1.0
+        when correction is enabled. Units and sign are described in Notes.
 
     Notes
     -----
@@ -43,6 +55,26 @@ class FlatTop(Pulse):
     documented by `Squad`, for example
     `window={"type": "tukey", "rise_end": 0.2, "fall_start": 0.7}`.
     Window dictionaries are validated and copied on construction.
+    Beta settings likewise use `window={"type": "beta", "mode": 0.4, "sum": 6}`;
+    standalone `beta_mode` and `beta_sum` are no longer accepted for SQUAD.
+
+    Before generic Pulse transforms, the envelope is `I + i*Q`. CD uses
+    `Q = -correction_factor * delta * dI/dt / (delta**2 + I**2)` and DRAG uses
+    `Q = -correction_factor * dI/dt / delta`. Thus weak-drive CD approaches
+    DRAG with the same signed delta and coefficient. Using the negative
+    anharmonicity as delta for EF relative to a GE drive follows this convention.
+    Direct `Squad` uses the opposite factor sign for equivalent quadrature.
+
+    Time is in ns. With angular-rate amplitude/delta (rad/ns), the analytic
+    CD coefficient is 1; with cyclic-rate amplitude/delta (GHz), it is
+    `1/(2*pi)`. With command amplitude and Rabi conversion r (GHz/command),
+    use `delta = (f_transition - f_drive)/r` and coefficient `1/(2*pi*r)`.
+    No unit inference or conversion is performed. These coefficients describe
+    the design model, not a hardware calibration. See `Squad` for details.
+
+    Configure the carrier separately. Recompute delta at each drive frequency
+    for carrier-adaptive SQUAD design; keep a fixed design delta only when
+    intentionally scanning one fixed waveform's carrier.
 
     Examples
     --------
@@ -76,12 +108,10 @@ class FlatTop(Pulse):
             key: value for key, value in kwargs.items() if key not in pulse_kwargs
         }
         window = shape_kwargs.get("window")
+        if type == "Squad":
+            _reject_removed_window_options(shape_kwargs)
         if type == "Squad" and isinstance(window, dict):
-            _resolve_window(
-                window,
-                shape_kwargs.get("beta_mode", 1.0 / 3.0),
-                shape_kwargs.get("beta_sum", 5.0),
-            )
+            _resolve_window(window)
             shape_kwargs["window"] = window.copy()
         super().__init__(
             duration=duration,
@@ -143,13 +173,21 @@ class FlatTop(Pulse):
         duration : float
             Duration of the pulse in ns.
         amplitude : float
-            Amplitude of the pulse.
+            In-phase level in the same units as `delta`, not carrier frequency.
         tau : float
             Rise and fall time of the pulse in ns.
         beta : float, optional
             DRAG correction coefficient. Default is None.
         type : RampType | None, optional
             Type of the pulse. Default is "RaisedCosine".
+        delta : float, optional
+            Signed transition-minus-drive design detuning. See `FlatTop`
+            for conversion between angular rates, GHz, and command units.
+        correction_type : {"DRAG", "CD"}, optional
+            Delta-based quadrature correction; None disables it.
+        correction_factor : float, optional
+            Signed, unit-dependent coefficient; None defaults to 1.0.
+            See `FlatTop` for the CD formula and sign relative to `Squad`.
 
         Returns
         -------
@@ -158,6 +196,9 @@ class FlatTop(Pulse):
         """
         if type is None:
             type = "RaisedCosine"
+        if type == "Squad":
+            _reject_removed_window_options(kwargs)
+            _resolve_window(kwargs.get("window"))
 
         t = np.asarray(t)
         T = 2 * tau

--- a/packages/qxpulse/src/qxpulse/library/squad.py
+++ b/packages/qxpulse/src/qxpulse/library/squad.py
@@ -40,6 +40,20 @@ WindowConfig: TypeAlias = SimpleWindowConfig | TukeyWindowConfig | BetaWindowCon
 WindowSpec: TypeAlias = SmoothingType | WindowConfig
 
 
+def _reject_removed_window_options(options: dict) -> None:
+    """Reject removed standalone window parameters before lazy sampling."""
+    removed = {
+        "beta_mode",
+        "beta_sum",
+        "tukey_rise_end",
+        "tukey_fall_start",
+    }.intersection(options)
+    if removed:
+        raise TypeError(
+            f"Unexpected SQUAD options {sorted(removed)}; use a window dictionary."
+        )
+
+
 def _real_window_parameter(value: object, name: str) -> float:
     if isinstance(value, bool) or not isinstance(value, Real):
         raise TypeError(f"window {name} must be a real number.")
@@ -48,10 +62,10 @@ def _real_window_parameter(value: object, name: str) -> float:
 
 def _resolve_window(
     window: object,
-    beta_mode: float = 1.0 / 3.0,
-    beta_sum: float = 5.0,
 ) -> tuple[SmoothingType, float, float, float, float]:
     """Resolve a window without modifying the caller's configuration."""
+    beta_mode = 1.0 / 3.0
+    beta_sum = 5.0
     if window is None:
         return "hann", beta_mode, beta_sum, 0.5, 0.5
     if isinstance(window, str):
@@ -71,11 +85,6 @@ def _resolve_window(
         allowed.update(("mode", "sum"))
     if any(key not in allowed for key in window):
         raise ValueError(f"Unexpected window keys for {kind}: {set(window) - allowed}")
-    if beta_mode != 1.0 / 3.0 or beta_sum != 5.0:
-        raise ValueError(
-            "A window dictionary cannot be combined with nondefault beta_mode or beta_sum."
-        )
-
     rise_end = fall_start = 0.5
     if kind == "tukey":
         rise_end = _real_window_parameter(window.get("rise_end", 0.5), "rise_end")
@@ -139,16 +148,18 @@ class Squad(Pulse):
     duration : float
         Total duration of the pulse in ns.
     amplitude : float
-        Flat-top amplitude of the pulse.
+        Flat-top in-phase envelope level, not the carrier frequency. Use the
+        same units as `delta`; there is no automatic unit conversion.
     delta : float
-        Signed detuning parameter in the same units as `amplitude`.
-        For qxsimulator, both are angular rates in rad/ns. The caller is
-        responsible for mapping the detuning and quadrature sign conventions.
+        Signed design detuning, transition frequency minus drive frequency,
+        expressed in the same units as `amplitude`. Shapes the envelope and
+        CD quadrature; does not set or shift the carrier. See Notes for units.
     tau : float
         Rise and fall time (each side) in ns.
     factor : float, optional
-        Strength of the quadrature (Q) component. If 0, no CD term.
-        If None, defaults to 1.0.
+        Signed CD coefficient; 0 disables CD and None defaults to 1.0.
+        Its magnitude depends on the amplitude units. Its sign is opposite
+        to `FlatTop.correction_factor` for equivalent quadrature (see Notes).
     window : str or WindowConfig, optional
         Window type or dictionary with a required `type` key. Default is
         "hann". String choices are "none", "hann", "tukey", and "beta".
@@ -158,24 +169,42 @@ class Squad(Pulse):
         reproduce Hann; (0, 1) reproduces "none". Beta dictionaries accept
         `mode` (default 1/3, range [0, 1]) and `sum` (default 5, finite and > 2).
         Other windows accept only `type`. Unknown keys are rejected.
-        Dictionaries are copied on construction and cannot be combined with
-        nondefault `beta_mode` or `beta_sum` arguments.
-    beta_mode : float, optional
-        Mode of the beta distribution for window="beta". Default is 1/3.
-    beta_sum : float, optional
-        Sum of alpha and beta parameters for window="beta". Default is 5.0.
+        Dictionaries are copied on construction. Standalone `beta_mode` and
+        `beta_sum` arguments have been removed; use the dictionary keys.
 
     Raises
     ------
     TypeError
-        If a dictionary's numeric settings are not real numbers.
+        If a dictionary's numeric settings are not real numbers, or removed
+        standalone window parameters are supplied.
     ValueError
-        If a window dictionary has missing/unknown keys, invalid values,
-        or conflicts with separate beta arguments.
+        If a window dictionary has missing/unknown keys or invalid values.
 
     Notes
     -----
     flat-top period = duration - 2 * tau
+
+    Before any generic Pulse scale/phase/detuning transforms, the envelope
+    is `I + i*Q` with `Q = factor * delta * dI/dt / (delta**2 + I**2)`.
+    `FlatTop(type="Squad", correction_type="CD")` uses the opposite sign:
+    set `factor = -correction_factor` to match it on the same sampling grid.
+
+    Time is in ns. If K is the angular Rabi rate in rad/ns per numeric
+    amplitude unit, the analytic CD coefficient magnitude is `1/K`.
+    For angular-rate inputs (rad/ns), use magnitude 1. For cyclic-rate
+    inputs (GHz = cycles/ns), use `1/(2*pi)`. For command amplitudes with
+    calibrated Rabi conversion r in GHz per command unit, pass
+    `delta = (f_transition - f_drive)/r` and use magnitude `1/(2*pi*r)`.
+    For example, amplitude 0.99 in command units must not be combined with
+    an unconverted GHz detuning. Qubit Rabi conversion is a model input,
+    not a guarantee of strong-drive hardware response. qxsimulator expects
+    angular-rate envelopes even though Control.frequency uses cyclic GHz.
+
+    The carrier is configured separately. For carrier-adaptive pulse design,
+    recompute `delta` from each drive frequency and regenerate the waveform.
+    Holding a design delta fixed instead scans the carrier of a fixed
+    waveform; these are different experiments. In particular, adapting delta
+    changes the waveform throughout a chevron and its fit interpretation.
 
     Window positions refer to normalized time `u=t/tau` inside the rising
     SQUAD ramp, not to the full pulse. The falling SQUAD ramp is its time
@@ -201,16 +230,10 @@ class Squad(Pulse):
         tau: float,
         factor: float | None = None,
         window: WindowSpec | None = None,
-        beta_mode: float = 1.0 / 3.0,
-        beta_sum: float = 5.0,
         **kwargs,
     ):
-        removed = {"tukey_rise_end", "tukey_fall_start"}.intersection(kwargs)
-        if removed:
-            raise TypeError(
-                f"Unexpected SQUAD options {sorted(removed)}; use a window dictionary."
-            )
-        _resolve_window(window, beta_mode, beta_sum)
+        _reject_removed_window_options(kwargs)
+        _resolve_window(window)
         super().__init__(
             duration=duration,
             **kwargs,
@@ -221,8 +244,6 @@ class Squad(Pulse):
         self.tau: Final = tau
         self.factor: Final = factor
         self.window: Final = window.copy() if isinstance(window, dict) else window
-        self.beta_mode: Final = beta_mode
-        self.beta_sum: Final = beta_sum
         self._finalize_initialization()
 
     @override
@@ -239,8 +260,6 @@ class Squad(Pulse):
             tau=self.tau,
             factor=self.factor,
             window=self.window,
-            beta_mode=self.beta_mode,
-            beta_sum=self.beta_sum,
         )
 
     # ------------------------------------------------------------------
@@ -254,8 +273,6 @@ class Squad(Pulse):
         amplitude: float,
         delta: float,
         window: WindowSpec | None = None,
-        beta_mode: float = 1.0 / 3.0,
-        beta_sum: float = 5.0,
     ) -> NDArray:
         """
         Rising (or falling, if t is time-reversed) SQUAD ramp.
@@ -264,9 +281,7 @@ class Squad(Pulse):
             sin θ(t) = sin θ_max * g(u),   u = t / tau ∈ [0,1],
         for each window type.
         """
-        window, beta_mode, beta_sum, rise_end, fall_start = _resolve_window(
-            window, beta_mode, beta_sum
-        )
+        window, beta_mode, beta_sum, rise_end, fall_start = _resolve_window(window)
 
         t = np.asarray(t, dtype=float)
         values = np.zeros_like(t, dtype=float)
@@ -334,8 +349,6 @@ class Squad(Pulse):
         delta: float,
         tau: float,
         window: WindowSpec | None = None,
-        beta_mode: float = 1.0 / 3.0,
-        beta_sum: float = 5.0,
     ) -> NDArray:
         """Compute the flat-top constant-adiabaticity pulse envelope (I component only)."""
         t = np.asarray(t, dtype=float)
@@ -362,8 +375,6 @@ class Squad(Pulse):
                 amplitude=amplitude,
                 delta=delta,
                 window=window,
-                beta_mode=beta_mode,
-                beta_sum=beta_sum,
             )
 
         # Flat-top
@@ -381,8 +392,6 @@ class Squad(Pulse):
                 amplitude=amplitude,
                 delta=delta,
                 window=window,
-                beta_mode=beta_mode,
-                beta_sum=beta_sum,
             )
 
         return values
@@ -400,8 +409,6 @@ class Squad(Pulse):
         delta: float,
         factor: float | None = None,
         window: WindowSpec | None = None,
-        beta_mode: float = 1.0 / 3.0,
-        beta_sum: float = 5.0,
     ) -> NDArray:
         """
         Compute the full complex SQUAD pulse.
@@ -413,8 +420,15 @@ class Squad(Pulse):
         `{"type": "tukey", "rise_end": 0.2, "fall_start": 0.7}` sets the
         normalized positions within each ramp. Omitted positions default to
         0.5 (Hann). See `Squad` for validation and time-reversal conventions.
+
+        `t`, `duration`, and `tau` are in ns. `amplitude` and signed `delta`
+        (transition minus drive) must share units. Delta does not shift the
+        carrier. `Q = factor * delta * dI/dt / (delta**2 + I**2)`; see `Squad`
+        for the unit-dependent factor and its sign relative to `FlatTop`.
+        Beta settings use `window={"type": "beta", "mode": 0.4, "sum": 6}`;
+        standalone beta arguments are not accepted.
         """
-        _resolve_window(window, beta_mode, beta_sum)
+        _resolve_window(window)
         t = np.asarray(t, dtype=float)
 
         if duration <= 0:
@@ -431,8 +445,6 @@ class Squad(Pulse):
             delta=delta,
             tau=tau,
             window=window,
-            beta_mode=beta_mode,
-            beta_sum=beta_sum,
         )
 
         if factor == 0:

--- a/tests/pulse/test_squad.py
+++ b/tests/pulse/test_squad.py
@@ -1,5 +1,6 @@
 """Tests for SQUAD ramp windows and sampled CD conventions."""
 
+import warnings
 from typing import Any
 
 import numpy as np
@@ -8,6 +9,106 @@ from numpy.testing import assert_allclose
 from qxpulse import FlatTop
 from qxpulse.library.squad import Squad, TukeyWindowConfig
 from scipy.integrate import quad
+
+
+def _sample_public_squad_api(api, **options):
+    """Sample one public constructor or function on the same time grid."""
+    kwargs: dict[str, Any] = dict(
+        duration=40.0, amplitude=0.6, delta=-0.8, tau=12.0, **options
+    )
+    times = np.arange(0.5, 40.0, 1.0)
+    if api == "squad":
+        return Squad(**kwargs, sampling_period=1.0).values
+    if api == "squad_func":
+        return Squad.func(times, **kwargs)
+    if api == "flat_top":
+        return FlatTop(**kwargs, type="Squad", sampling_period=1.0).values
+    return FlatTop.func(times, **kwargs, type="Squad")
+
+
+@pytest.mark.parametrize("api", ["squad", "squad_func", "flat_top", "flat_top_func"])
+@pytest.mark.parametrize(
+    "options",
+    [{"beta_mode": 1 / 3}, {"beta_sum": 5.0}, {"beta_mode": 0.4, "beta_sum": 6.0}],
+)
+def test_removed_beta_arguments_are_rejected(api, options):
+    """Standalone beta arguments, including former defaults, are rejected at every public entry."""
+    with pytest.raises(TypeError, match=r"beta_mode|beta_sum"):
+        _sample_public_squad_api(api, window="beta", **options)
+
+
+@pytest.mark.parametrize("api", ["squad", "squad_func", "flat_top", "flat_top_func"])
+@pytest.mark.parametrize(
+    "window",
+    [None, "hann", "beta", {"type": "beta"}, {"type": "beta", "mode": 0.4, "sum": 6.0}],
+)
+def test_canonical_window_calls_do_not_warn(api, window):
+    """Calls without legacy beta keywords remain warning-free and produce finite samples."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        values = _sample_public_squad_api(api, window=window)
+    assert values.shape == (40,)
+    assert np.all(np.isfinite(values))
+
+
+@pytest.mark.parametrize("api", ["squad", "flat_top"])
+def test_removed_beta_arguments_are_rejected_before_lazy_sampling(api):
+    """Lazy pulses reject removed beta keywords at construction, not during later sampling."""
+    cls = Squad if api == "squad" else FlatTop
+    extra: dict[str, Any] = {} if api == "squad" else {"type": "Squad"}
+    with pytest.raises(TypeError, match="beta_mode"):
+        cls(
+            duration=40,
+            amplitude=0.6,
+            delta=-0.8,
+            tau=12,
+            window="beta",
+            beta_mode=0.4,
+            lazy=True,
+            **extra,
+        )
+
+
+@pytest.mark.parametrize("api", ["squad", "squad_func", "flat_top", "flat_top_func"])
+def test_removed_beta_defaults_with_dictionary_are_rejected(api):
+    """A window dictionary does not make removed top-level beta arguments acceptable."""
+    window = {"type": "beta", "mode": 0.4, "sum": 6.0}
+    with pytest.raises(TypeError, match=r"beta_mode|beta_sum"):
+        _sample_public_squad_api(api, window=window, beta_mode=1 / 3, beta_sum=5.0)
+
+
+@pytest.mark.parametrize("api", ["squad", "flat_top"])
+def test_documented_squad_unit_conversions_preserve_iq(api):
+    """Angular, cyclic-GHz and command-unit inputs agree with the documented CD scaling."""
+
+    def sample(amplitude, delta, factor):
+        kwargs: dict[str, Any] = dict(
+            duration=80,
+            tau=16,
+            amplitude=amplitude,
+            delta=delta,
+            window={"type": "beta", "mode": 0.4, "sum": 6.0},
+            sampling_period=2,
+        )
+        if api == "squad":
+            return Squad(**kwargs, factor=factor).values
+        return FlatTop(
+            **kwargs, type="Squad", correction_type="CD", correction_factor=factor
+        ).values
+
+    sign = -1 if api == "squad" else 1
+    rabi_ghz_per_command = 0.5
+    angular = sample(2 * np.pi * 0.2, 2 * np.pi * (-0.25), sign)
+    cyclic = sample(0.2, -0.25, sign / (2 * np.pi))
+    command = sample(
+        0.2 / rabi_ghz_per_command,
+        -0.25 / rabi_ghz_per_command,
+        sign / (2 * np.pi * rabi_ghz_per_command),
+    )
+    assert_allclose(angular, 2 * np.pi * cyclic, rtol=1e-12, atol=1e-14)
+    assert_allclose(
+        angular, 2 * np.pi * rabi_ghz_per_command * command, rtol=1e-12, atol=1e-14
+    )
 
 
 @pytest.mark.parametrize("sampling_period", [0.1, 2.0])
@@ -298,19 +399,39 @@ def test_single_tukey_position_defaults_the_other_to_half(position):
     )
 
 
-def test_beta_dict_matches_legacy_parameters():
-    """Beta dictionary settings reproduce the existing beta_mode and beta_sum API."""
+@pytest.mark.parametrize("api", ["squad", "flat_top"])
+def test_custom_beta_dictionary_matches_independent_integral(api):
+    """Nondefault beta shape parameters reproduce a numerically integrated beta density."""
+    times = np.arange(0.5, 12, 1.0)
+    alpha, beta = 2.6, 3.4  # mode 0.4, sum 6
+
+    def density(u):
+        return u ** (alpha - 1) * (1 - u) ** (beta - 1)
+
+    area = quad(density, 0, 1, epsabs=1e-13)[0]
+    g = np.array([quad(density, 0, t / 12, epsabs=1e-13)[0] / area for t in times])
+    sine = np.sin(np.arctan(0.6 / -0.8)) * g
+    expected = -0.8 * sine / np.sqrt(1 - sine**2)
+    options = {"factor": 0} if api == "squad" else {}
+    values = _sample_public_squad_api(
+        api, window={"type": "beta", "mode": 0.4, "sum": 6.0}, **options
+    )
+    assert_allclose(values[:12], expected, rtol=1e-10, atol=1e-13)
+
+
+def test_beta_dict_matches_default_string_window():
+    """An explicit default beta dictionary matches the parameter-free beta window string."""
     kwargs: dict[str, Any] = dict(duration=40, amplitude=0.6, delta=0.8, tau=12)
     assert_allclose(
-        Squad(**kwargs, window={"type": "beta", "mode": 0.4, "sum": 6.0}).values,
-        Squad(**kwargs, window="beta", beta_mode=0.4, beta_sum=6.0).values,
+        Squad(**kwargs, window={"type": "beta", "mode": 1 / 3, "sum": 5.0}).values,
+        Squad(**kwargs, window="beta").values,
         rtol=0,
         atol=0,
     )
 
 
 @pytest.mark.parametrize("options", [{"beta_mode": 0.4}, {"beta_sum": 6.0}])
-def test_dictionary_rejects_conflicting_legacy_beta_options(options):
+def test_dictionary_rejects_removed_beta_options(options):
     """Dictionary settings cannot silently override separate nondefault beta arguments."""
     kwargs: dict[str, Any] = dict(
         duration=40,
@@ -320,7 +441,7 @@ def test_dictionary_rejects_conflicting_legacy_beta_options(options):
         window={"type": "beta", "mode": 0.2},
         **options,
     )
-    with pytest.raises(ValueError, match=r"beta_mode.*beta_sum"):
+    with pytest.raises(TypeError, match=r"beta_mode|beta_sum"):
         Squad(**kwargs)
 
 


### PR DESCRIPTION
## Background

Unify custom SQUAD window parameters under the same dictionary interface already used by Tukey, and remove ambiguity between command amplitudes, cyclic GHz, and angular-rate inputs. Per maintainer request, remove the unused standalone beta options outright rather than deprecating them.

## Changes

- Remove `beta_mode` / `beta_sum` from `Squad`, its function/helpers and instance attributes; reject them on the `FlatTop(type="Squad")` paths too, including former defaults and lazy construction.
- Use `window={"type": "beta", "mode": 0.4, "sum": 6.0}`. The parameter-free `window="beta"` default remains supported.
- Document transition-minus-drive design delta, amplitude/delta unit matching, CD coefficient scaling, and the opposite direct-Squad/FlatTop quadrature factors.
- Distinguish fixed-waveform carrier scans from carrier-adaptive delta regeneration. Delta is not a carrier-setting API.
- Add bilingual migration guidance and regression coverage, including independent beta-density integration and angular/GHz/command-unit I/Q equivalence.

## Compatibility and scope

Breaking removal: standalone beta keywords now raise `TypeError`; there is no deprecation shim. Pulse arithmetic, sampling, default waveforms and CD sign conventions are unchanged. No hardware execution, deployment or experimental calibration changes are included.

## Verification

Executed in this worktree's uv-managed environment:

- `uv run --no-sync ruff check --fix` — passed
- `uv run --no-sync ruff format` — clean after formatting
- `uv run --no-sync pyright` — 0 errors, 0 warnings
- `uv run --no-sync pytest -q` — 1665 passed
- `uv run --no-sync pytest -q tests/pulse/test_squad.py` — 128 passed, including the additional independent beta integral cases
- `uv run --no-sync mkdocs build` — succeeded; existing documentation parameter/autoreference warnings remain
- `git diff --check` — passed

These checks validate API behavior and waveform/unit equivalence, not physical hardware CD performance.