### PR TITLE
fix: preserve Pauli Y signs in MLE tomography

### DIFF
--- a/src/qubex/analysis/state_tomography.py
+++ b/src/qubex/analysis/state_tomography.py
@@ -99,7 +99,10 @@ def mle_fit_density_matrix(
     b_list: list[float] = []
     for basis, val in expected_values.items():
         op = reduce(np.kron, [paulis[p] for p in basis])
-        A_list.append(op.reshape(1, -1).conj())
+        # Match cp.vec's column-major order: vec(op).H @ vec(rho) equals
+        # trace(op.H @ rho), or trace(op @ rho) for Hermitian Pauli operators.
+        # Mixing row-major operator coefficients with column-major rho flips Y.
+        A_list.append(op.reshape(1, -1, order="F").conj())
         b_list.append(val)
     A = np.vstack(A_list)
     b = np.array(b_list)

--- a/tests/analysis/test_state_tomography.py
+++ b/tests/analysis/test_state_tomography.py
@@ -1,0 +1,106 @@
+"""Public state-tomography regressions for complex coherence conventions."""
+
+from __future__ import annotations
+
+from functools import reduce
+from itertools import product
+
+import numpy as np
+import pytest
+from numpy.typing import NDArray
+
+from qubex.analysis.state_tomography import (
+    calculate_expected_values,
+    create_density_matrix,
+    mle_fit_density_matrix,
+)
+
+
+def _born_probabilities(rho: NDArray) -> dict[str, NDArray]:
+    """Generate ideal outcome probabilities from independent Pauli eigenvectors."""
+    eigenvectors = {
+        "X": (np.array([1, 1]), np.array([1, -1])),
+        "Y": (np.array([1, 1j]), np.array([1, -1j])),
+        "Z": (np.array([1, 0]), np.array([0, 1])),
+    }
+    n_qubits = round(np.log2(rho.shape[0]))
+    probabilities = {}
+    for axes in product("XYZ", repeat=n_qubits):
+        outcomes = []
+        for bits in product((0, 1), repeat=n_qubits):
+            vectors = [
+                eigenvectors[axis][bit] / np.linalg.norm(eigenvectors[axis][bit])
+                for axis, bit in zip(axes, bits, strict=True)
+            ]
+            vector = reduce(np.kron, vectors)
+            outcomes.append(float(np.vdot(vector, rho @ vector).real))
+        probabilities["".join(axes)] = np.asarray(outcomes)
+    return probabilities
+
+
+@pytest.mark.parametrize("sign", [1.0, -1.0], ids=["positive_y", "negative_y"])
+def test_mle_preserves_signed_y_expectation(sign: float) -> None:
+    """MLE reconstructs the supplied Y sign rather than conjugating the state."""
+    pauli_y = np.array([[0, -1j], [1j, 0]], dtype=complex)
+    probabilities = {
+        "X": np.array([0.5, 0.5]),
+        "Y": np.array([(1 + sign) / 2, (1 - sign) / 2]),
+        "Z": np.array([0.5, 0.5]),
+    }
+    linear = create_density_matrix(probabilities, mle_fit=False)
+    reconstructed = create_density_matrix(probabilities, mle_fit=True)
+
+    linear_y = float(np.trace(pauli_y @ linear).real)
+    mle_y = float(np.trace(pauli_y @ reconstructed).real)
+    assert linear_y == pytest.approx(sign, abs=1e-12)
+    assert mle_y == pytest.approx(sign, abs=1e-4)
+    np.testing.assert_allclose(reconstructed, linear, atol=1e-4, rtol=0)
+
+
+@pytest.mark.parametrize(
+    "vector",
+    [
+        np.array([np.sqrt(0.37), np.exp(0.73j) * np.sqrt(0.63)]),
+        np.array([np.sqrt(0.43), 0, 0, np.exp(1.13j) * np.sqrt(0.57)]),
+        np.kron(np.array([1, 1j]), np.array([1, -1j])) / 2,
+    ],
+    ids=["complex_qubit", "complex_bell", "opposite_y_product"],
+)
+def test_tomography_preserves_complex_coherences(vector: NDArray) -> None:
+    """Public linear and MLE reconstruction agree on independently generated Born data."""
+    dim = vector.size
+    expected = 0.8 * np.outer(vector, vector.conj()) + 0.2 * np.eye(dim) / dim
+    probabilities = _born_probabilities(expected)
+
+    linear = create_density_matrix(probabilities, mle_fit=False)
+    reconstructed = create_density_matrix(probabilities, mle_fit=True)
+
+    np.testing.assert_allclose(linear, expected, atol=1e-12, rtol=0)
+    np.testing.assert_allclose(reconstructed, expected, atol=1e-4, rtol=0)
+    assert np.min(np.linalg.eigvalsh(reconstructed)) >= -1e-10
+    assert np.trace(reconstructed).real == pytest.approx(1.0, abs=1e-10)
+
+
+def test_mle_preserves_a_general_mixed_two_qubit_state() -> None:
+    """MLE retains real and imaginary coherences across every entry of a mixed state."""
+    rng = np.random.default_rng(9735)
+    factor = rng.normal(size=(4, 4)) + 1j * rng.normal(size=(4, 4))
+    expected = factor @ factor.conj().T
+    expected /= np.trace(expected)
+    probabilities = _born_probabilities(expected)
+
+    reconstructed = mle_fit_density_matrix(calculate_expected_values(probabilities))
+
+    np.testing.assert_allclose(reconstructed, expected, atol=1e-4, rtol=0)
+
+
+@pytest.mark.parametrize("axis", ["X", "Z"])
+def test_mle_keeps_real_pauli_states_unchanged(axis: str) -> None:
+    """The coherence-sign correction leaves real-axis tomography unchanged."""
+    probabilities = {label: np.array([0.5, 0.5]) for label in "XYZ"}
+    probabilities[axis] = np.array([0.8, 0.2])
+    linear = create_density_matrix(probabilities, mle_fit=False)
+
+    reconstructed = create_density_matrix(probabilities, mle_fit=True)
+
+    np.testing.assert_allclose(reconstructed, linear, atol=1e-4, rtol=0)


### PR DESCRIPTION
## Background

The MLE tomography path flattened Pauli operators with NumPy's default C-order while CVXPY flattened the density matrix with `cp.vec(..., order="F")`. This mismatched coefficient layout transposed the operators, reversing signs for Pauli strings with an odd number of Y factors and potentially conjugating reconstructed complex coherences.

## Changes

- Explicitly flatten Pauli operators in F-order before taking their conjugate, matching the existing density-matrix vectorization.
- Document the corresponding Hermitian-operator expectation identity beside the numerical code.
- Add eight public-API regressions covering +Y/-Y, complex one-qubit and Bell-like states, an opposite-Y product state, a general mixed two-qubit state, and unchanged real X/Z states. Born probabilities are generated from independent Pauli eigenvectors.

## Impact and compatibility

Public signatures and result shapes are unchanged. The linear reconstruction path is unchanged; the MLE path now preserves the supplied Y sign and imaginary coherences. Affected previously saved MLE reconstructions can be regenerated from their original probabilities; this PR does not rewrite data or calibration files.

For a synthetic input with Y = +1, the reconstructed expectation changes from **-0.9999657776** on the base commit to **+0.9999657776** with this fix. This is numerical reconstruction evidence, not a hardware fidelity or calibration claim.

## Verification

- `uv run --no-sync ruff check --fix` — passed.
- `uv run --no-sync ruff format` — passed; only the new test file required formatting.
- `uv run --no-sync pyright` — 0 errors, 0 warnings.
- `uv run --no-sync pytest -q tests/analysis/test_state_tomography.py` — 8 passed.
- `uv run --no-sync pytest -q` — 1708 passed in 45.03 s.
- `git diff --cached --check` — passed before commit.

No hardware operations were performed. Documentation/package builds were not run because those surfaces are unchanged.