### PR TITLE
fix: unify SQUAD CD sign and correction strength API

### DIFF
--- a/docs/release-notes/v1-5-0-migration.ja.md
+++ b/docs/release-notes/v1-5-0-migration.ja.md
@@ -40,7 +40,7 @@
 
 ```python
 pulse = Squad(
-    duration=40, amplitude=0.6, delta=-0.8, tau=12, factor=0,
+    duration=40, amplitude=0.6, delta=-0.8, tau=12, correction_factor=0,
     window={"type": "beta", "mode": 0.4, "sum": 6.0},
 )
 ```
@@ -48,14 +48,52 @@ pulse = Squad(
 文字列 `window="beta"` は引き続き mode=1/3、sum=5 を使います。
 Tukey の設定も従来どおり辞書で渡します。
 
-amplitude は包絡線の振幅であり、carrier 周波数ではありません。
-amplitude と設計 delta（遷移周波数 − drive 周波数）は同じ単位で渡します。
-delta は carrier を設定しません。時間を ns とすると、解析的な CD 係数の大きさは、
-角周波数単位（rad/ns）なら 1、通常の周波数単位（GHz）なら `1/(2*pi)`、
-制御振幅単位なら Rabi 換算 r（GHz/command）に対して `1/(2*pi*r)` です。
-最後の場合は `delta=(f_transition-f_drive)/r` を渡します。
-同じ CD 直交成分を得るには、直接の `Squad.factor` と
-`FlatTop.correction_factor` の符号を反転します。波形の計算式・符号規約は変更していません。
+### CD の符号と補正強度の統一
+
+直接の `Squad` / `Squad.func` に対する破壊的変更です。
+旧 `factor` は削除し、`factor=None` を明示した場合も `TypeError` にします。
+instance 属性も `correction_factor` へ変更しました。
+
+両 SQUAD API で delta は「遷移周波数 − drive」、包絡線は `I + i*Q` とし、
+CD 式を `Q = -correction_factor * delta * dI/dt / (delta**2 + I**2)` に統一します。
+amplitude と delta は rad/ns、時間は ns で渡します。
+`correction_factor` は無次元で、1 が解析的 CD 強度、0.5 は半分、0 は CD なしです。
+carrier は別に設定します。
+
+旧 direct-SQUAD 波形を保存するには、旧 factor の符号を反転して渡します。
+
+```python
+# 旧: Squad(..., factor=x)
+# 新:
+pulse = Squad(
+    duration=40, amplitude=0.6, delta=-0.8, tau=12,
+    correction_factor=-x,
+)
+```
+
+**旧 factor 省略/None は +1 なので、旧デフォルト波形の再現には
+新 correction_factor=-1 が必要です。**
+新 correction_factor の省略/None は統一規約の +1 であり、旧デフォルトの Q と逆符号です。
+暗黙の互換 alias は設けません。
+`FlatTop` の既存 CD 式、DRAG、補正なしのデフォルト、ランプ sampling と符号は変更しません。
+直接の `Squad` は引き続きデフォルトで CD を有効にします。
+
+実機の単位換算は補正強度から分離します。
+
+```python
+K = 2 * np.pi * rabi_ghz_per_command
+pulse = FlatTop(
+    duration=40, tau=12, type="Squad",
+    amplitude=K * command_amplitude,
+    delta=2 * np.pi * (transition_ghz - drive_ghz),
+    correction_type="CD", correction_factor=1.0,
+    scale=1 / K,
+)
+```
+
+scale は I/Q の両方を制御振幅へ戻します。旧 FlatTop で delta を Rabi 換算し、
+correction_factor を K で割っていた波形と同値です。両方の換算を重ねて適用しないでください。
+Rabi 換算は呼び出し側の実機モデルであり、pulse API 自体が較正するわけではありません。
 
 drive 周波数に追従して SQUAD を設計する場合は各周波数で delta を再計算します。
 delta を固定する場合は、意図的に同じ波形の carrier のみを掃引する実験です。

--- a/docs/release-notes/v1-5-0-migration.md
+++ b/docs/release-notes/v1-5-0-migration.md
@@ -42,7 +42,7 @@ There is no deprecation period. Replace them with a window dictionary:
 
 ```python
 pulse = Squad(
-    duration=40, amplitude=0.6, delta=-0.8, tau=12, factor=0,
+    duration=40, amplitude=0.6, delta=-0.8, tau=12, correction_factor=0,
     window={"type": "beta", "mode": 0.4, "sum": 6.0},
 )
 ```
@@ -50,14 +50,55 @@ pulse = Squad(
 The string `window="beta"` still uses mode 1/3 and sum 5.
 Tukey settings continue to use the same dictionary interface.
 
-Amplitude is an envelope level, not the carrier frequency. Amplitude and
-design delta (transition minus drive) must use the same units. Delta does not
-set the carrier. For time in ns, the analytic CD coefficient magnitude is 1
-with angular-rate inputs (rad/ns), `1/(2*pi)` with cyclic-rate inputs (GHz),
-or `1/(2*pi*r)` with command amplitudes and Rabi conversion r in GHz/command.
-In the last case, pass `delta=(f_transition-f_drive)/r`.
-Direct `Squad.factor` has the opposite sign to `FlatTop.correction_factor`
-for the same CD quadrature. Pulse arithmetic and sign conventions are unchanged.
+### Unified CD sign and strength
+
+This is a breaking change to direct `Squad` / `Squad.func`:
+`factor` has been removed and is rejected with `TypeError`, including
+explicit `factor=None`. The instance attribute is now `correction_factor`.
+
+Both SQUAD entry points use transition-minus-drive delta, an `I + i*Q`
+envelope, and the same negative-sign CD formula:
+`Q = -correction_factor * delta * dI/dt / (delta**2 + I**2)`.
+Use angular-rate amplitude/delta in rad/ns and time in ns.
+`correction_factor` is dimensionless: 1 is the analytic CD strength,
+0.5 halves it, and 0 disables it. The carrier is configured separately.
+
+To preserve an old direct-SQUAD waveform, negate its old factor:
+
+```python
+# Before: Squad(..., factor=x)
+# After:
+pulse = Squad(
+    duration=40, amplitude=0.6, delta=-0.8, tau=12,
+    correction_factor=-x,
+)
+```
+
+**Old omitted/None factor meant +1: use new correction_factor=-1 to
+preserve that old waveform.** New omitted/None correction_factor means +1
+in the unified convention and therefore reverses the old default Q.
+There is no silent compatibility alias. `FlatTop`'s existing CD formula,
+DRAG behavior, correction-disabled default, ramp sampling and signs are unchanged.
+Direct `Squad` still enables CD by default.
+
+Keep hardware-unit conversion separate from correction strength:
+
+```python
+K = 2 * np.pi * rabi_ghz_per_command
+pulse = FlatTop(
+    duration=40, tau=12, type="Squad",
+    amplitude=K * command_amplitude,
+    delta=2 * np.pi * (transition_ghz - drive_ghz),
+    correction_type="CD", correction_factor=1.0,
+    scale=1 / K,
+)
+```
+
+Scale converts both I and Q to command amplitudes. This preserves older
+command-unit FlatTop waveforms that used delta divided by the Rabi scale
+and correction_factor divided by K; do not apply both conversions.
+The Rabi scale remains a caller-supplied hardware model, not a calibration
+performed by the pulse API.
 
 Recompute delta per drive frequency for carrier-adaptive SQUAD design.
 Holding delta fixed instead deliberately scans one waveform's carrier;

--- a/packages/qxpulse/src/qxpulse/library/_corrections.py
+++ b/packages/qxpulse/src/qxpulse/library/_corrections.py
@@ -1,0 +1,23 @@
+"""Shared quadrature corrections for pulse envelopes."""
+
+from numpy.typing import NDArray
+
+
+def _cd_quadrature(
+    envelope: NDArray,
+    derivative: NDArray,
+    *,
+    delta: float,
+    correction_factor: float,
+) -> NDArray:
+    """Return CD Q for transition-minus-drive delta and I+iQ angular-rate inputs."""
+    return -(correction_factor * delta) / (delta**2 + envelope**2) * derivative
+
+
+def _reject_legacy_factor(options: dict) -> None:
+    """Reject the removed direct-SQUAD factor before it can be silently ignored."""
+    if "factor" in options:
+        raise TypeError(
+            "factor has been removed; use correction_factor=-old_factor "
+            "to preserve a legacy Squad waveform (old None/default means 1)."
+        )

--- a/packages/qxpulse/src/qxpulse/library/flat_top.py
+++ b/packages/qxpulse/src/qxpulse/library/flat_top.py
@@ -11,6 +11,7 @@ from typing_extensions import override
 from qxpulse.pulse import Pulse
 from qxpulse.waveform import floor_to_sampling_period
 
+from ._corrections import _cd_quadrature, _reject_legacy_factor
 from .bump import Bump
 from .gaussian import Gaussian
 from .multi_derivative import MultiDerivative
@@ -30,22 +31,22 @@ class FlatTop(Pulse):
         Duration of the pulse in ns.
     amplitude : float
         Flat-top in-phase envelope level, not a carrier frequency. For SQUAD
-        or delta-based correction, use the same units as `delta`.
+        or delta-based correction, use rad/ns before output scaling.
     tau : float
         Rise and fall time of the pulse in ns.
     beta : float, optional
         DRAG correction coefficient. Default is None.
     delta : float, optional
-        Transition frequency minus drive frequency, in the same units as
-        `amplitude`. Required for SQUAD ramps or delta-based correction.
+        Transition frequency minus drive frequency in rad/ns.
+        Required for SQUAD ramps or delta-based correction.
         Shapes the waveform; does not set or shift its carrier frequency.
     type : RampType, optional
         Ramp shape, default "RaisedCosine". Use "Squad" for SQUAD.
     correction_type : {"DRAG", "CD"}, optional
         Quadrature correction. None (default) disables delta-based correction.
     correction_factor : float, optional
-        Signed coefficient for delta-based correction. None defaults to 1.0
-        when correction is enabled. Units and sign are described in Notes.
+        Dimensionless correction strength for angular-rate inputs.
+        None defaults to 1.0; 0.5 halves the correction and 0 disables it.
 
     Notes
     -----
@@ -63,14 +64,13 @@ class FlatTop(Pulse):
     `Q = -correction_factor * dI/dt / delta`. Thus weak-drive CD approaches
     DRAG with the same signed delta and coefficient. Using the negative
     anharmonicity as delta for EF relative to a GE drive follows this convention.
-    Direct `Squad` uses the opposite factor sign for equivalent quadrature.
+    Direct `Squad` uses the same formula and coefficient sign.
 
-    Time is in ns. With angular-rate amplitude/delta (rad/ns), the analytic
-    CD coefficient is 1; with cyclic-rate amplitude/delta (GHz), it is
-    `1/(2*pi)`. With command amplitude and Rabi conversion r (GHz/command),
-    use `delta = (f_transition - f_drive)/r` and coefficient `1/(2*pi*r)`.
-    No unit inference or conversion is performed. These coefficients describe
-    the design model, not a hardware calibration. See `Squad` for details.
+    Time is in ns and amplitude/delta are angular rates (rad/ns).
+    For command amplitude A with Rabi scale r in GHz/command, pass
+    `amplitude=K*A`, `delta=2*pi*(f_transition-f_drive)`, and `scale=1/K`,
+    where `K=2*pi*r`. Scaling converts the completed I/Q to command units;
+    `correction_factor` remains dimensionless. No Rabi conversion is inferred.
 
     Configure the carrier separately. Recompute delta at each drive frequency
     for carrier-adaptive SQUAD design; keep a fixed design delta only when
@@ -109,6 +109,7 @@ class FlatTop(Pulse):
         }
         window = shape_kwargs.get("window")
         if type == "Squad":
+            _reject_legacy_factor(shape_kwargs)
             _reject_removed_window_options(shape_kwargs)
         if type == "Squad" and isinstance(window, dict):
             _resolve_window(window)
@@ -173,7 +174,7 @@ class FlatTop(Pulse):
         duration : float
             Duration of the pulse in ns.
         amplitude : float
-            In-phase level in the same units as `delta`, not carrier frequency.
+            In-phase level; use rad/ns for SQUAD or delta-based correction.
         tau : float
             Rise and fall time of the pulse in ns.
         beta : float, optional
@@ -181,13 +182,13 @@ class FlatTop(Pulse):
         type : RampType | None, optional
             Type of the pulse. Default is "RaisedCosine".
         delta : float, optional
-            Signed transition-minus-drive design detuning. See `FlatTop`
-            for conversion between angular rates, GHz, and command units.
+            Signed transition-minus-drive design detuning in rad/ns.
+            Does not set the carrier. See `FlatTop` for output scaling.
         correction_type : {"DRAG", "CD"}, optional
             Delta-based quadrature correction; None disables it.
         correction_factor : float, optional
-            Signed, unit-dependent coefficient; None defaults to 1.0.
-            See `FlatTop` for the CD formula and sign relative to `Squad`.
+            Dimensionless strength; None defaults to 1.0 and 0.5 halves it.
+            See `FlatTop` for the shared CD convention.
 
         Returns
         -------
@@ -197,6 +198,7 @@ class FlatTop(Pulse):
         if type is None:
             type = "RaisedCosine"
         if type == "Squad":
+            _reject_legacy_factor(kwargs)
             _reject_removed_window_options(kwargs)
             _resolve_window(kwargs.get("window"))
 
@@ -264,7 +266,7 @@ class FlatTop(Pulse):
         if correction_type == "DRAG":
             Q = -(correction_factor / delta) * dI
         elif correction_type == "CD":
-            Q = -(correction_factor * delta) / (delta**2 + I**2) * dI
+            Q = _cd_quadrature(I, dI, delta=delta, correction_factor=correction_factor)
         else:
             raise ValueError(f"Unknown correction type: {correction_type}")
         return I + 1j * Q
@@ -326,7 +328,7 @@ def _ramp_func(
                 Pulse.SAMPLING_PERIOD,
             ),
             delta=delta,
-            factor=0,
+            correction_factor=0,
             **kwargs,
         )
     else:

--- a/packages/qxpulse/src/qxpulse/library/squad.py
+++ b/packages/qxpulse/src/qxpulse/library/squad.py
@@ -11,6 +11,8 @@ from typing_extensions import NotRequired, override
 
 from qxpulse.pulse import Pulse
 
+from ._corrections import _cd_quadrature, _reject_legacy_factor
+
 SmoothingType = Literal["none", "hann", "tukey", "beta"]
 
 
@@ -126,98 +128,69 @@ def _integrated_tukey(u: NDArray, *, rise_end: float, fall_start: float) -> NDAr
 
 class Squad(Pulse):
     """
-    Smooth quasi-adiabatic (SQUAD) pulse.
-
-    The pulse consists of:
-    - ramp-up on [0, tau]
-    - flat top on [tau, duration - tau]
-    - ramp-down on [duration - tau, duration]
-
-    Window types
-    ------------
-    - "none" : constant-adiabatic ramp (FAQUAD-like, ε(t) = const)
-    - "hann" : smooth adiabatic ramp using a sin^2(pi u) window
-               (integrated to g(u) = u - sin(2πu)/(2π)).
-    - "tukey" : normalized integral of a Tukey window with independent
-                rise-end and fall-start positions within each ramp.
-    - "beta" : smooth adiabatic ramp using the regularized incomplete
-               beta function I_u(α, β) with fixed shape parameters.
+    SQUAD flat-top envelope with counterdiabatic (CD) quadrature.
 
     Parameters
     ----------
     duration : float
-        Total duration of the pulse in ns.
+        Complete pulse duration in ns, including both ramps.
     amplitude : float
-        Flat-top in-phase envelope level, not the carrier frequency. Use the
-        same units as `delta`; there is no automatic unit conversion.
+        Flat-top in-phase amplitude in rad/ns, before Pulse scaling.
     delta : float
-        Signed design detuning, transition frequency minus drive frequency,
-        expressed in the same units as `amplitude`. Shapes the envelope and
-        CD quadrature; does not set or shift the carrier. See Notes for units.
+        Signed design detuning in rad/ns: transition frequency minus drive
+        frequency. Must be nonzero for a meaningful SQUAD ramp. This shapes
+        the envelope; it does not set the carrier frequency.
     tau : float
-        Rise and fall time (each side) in ns.
-    factor : float, optional
-        Signed CD coefficient; 0 disables CD and None defaults to 1.0.
-        Its magnitude depends on the amplitude units. Its sign is opposite
-        to `FlatTop.correction_factor` for equivalent quadrature (see Notes).
+        Duration of each ramp in ns; the flat top lasts duration - 2*tau.
+    correction_factor : float, optional
+        Dimensionless CD strength. None defaults to 1.0; 0 disables CD and
+        0.5 halves it. Negative values reverse the correction.
     window : str or WindowConfig, optional
-        Window type or dictionary with a required `type` key. Default is
-        "hann". String choices are "none", "hann", "tukey", and "beta".
-        Tukey dictionaries accept `rise_end` and `fall_start`, both defaulting
-        to 0.5, with `0 <= rise_end <= fall_start <= 1`. These normalized
-        positions end the window's rise and begin its fall. Both at 0.5
-        reproduce Hann; (0, 1) reproduces "none". Beta dictionaries accept
-        `mode` (default 1/3, range [0, 1]) and `sum` (default 5, finite and > 2).
-        Other windows accept only `type`. Unknown keys are rejected.
-        Dictionaries are copied on construction. Standalone `beta_mode` and
-        `beta_sum` arguments have been removed; use the dictionary keys.
+        Adiabaticity window, default "hann". String choices are "none",
+        "hann", "tukey", and "beta". A dictionary requires a `type` key.
+        Tukey accepts `rise_end` and `fall_start` (default 0.5 each),
+        with `0 <= rise_end <= fall_start <= 1`. Beta accepts `mode`
+        (default 1/3, range [0, 1]) and `sum` (default 5, finite and > 2).
+        Other windows accept only `type`. Dictionaries are copied.
 
     Raises
     ------
     TypeError
-        If a dictionary's numeric settings are not real numbers, or removed
-        standalone window parameters are supplied.
+        If removed standalone options are supplied or window settings have
+        non-real numeric values.
     ValueError
-        If a window dictionary has missing/unknown keys or invalid values.
+        If a window has missing/unknown keys or invalid values.
 
     Notes
     -----
-    flat-top period = duration - 2 * tau
+    With time in ns and the envelope `I + i*Q`, both SQUAD APIs use
+    `Q = -correction_factor * delta * dI/dt / (delta**2 + I**2)`.
+    The derivative is evaluated on the supplied sampling grid. This follows
+    the drive-frame convention `H/hbar = (-delta*Z + I*X + Q*Y)/2`.
+    `FlatTop(type="Squad", correction_type="CD")` uses this same convention;
+    the coefficient never needs an API-dependent sign change.
 
-    Before any generic Pulse scale/phase/detuning transforms, the envelope
-    is `I + i*Q` with `Q = factor * delta * dI/dt / (delta**2 + I**2)`.
-    `FlatTop(type="Squad", correction_type="CD")` uses the opposite sign:
-    set `factor = -correction_factor` to match it on the same sampling grid.
+    For command amplitude A and Rabi scale r in GHz/command, set
+    `K = 2*pi*r`, pass `amplitude=K*A` and
+    `delta=2*pi*(f_transition-f_drive)`, then use `scale=1/K` to convert
+    the completed I/Q back to command units. Keep `correction_factor`
+    dimensionless; no Rabi calibration or unit conversion is inferred here.
 
-    Time is in ns. If K is the angular Rabi rate in rad/ns per numeric
-    amplitude unit, the analytic CD coefficient magnitude is `1/K`.
-    For angular-rate inputs (rad/ns), use magnitude 1. For cyclic-rate
-    inputs (GHz = cycles/ns), use `1/(2*pi)`. For command amplitudes with
-    calibrated Rabi conversion r in GHz per command unit, pass
-    `delta = (f_transition - f_drive)/r` and use magnitude `1/(2*pi*r)`.
-    For example, amplitude 0.99 in command units must not be combined with
-    an unconverted GHz detuning. Qubit Rabi conversion is a model input,
-    not a guarantee of strong-drive hardware response. qxsimulator expects
-    angular-rate envelopes even though Control.frequency uses cyclic GHz.
+    The window is integrated and normalized before the SQUAD mapping.
+    Positions describe normalized time inside each ramp, not outer pulse
+    durations. The falling ramp is the time reverse of the rising ramp.
+    Tukey (0.5, 0.5) reproduces Hann and (0, 1) reproduces "none".
 
-    The carrier is configured separately. For carrier-adaptive pulse design,
-    recompute `delta` from each drive frequency and regenerate the waveform.
-    Holding a design delta fixed instead scans the carrier of a fixed
-    waveform; these are different experiments. In particular, adapting delta
-    changes the waveform throughout a chevron and its fit interpretation.
-
-    Window positions refer to normalized time `u=t/tau` inside the rising
-    SQUAD ramp, not to the full pulse. The falling SQUAD ramp is its time
-    reverse, including the window. Thus an asymmetric Tukey window does not
-    change the equal outer ramp durations `tau` or the pulse's flat top.
-    The window is integrated and normalized before the SQUAD mapping; it
-    does not multiply the final I/Q envelope.
+    Configure the carrier separately. Recompute delta when intentionally
+    redesigning the waveform for each carrier, or hold design delta fixed
+    when scanning one fixed waveform. These are different experiments.
 
     Examples
     --------
     >>> pulse = Squad(
-    ...     duration=40, amplitude=0.6, delta=0.8, tau=12,
-    ...     window={"type": "tukey", "rise_end": 0.2, "fall_start": 0.7},
+    ...     duration=40, amplitude=0.6, delta=-0.8, tau=12,
+    ...     correction_factor=1.0,
+    ...     window={"type": "beta", "mode": 0.4, "sum": 6},
     ... )
     """
 
@@ -228,10 +201,11 @@ class Squad(Pulse):
         amplitude: float,
         delta: float,
         tau: float,
-        factor: float | None = None,
+        correction_factor: float | None = None,
         window: WindowSpec | None = None,
         **kwargs,
     ):
+        _reject_legacy_factor(kwargs)
         _reject_removed_window_options(kwargs)
         _resolve_window(window)
         super().__init__(
@@ -242,7 +216,7 @@ class Squad(Pulse):
         self.amplitude: Final = amplitude
         self.delta: Final = delta
         self.tau: Final = tau
-        self.factor: Final = factor
+        self.correction_factor: Final = correction_factor
         self.window: Final = window.copy() if isinstance(window, dict) else window
         self._finalize_initialization()
 
@@ -258,7 +232,7 @@ class Squad(Pulse):
             amplitude=self.amplitude,
             delta=self.delta,
             tau=self.tau,
-            factor=self.factor,
+            correction_factor=self.correction_factor,
             window=self.window,
         )
 
@@ -407,26 +381,16 @@ class Squad(Pulse):
         amplitude: float,
         tau: float,
         delta: float,
-        factor: float | None = None,
+        correction_factor: float | None = None,
         window: WindowSpec | None = None,
     ) -> NDArray:
         """
-        Compute the full complex SQUAD pulse.
+        Sample the SQUAD envelope as I + i*Q, before generic Pulse transforms.
 
-        Returns `I(t) + i Q(t)`, where `I(t)` is the flat-top envelope with
-        chosen SQUAD ramps and `Q(t)` is the scaled counter-diabatic quadrature.
-
-        A window dictionary such as
-        `{"type": "tukey", "rise_end": 0.2, "fall_start": 0.7}` sets the
-        normalized positions within each ramp. Omitted positions default to
-        0.5 (Hann). See `Squad` for validation and time-reversal conventions.
-
-        `t`, `duration`, and `tau` are in ns. `amplitude` and signed `delta`
-        (transition minus drive) must share units. Delta does not shift the
-        carrier. `Q = factor * delta * dI/dt / (delta**2 + I**2)`; see `Squad`
-        for the unit-dependent factor and its sign relative to `FlatTop`.
-        Beta settings use `window={"type": "beta", "mode": 0.4, "sum": 6}`;
-        standalone beta arguments are not accepted.
+        `t`, `duration`, and `tau` are in ns. `amplitude` and signed
+        `delta` (transition minus drive) are in rad/ns. `correction_factor`
+        is dimensionless: None means 1, 0 disables CD, and 0.5 halves it.
+        See `Squad` for the shared CD formula, windows and hardware scaling.
         """
         _resolve_window(window)
         t = np.asarray(t, dtype=float)
@@ -434,8 +398,8 @@ class Squad(Pulse):
         if duration <= 0:
             return np.zeros_like(t, dtype=np.complex128)
 
-        if factor is None:
-            factor = 1.0
+        if correction_factor is None:
+            correction_factor = 1.0
 
         # In-phase component
         I = Squad._squad_flat_top_envelope(
@@ -447,7 +411,7 @@ class Squad(Pulse):
             window=window,
         )
 
-        if factor == 0:
+        if correction_factor == 0:
             return I.astype(np.complex128)
 
         # Numerical derivative dI/dt
@@ -459,6 +423,11 @@ class Squad(Pulse):
         # Avoid division by zero if Δ=0 and I=0 everywhere
         Q = np.zeros_like(I.real)
         nonzero = denom != 0.0
-        Q[nonzero] = (factor * Δ * dI_dt[nonzero]) / denom[nonzero]
+        Q[nonzero] = _cd_quadrature(
+            I.real[nonzero],
+            dI_dt[nonzero],
+            delta=Δ,
+            correction_factor=correction_factor,
+        )
 
         return I.real + 1j * Q

--- a/tests/pulse/test_squad.py
+++ b/tests/pulse/test_squad.py
@@ -79,9 +79,9 @@ def test_removed_beta_defaults_with_dictionary_are_rejected(api):
 
 @pytest.mark.parametrize("api", ["squad", "flat_top"])
 def test_documented_squad_unit_conversions_preserve_iq(api):
-    """Angular, cyclic-GHz and command-unit inputs agree with the documented CD scaling."""
+    """Legacy numeric-unit conversions remain algebraically equivalent after the sign change."""
 
-    def sample(amplitude, delta, factor):
+    def sample(amplitude, delta, correction_factor):
         kwargs: dict[str, Any] = dict(
             duration=80,
             tau=16,
@@ -91,12 +91,15 @@ def test_documented_squad_unit_conversions_preserve_iq(api):
             sampling_period=2,
         )
         if api == "squad":
-            return Squad(**kwargs, factor=factor).values
+            return Squad(**kwargs, correction_factor=correction_factor).values
         return FlatTop(
-            **kwargs, type="Squad", correction_type="CD", correction_factor=factor
+            **kwargs,
+            type="Squad",
+            correction_type="CD",
+            correction_factor=correction_factor,
         ).values
 
-    sign = -1 if api == "squad" else 1
+    sign = 1
     rabi_ghz_per_command = 0.5
     angular = sample(2 * np.pi * 0.2, 2 * np.pi * (-0.25), sign)
     cyclic = sample(0.2, -0.25, sign / (2 * np.pi))
@@ -113,15 +116,15 @@ def test_documented_squad_unit_conversions_preserve_iq(api):
 
 @pytest.mark.parametrize("sampling_period", [0.1, 2.0])
 @pytest.mark.parametrize("delta", [-0.8, 0.8])
-@pytest.mark.parametrize("factor", [None, 0.0, 1.0, -1.0])
-def test_tukey_midpoints_match_hann(sampling_period, delta, factor):
+@pytest.mark.parametrize("correction_factor", [None, 0.0, 1.0, -1.0])
+def test_tukey_midpoints_match_hann(sampling_period, delta, correction_factor):
     """Tukey positions (0.5, 0.5) reproduce the full sampled Hann I/Q pulse."""
     kwargs: dict[str, Any] = dict(
         duration=40.0,
         amplitude=0.6,
         delta=delta,
         tau=12.0,
-        factor=factor,
+        correction_factor=correction_factor,
     )
     hann = Squad(**kwargs, window="hann", sampling_period=sampling_period)
     tukey = Squad(
@@ -193,7 +196,7 @@ def test_tukey_matches_independent_window_integral(rise_end, fall_start):
         amplitude=0.6,
         delta=0.8,
         tau=12,
-        factor=0,
+        correction_factor=0,
         window={"type": "tukey", "rise_end": rise_end, "fall_start": fall_start},
     )
 
@@ -222,7 +225,7 @@ def test_tukey_constructor_matches_func_and_preserves_pulse_symmetry(lazy):
         amplitude=0.6,
         delta=0.8,
         tau=12,
-        factor=0.7,
+        correction_factor=0.7,
         window={"type": "tukey", "rise_end": 0.2, "fall_start": 0.6},
     )
     pulse = Squad(**kwargs, sampling_period=0.1, lazy=lazy)
@@ -236,9 +239,9 @@ def test_tukey_constructor_matches_func_and_preserves_pulse_symmetry(lazy):
 
 
 @pytest.mark.parametrize("delta", [-0.8, 0.8])
-@pytest.mark.parametrize("factor", [-1.0, 0.0, 1.0])
-def test_tukey_preserves_direct_cd_sign(delta, factor):
-    """Direct SQUAD keeps Q = factor * delta * dI/dt / (delta**2 + I**2)."""
+@pytest.mark.parametrize("correction_factor", [-1.0, 0.0, 1.0])
+def test_tukey_uses_shared_cd_sign(delta, correction_factor):
+    """Direct SQUAD uses Q = -correction_factor * delta * dI/dt / (delta**2 + I**2)."""
     t = np.linspace(0, 40, 401)
     values = Squad.func(
         t,
@@ -246,18 +249,21 @@ def test_tukey_preserves_direct_cd_sign(delta, factor):
         amplitude=0.6,
         delta=delta,
         tau=12,
-        factor=factor,
+        correction_factor=correction_factor,
         window={"type": "tukey", "rise_end": 0.2, "fall_start": 0.7},
     )
     expected_q = (
-        factor * delta * np.gradient(values.real, t) / (delta**2 + values.real**2)
+        -correction_factor
+        * delta
+        * np.gradient(values.real, t)
+        / (delta**2 + values.real**2)
     )
     assert_allclose(values.imag, expected_q, rtol=1e-12, atol=1e-14)
 
 
 @pytest.mark.parametrize("sampling_period", [0.1, 2.0])
 def test_flat_top_forwards_tukey_positions_with_existing_cd_mapping(sampling_period):
-    """FlatTop forwards the window positions and retains its opposite CD factor convention."""
+    """FlatTop forwards the window positions and uses the shared CD correction_factor convention."""
     kwargs: dict[str, Any] = dict(
         duration=40,
         amplitude=0.6,
@@ -265,12 +271,12 @@ def test_flat_top_forwards_tukey_positions_with_existing_cd_mapping(sampling_per
         tau=12,
         window={"type": "tukey", "rise_end": 0.2, "fall_start": 0.7},
     )
-    direct = Squad(**kwargs, factor=1, sampling_period=sampling_period)
+    direct = Squad(**kwargs, correction_factor=1, sampling_period=sampling_period)
     flat = FlatTop(
         **kwargs,
         type="Squad",
         correction_type="CD",
-        correction_factor=-1,
+        correction_factor=1,
         sampling_period=sampling_period,
     )
     assert_allclose(flat.values, direct.values, rtol=1e-12, atol=1e-14)
@@ -299,7 +305,7 @@ def test_tukey_rejects_invalid_positions_at_public_entry_points(
         amplitude=0.6,
         delta=0.8,
         tau=0,
-        factor=0,
+        correction_factor=0,
         window={"type": "tukey", "rise_end": rise_end, "fall_start": fall_start},
     )
     message = r"0 <= rise_end <= fall_start <= 1"
@@ -412,7 +418,7 @@ def test_custom_beta_dictionary_matches_independent_integral(api):
     g = np.array([quad(density, 0, t / 12, epsabs=1e-13)[0] / area for t in times])
     sine = np.sin(np.arctan(0.6 / -0.8)) * g
     expected = -0.8 * sine / np.sqrt(1 - sine**2)
-    options = {"factor": 0} if api == "squad" else {}
+    options = {"correction_factor": 0} if api == "squad" else {}
     values = _sample_public_squad_api(
         api, window={"type": "beta", "mode": 0.4, "sum": 6.0}, **options
     )

--- a/tests/pulse/test_squad_cd_convention.py
+++ b/tests/pulse/test_squad_cd_convention.py
@@ -1,0 +1,144 @@
+"""Public CD convention, migration, and physical two-level regression tests."""
+
+from typing import Any
+
+import numpy as np
+import pytest
+from numpy.testing import assert_allclose
+from qxpulse import FlatTop
+from qxpulse.library.squad import Squad
+from scipy.linalg import expm
+
+
+@pytest.mark.parametrize("delta", [-0.8, 0.8])
+@pytest.mark.parametrize("coefficient", [None, 0.0, 0.5, 1.0, -1.0])
+@pytest.mark.parametrize("lazy", [False, True])
+def test_public_cd_apis_have_identical_sign(delta, coefficient, lazy):
+    """Both public constructors produce identical I/Q for equal CD settings."""
+    kwargs: dict[str, Any] = dict(
+        duration=40, amplitude=0.6, tau=12, delta=delta, sampling_period=0.1
+    )
+    direct = Squad(**kwargs, correction_factor=coefficient, lazy=lazy)
+    flat = FlatTop(
+        **kwargs,
+        type="Squad",
+        correction_type="CD",
+        correction_factor=coefficient,
+        lazy=lazy,
+    )
+    assert_allclose(direct.values, flat.values, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("api", [Squad, Squad.func])
+@pytest.mark.parametrize("legacy", [None, 0.0, 1.0, -0.5])
+def test_legacy_factor_is_not_silently_reinterpreted(api, legacy):
+    """Removed factor keywords fail instead of silently reversing an existing pulse."""
+    args = () if api is Squad else (np.arange(0.5, 40, 1),)
+    with pytest.raises(TypeError, match="factor"):
+        api(*args, duration=40, amplitude=0.6, delta=-0.8, tau=12, factor=legacy)
+
+
+def test_migrating_legacy_factor_preserves_iq():
+    """Negating the old factor reproduces the released direct-SQUAD quadrature."""
+    t = np.arange(0.05, 40, 0.1)
+    legacy_factor = 0.7
+    pulse = Squad.func(
+        t,
+        duration=40,
+        amplitude=0.6,
+        delta=-0.8,
+        tau=12,
+        correction_factor=-legacy_factor,
+    )
+    expected_q = (
+        legacy_factor * (-0.8) * np.gradient(pulse.real, t) / (0.8**2 + pulse.real**2)
+    )
+    assert_allclose(pulse.imag, expected_q, rtol=1e-12, atol=1e-14)
+
+
+@pytest.mark.parametrize("amplitude", [0.6, 0.01])
+def test_flat_top_cd_keeps_released_formula(amplitude):
+    """FlatTop retains its existing negative CD sign and sampled derivative."""
+    t = np.arange(0.05, 40, 0.1)
+    pulse = FlatTop.func(
+        t,
+        duration=40,
+        amplitude=amplitude,
+        delta=-0.8,
+        tau=12,
+        type="Squad",
+        correction_type="CD",
+        correction_factor=0.5,
+    )
+    expected_q = -0.5 * (-0.8) * np.gradient(pulse.real, t) / (0.8**2 + pulse.real**2)
+    assert_allclose(pulse.imag, expected_q, rtol=1e-12, atol=1e-14)
+
+
+def test_weak_drive_cd_approaches_drag():
+    """CD and DRAG share sign and strength in the weak-drive limit."""
+    t = np.arange(0.05, 40, 0.1)
+    kwargs: dict[str, Any] = dict(
+        duration=40,
+        amplitude=1e-4,
+        delta=-0.8,
+        tau=12,
+        type="Squad",
+        correction_factor=0.5,
+    )
+    cd = FlatTop.func(t, **kwargs, correction_type="CD")
+    drag = FlatTop.func(t, **kwargs, correction_type="DRAG")
+    assert_allclose(cd, drag, rtol=2e-8, atol=1e-14)
+
+
+@pytest.mark.parametrize("api", [Squad, FlatTop])
+def test_dimensionless_strength_and_output_scale(api):
+    """Angular-rate construction with final scaling preserves command-unit I/Q."""
+    k = 4.0
+    kwargs: dict[str, Any] = dict(duration=40, tau=12, sampling_period=0.1)
+    if api is FlatTop:
+        kwargs.update(type="Squad", correction_type="CD")
+    angular = api(
+        **kwargs,
+        amplitude=k * 0.6,
+        delta=k * (-0.8),
+        correction_factor=0.5,
+        scale=1 / k,
+    )
+    command_reference = FlatTop(
+        duration=40,
+        tau=12,
+        sampling_period=0.1,
+        amplitude=0.6,
+        delta=-0.8,
+        type="Squad",
+        correction_type="CD",
+        correction_factor=0.5 / k,
+    )
+    assert_allclose(angular.values, command_reference.values, rtol=1e-12, atol=1e-14)
+
+
+def test_cd_sign_follows_transition_minus_drive_hamiltonian():
+    """CD returns a two-level eigenstate under H=(-delta Z+I X+Q Y)/2."""
+    dt = 0.01
+    t = np.arange(dt / 2, 12, dt)
+    delta = -0.6
+    x = np.array([[0, 1], [1, 0]], dtype=complex)
+    y = np.array([[0, -1j], [1j, 0]])
+    z = np.diag([1, -1])
+    errors = []
+    for strength in (0.0, 1.0):
+        pulse = Squad.func(
+            t,
+            duration=12,
+            tau=4,
+            amplitude=0.9,
+            delta=delta,
+            correction_factor=strength,
+        )
+        state = np.array([1, 0], dtype=complex)
+        for sample in pulse:
+            h = (-delta * z + sample.real * x + sample.imag * y) / 2
+            state = expm(-1j * dt * h) @ state
+        errors.append(abs(state[1]) ** 2)
+    assert errors[1] < 1e-5
+    assert errors[0] > 1e-3


### PR DESCRIPTION
## Summary

Unify direct `Squad` and `FlatTop(type="Squad", correction_type="CD")` around one CD convention instead of asking callers to reverse signs between APIs.

- Use transition-minus-drive `delta`, an `I + i*Q` envelope, and shared `Q = -correction_factor * delta * dI/dt / (delta**2 + I**2)` implementation.
- Replace direct-SQUAD `factor` with `correction_factor` and reject removed legacy keywords instead of silently interpreting them with the new sign.
- Keep `FlatTop`'s existing CD/DRAG arithmetic, correction-disabled default, and ramp sampling behavior.
- Simplify class/function docstrings: compute amplitude/delta in rad/ns, keep correction strength dimensionless, and use final `scale=1/K` for command-unit output.
- Put historical sign differences and migration instructions in the English/Japanese migration guides.

## Breaking change and migration

This is an explicitly requested breaking change to the released direct-SQUAD API:

- Old `Squad(..., factor=x)` becomes `Squad(..., correction_factor=-x)` to preserve the old waveform.
- **Old omitted/None factor meant +1. To preserve that waveform, explicitly use new `correction_factor=-1`.** New omitted/None `correction_factor` means +1 in the unified convention, reversing the previous default Q.
- The instance attribute is now `correction_factor`; there is no compatibility alias.
- Existing `FlatTop` callers do not need a sign change.

Hardware unit conversion remains caller-supplied. No experimental checkout, running kernel, hardware configuration or calibration has been updated by this PR.

## Verification

Tests first: the new convention suite initially reported 27 failures and 8 passes, then all 35 passed after the implementation.

Final checks in the worktree's uv environment:

- `uv run --no-sync ruff check --fix` — passed
- `uv run --no-sync ruff format` — clean
- `uv run --no-sync pyright` — 0 errors, 0 warnings
- `uv run --no-sync pytest -q` — **1700 passed**
- `uv run --no-sync mkdocs build` — passed (existing parameter/autoreference documentation warnings)
- `git diff --check` — passed

Coverage includes equal I/Q for both APIs, old-factor migration, default/zero/half/negative strengths, lazy sampling, FlatTop formula preservation, weak-drive CD-to-DRAG agreement, angular-to-command scaling, and a two-level Hamiltonian sign/return sentinel. The physical sentinel is model evidence, not hardware validation.