### PR TITLE
fix(quel3): align interfaces with quelware-client 0.6.1

### DIFF
--- a/src/qubex/backend/quel3/builders/sequencer_builder.py
+++ b/src/qubex/backend/quel3/builders/sequencer_builder.py
@@ -3,10 +3,13 @@
 from __future__ import annotations
 
 import math
-from collections.abc import Callable, Mapping
+from collections.abc import Mapping
 from typing import TypeVar
 
-from qubex.backend.quel3.interfaces import SequencerProtocol
+from qubex.backend.quel3.interfaces import (
+    SequencerFactoryProtocol,
+    SequencerProtocol,
+)
 from qubex.backend.quel3.models import Quel3ExecutionPayload
 
 T = TypeVar("T", bound=SequencerProtocol)
@@ -47,7 +50,7 @@ class Quel3SequencerBuilder:
         self,
         *,
         payload: Quel3ExecutionPayload,
-        sequencer_factory: Callable[..., T],
+        sequencer_factory: SequencerFactoryProtocol[T],
         default_sampling_period_ns: float,
         alias_bindings: Mapping[str, tuple[int, int]],
     ) -> T:
@@ -58,8 +61,8 @@ class Quel3SequencerBuilder:
         ----------
         payload : Quel3ExecutionPayload
             QuEL-3 execution payload from measurement adapter.
-        sequencer_factory : Callable[..., T]
-            Sequencer class or factory compatible with quelware `Sequencer`.
+        sequencer_factory : SequencerFactoryProtocol[T]
+            Quelware-compatible sequencer factory.
         default_sampling_period_ns : float
             Sequencer default sampling period in ns.
         alias_bindings : Mapping[str, tuple[int, int]]
@@ -70,8 +73,14 @@ class Quel3SequencerBuilder:
         T
             Built sequencer instance.
         """
+        iter_blank_ns = (
+            self._resolve_effective_shot_interval_ns(payload.shot_interval_ns)
+            if payload.shot_interval_ns > 0
+            else 0.0
+        )
         sequencer = sequencer_factory(
-            default_sampling_period_ns=default_sampling_period_ns
+            default_sampling_period_ns=default_sampling_period_ns,
+            iter_blank_ns=iter_blank_ns,
         )
         sequencer.set_iterations(payload.n_iterations)
 
@@ -127,10 +136,5 @@ class Quel3SequencerBuilder:
                         sampling_period_fs,
                     ),
                 )
-
-        if payload.shot_interval_ns > 0:
-            sequencer.extend_length_ns(
-                self._resolve_effective_shot_interval_ns(payload.shot_interval_ns)
-            )
 
         return sequencer

--- a/src/qubex/backend/quel3/interfaces/__init__.py
+++ b/src/qubex/backend/quel3/interfaces/__init__.py
@@ -16,6 +16,8 @@ from qubex.backend.quel3.interfaces.client import (
     QuelwareClientProtocol,
     ResourceIdProtocol,
     SessionProtocol,
+    UnitConfigurationProtocol,
+    UnitControlSpecProtocol,
 )
 from qubex.backend.quel3.interfaces.directives import (
     CaptureModeNamespaceProtocol,
@@ -35,7 +37,10 @@ from qubex.backend.quel3.interfaces.resolver import (
     InstrumentResolverFactory,
     InstrumentResolverProtocol,
 )
-from qubex.backend.quel3.interfaces.sequencer import SequencerProtocol
+from qubex.backend.quel3.interfaces.sequencer import (
+    SequencerFactoryProtocol,
+    SequencerProtocol,
+)
 
 __all__ = [
     "CaptureModeNamespaceProtocol",
@@ -60,8 +65,11 @@ __all__ = [
     "QuelwareClientProtocol",
     "ResourceIdProtocol",
     "ResultContainerProtocol",
+    "SequencerFactoryProtocol",
     "SequencerProtocol",
     "SessionProtocol",
     "SetCaptureModeFactory",
     "SetFrequencyFactory",
+    "UnitConfigurationProtocol",
+    "UnitControlSpecProtocol",
 ]

--- a/src/qubex/backend/quel3/interfaces/client.py
+++ b/src/qubex/backend/quel3/interfaces/client.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Iterable
+from collections.abc import Collection, Mapping
 from contextlib import AbstractAsyncContextManager
 from typing import Protocol, TypeAlias
 
@@ -191,21 +191,92 @@ class PortInfoProtocol(Protocol):
         ...
 
 
+class UnitControlSpecProtocol(Protocol):
+    """Unit-control specification protocol."""
+
+    @property
+    def key(self) -> str:
+        """Return the vendor-namespaced control key."""
+        ...
+
+    @property
+    def allowed_values(self) -> tuple[str, ...]:
+        """Return the control's allowed values."""
+        ...
+
+    @property
+    def current_value(self) -> str:
+        """Return the control's current value."""
+        ...
+
+
+class UnitConfigurationProtocol(Protocol):
+    """Unit-wide control configuration protocol."""
+
+    @property
+    def supported(self) -> tuple[UnitControlSpecProtocol, ...]:
+        """Return the controls supported by one unit."""
+        ...
+
+    def values(self) -> dict[str, str]:
+        """Return current control values keyed by control name."""
+        ...
+
+
 class SessionProtocol(Protocol):
-    """Minimal quelware session protocol."""
+    """Quelware session protocol used by the QuEL-3 backend."""
+
+    @property
+    def available_resource_ids(self) -> set[ResourceIdProtocol]:
+        """Return resource IDs locked by this session."""
+        ...
+
+    @property
+    def unit_labels(self) -> list[UnitLabelProtocol]:
+        """Return unit labels spanned by this session."""
+        ...
+
+    @property
+    def token(self) -> str:
+        """Return the open session token."""
+        ...
+
+    async def open(self) -> None:
+        """Open the session and lock its resources."""
+        ...
+
+    async def close(self) -> None:
+        """Close the session and release its resources."""
+        ...
+
+    async def extend(self, new_ttl_ms: int) -> bool:
+        """Extend the session lease to one new TTL in milliseconds."""
+        ...
 
     async def deploy_instruments(
         self,
         port_id: ResourceIdProtocol,
-        definitions: Iterable[InstrumentDefinitionProtocol],
+        definitions: Collection[InstrumentDefinitionProtocol],
         append: bool = False,
     ) -> list[InstrumentInfoProtocol]:
         """Deploy one or more instruments to one port."""
         ...
 
+    async def discard_instruments(self, port_id: ResourceIdProtocol) -> None:
+        """Discard all instruments deployed on one port."""
+        ...
+
+    async def configure_unit(
+        self,
+        unit_label: UnitLabelProtocol,
+        controls: Mapping[str, str],
+    ) -> dict[str, str]:
+        """Apply unit-wide controls and return their resulting values."""
+        ...
+
     async def trigger(
         self,
-        instrument_ids: Iterable[ResourceIdProtocol],
+        instrument_ids: Collection[ResourceIdProtocol],
         wait_ms: int | None = None,
     ) -> int:
         """Trigger one fixed-timeline session run."""
@@ -213,7 +284,19 @@ class SessionProtocol(Protocol):
 
 
 class QuelwareClientProtocol(Protocol):
-    """Minimal quelware client protocol for execution."""
+    """Quelware client protocol used by the QuEL-3 backend."""
+
+    async def start(self) -> None:
+        """Initialize the client on async-context entry."""
+        ...
+
+    async def stop(self) -> None:
+        """Close the client transport."""
+        ...
+
+    async def initialize(self) -> None:
+        """Discover units and initialize their agents."""
+        ...
 
     def list_unit_labels(self) -> list[UnitLabelProtocol]:
         """List available QuEL-3 unit labels."""
@@ -237,9 +320,16 @@ class QuelwareClientProtocol(Protocol):
         """Dump diagnostic state for one port resource ID."""
         ...
 
+    async def get_unit_configuration(
+        self,
+        unit_label: UnitLabelProtocol,
+    ) -> UnitConfigurationProtocol:
+        """Get unit-wide controls supported by one unit."""
+        ...
+
     def create_session(
         self,
-        resource_ids: Iterable[ResourceIdProtocol],
+        resource_ids: Collection[ResourceIdProtocol],
         ttl_ms: int = 4_000,
         tentative_ttl_ms: int = 1_000,
     ) -> AbstractAsyncContextManager[SessionProtocol]:

--- a/src/qubex/backend/quel3/interfaces/directives.py
+++ b/src/qubex/backend/quel3/interfaces/directives.py
@@ -26,6 +26,7 @@ class CaptureModeProtocol(Protocol):
 class CaptureModeNamespaceProtocol(Protocol):
     """Capture-mode enum namespace protocol."""
 
+    UNSPECIFIED: CaptureModeProtocol
     RAW_WAVEFORMS: CaptureModeProtocol
     AVERAGED_WAVEFORM: CaptureModeProtocol
     AVERAGED_VALUE: CaptureModeProtocol

--- a/src/qubex/backend/quel3/interfaces/driver.py
+++ b/src/qubex/backend/quel3/interfaces/driver.py
@@ -36,6 +36,11 @@ class ResultContainerProtocol(Protocol):
         """Return point capture-window IQ results keyed by window name."""
         ...
 
+    @property
+    def integer_result(self) -> Mapping[str, Sequence[int]]:
+        """Return integer results keyed by capture-window name."""
+        ...
+
 
 class InstrumentConfigProtocol(Protocol):
     """Minimal instrument-config protocol."""
@@ -46,8 +51,18 @@ class InstrumentConfigProtocol(Protocol):
         ...
 
     @property
+    def bitdepth(self) -> int:
+        """Return waveform sample bit depth."""
+        ...
+
+    @property
     def timeline_step_samples(self) -> int:
         """Return timeline-step alignment size in samples."""
+        ...
+
+    @property
+    def samples_per_tick(self) -> int:
+        """Return the number of samples per hardware clock tick."""
         ...
 
 
@@ -62,15 +77,22 @@ class InstrumentDriverProtocol(Protocol):
     async def apply(
         self,
         directive: DirectiveProtocol | Sequence[DirectiveProtocol],
-    ) -> None:
-        """Apply one or more fixed-timeline directives."""
+    ) -> bool:
+        """Apply one or more fixed-timeline directives and return success."""
         ...
 
     async def initialize(self) -> None:
         """Initialize instrument state before apply/trigger flow."""
         ...
 
-    async def wait_for_result(self) -> ResultContainerProtocol:
+    async def fetch_result(self) -> ResultContainerProtocol:
+        """Fetch the current fixed-timeline execution result."""
+        ...
+
+    async def wait_for_result(
+        self,
+        timeout_sec: float | None = None,
+    ) -> ResultContainerProtocol:
         """Wait for one fixed-timeline execution result."""
         ...
 

--- a/src/qubex/backend/quel3/interfaces/resolver.py
+++ b/src/qubex/backend/quel3/interfaces/resolver.py
@@ -18,14 +18,24 @@ class InstrumentResolverProtocol(Protocol):
         """Refresh instrument mapping from current resources."""
         ...
 
-    def resolve(self, aliases: list[str]) -> list[ResourceIdProtocol]:
+    def resolve(
+        self,
+        aliases: list[str],
+        unit: str | None = None,
+    ) -> list[ResourceIdProtocol]:
         """Resolve instrument aliases to resource IDs."""
+        ...
+
+    def find_inst_info_by_id(
+        self,
+        instrument_id: ResourceIdProtocol,
+    ) -> InstrumentInfoProtocol:
+        """Return one instrument info resolved by resource ID."""
         ...
 
     def find_inst_info_by_alias(
         self,
         alias: str,
-        *,
         unit: str | None = None,
     ) -> InstrumentInfoProtocol:
         """Return one instrument info resolved by alias."""

--- a/src/qubex/backend/quel3/interfaces/sequencer.py
+++ b/src/qubex/backend/quel3/interfaces/sequencer.py
@@ -2,7 +2,7 @@
 
 from __future__ import annotations
 
-from typing import Protocol
+from typing import Protocol, TypeVar
 
 import numpy.typing as npt
 
@@ -59,9 +59,29 @@ class SequencerProtocol(Protocol):
         """Extend timeline length by one additional duration in ns."""
         ...
 
+    def get_aligned_length_fs(self, post_blank_fs: int = 0) -> int:
+        """Return aligned timeline length with an optional trailing blank."""
+        ...
+
     def export_set_fixed_timeline_directive(
         self,
         instrument_alias: str,
     ) -> DirectiveProtocol:
         """Export fixed-timeline directive for one instrument alias."""
+        ...
+
+
+T_co = TypeVar("T_co", bound=SequencerProtocol, covariant=True)
+
+
+class SequencerFactoryProtocol(Protocol[T_co]):
+    """Factory protocol for quelware sequencers."""
+
+    def __call__(
+        self,
+        default_sampling_period_ns: float,
+        enforce_sample_grid: bool = True,
+        iter_blank_ns: float = 2_000,
+    ) -> T_co:
+        """Create one quelware sequencer."""
         ...

--- a/src/qubex/backend/quel3/managers/execution_manager.py
+++ b/src/qubex/backend/quel3/managers/execution_manager.py
@@ -32,6 +32,7 @@ from qubex.backend.quel3.interfaces import (
     QuelwareClientFactory,
     ResourceIdProtocol,
     ResultContainerProtocol,
+    SequencerFactoryProtocol,
     SequencerProtocol,
     SessionProtocol,
     SetCaptureModeFactory,
@@ -99,7 +100,7 @@ class _QuelwareExecutionApi:
 
     client_factory: QuelwareClientFactory
     instrument_resolver_factory: InstrumentResolverFactory
-    sequencer_factory: Callable[..., SequencerProtocol]
+    sequencer_factory: SequencerFactoryProtocol[SequencerProtocol]
     fixed_timeline_driver_factory: InstrumentDriverFactory
     set_frequency_directive_factory: SetFrequencyFactory
     set_capture_mode_directive_factory: SetCaptureModeFactory
@@ -971,7 +972,9 @@ class Quel3ExecutionManager:
         instrument_resolver_factory: InstrumentResolverFactory = (
             resolver_module.InstrumentResolver
         )
-        sequencer_factory: Callable[..., SequencerProtocol] = sequencer_module.Sequencer
+        sequencer_factory: SequencerFactoryProtocol[SequencerProtocol] = (
+            sequencer_module.Sequencer
+        )
         fixed_timeline_driver_factory: InstrumentDriverFactory = (
             driver_module.create_instrument_driver_fixed_timeline
         )

--- a/tests/backend/test_quel3_backend_controller.py
+++ b/tests/backend/test_quel3_backend_controller.py
@@ -527,6 +527,7 @@ def test_extract_capture_samples_from_waveform_result_container() -> None:
                 ]
             }
             self.iq_point_result = {}
+            self.integer_result = {}
 
     values = Quel3ExecutionManager._extract_capture_samples(
         _Result(),
@@ -554,6 +555,7 @@ def test_extract_capture_samples_from_raw_waveform_result_container() -> None:
                 ]
             }
             self.iq_point_result = {}
+            self.integer_result = {}
 
     values = Quel3ExecutionManager._extract_capture_samples(
         _Result(),
@@ -583,6 +585,7 @@ def test_extract_capture_samples_from_point_result_container() -> None:
             self.iq_point_result = {
                 "RQ00:0": [1.0 + 2.0j, 3.0 + 4.0j],
             }
+            self.integer_result = {}
 
     values = Quel3ExecutionManager._extract_capture_samples(
         _Result(),
@@ -1200,6 +1203,7 @@ class _FakeResultContainer:
     def __init__(self) -> None:
         self.iq_waveform_result = {}
         self.iq_point_result = {"alias-rq00:0": [1.0 + 0.0j]}
+        self.integer_result = {}
 
 
 class _FakeInstrumentDriver:
@@ -1222,8 +1226,15 @@ class _FakeInstrumentDriver:
 
 
 class _FakeSequencer:
-    def __init__(self, default_sampling_period_ns: float) -> None:
+    def __init__(
+        self,
+        default_sampling_period_ns: float,
+        enforce_sample_grid: bool = True,
+        iter_blank_ns: float = 2_000,
+    ) -> None:
         self.default_sampling_period_ns = default_sampling_period_ns
+        self.enforce_sample_grid = enforce_sample_grid
+        self.iter_blank_ns = iter_blank_ns
 
     def bind(
         self,
@@ -1266,6 +1277,9 @@ class _FakeSequencer:
     def extend_length_ns(self, additional_ns: float) -> None:
         del additional_ns
 
+    def get_aligned_length_fs(self, post_blank_fs: int = 0) -> int:
+        return post_blank_fs
+
     def export_set_fixed_timeline_directive(self, instrument_alias: str) -> object:
         return ("timeline", instrument_alias)
 
@@ -1287,6 +1301,7 @@ class _ParallelResultContainer:
     def __init__(self, alias: str, value: complex) -> None:
         self.iq_waveform_result = {}
         self.iq_point_result = {f"{alias}:0": [value]}
+        self.integer_result = {}
 
 
 class _ParallelInstrumentDriver:

--- a/tests/backend/test_quel3_sequencer_builder.py
+++ b/tests/backend/test_quel3_sequencer_builder.py
@@ -50,8 +50,15 @@ class _Binding:
 
 
 class _RecordingSequencer:
-    def __init__(self, default_sampling_period_ns: float) -> None:
+    def __init__(
+        self,
+        default_sampling_period_ns: float,
+        enforce_sample_grid: bool = True,
+        iter_blank_ns: float = 2_000,
+    ) -> None:
         self.default_sampling_period_ns = default_sampling_period_ns
+        self.enforce_sample_grid = enforce_sample_grid
+        self.iter_blank_ns = iter_blank_ns
         self.registered_waveforms: dict[str, _RegisteredWaveform] = {}
         self.events: list[_Event] = []
         self.capture_windows: list[_CaptureWindow] = []
@@ -123,6 +130,9 @@ class _RecordingSequencer:
 
     def extend_length_ns(self, additional_ns: float) -> None:
         self.extended_by_ns += additional_ns
+
+    def get_aligned_length_fs(self, post_blank_fs: int = 0) -> int:
+        return post_blank_fs
 
     def export_set_fixed_timeline_directive(
         self,
@@ -209,6 +219,7 @@ def test_builder_registers_waveforms_and_forwards_events() -> None:
         _Binding(alias="alias-RQ00", sampling_period_fs=400_000, step_samples=64)
     ]
     assert sequencer.extended_by_ns == pytest.approx(0.0)
+    assert sequencer.iter_blank_ns == pytest.approx(0.0)
     assert sequencer.iterations == 16
 
 
@@ -412,8 +423,8 @@ def test_builder_rejects_missing_alias_binding() -> None:
         )
 
 
-def test_builder_extends_timeline_length_to_match_interval() -> None:
-    """Given longer shot interval, builder extends sequencer length to match it."""
+def test_builder_passes_shot_interval_as_iteration_blank() -> None:
+    """Given a shot interval, builder passes its aligned value as the iteration blank."""
     payload = _make_payload(
         waveform_library={
             "wf_known": Quel3Waveform(
@@ -433,7 +444,6 @@ def test_builder_extends_timeline_length_to_match_interval() -> None:
                 length_ns=10.0,
             )
         },
-        n_iterations=1,
         shot_interval_ns=2048.0,
     )
 
@@ -445,11 +455,12 @@ def test_builder_extends_timeline_length_to_match_interval() -> None:
         alias_bindings={"alias-RQ00": (400_000, 64)},
     )
 
-    assert sequencer.extended_by_ns == pytest.approx(2048.0)
+    assert sequencer.iter_blank_ns == pytest.approx(2048.0)
+    assert sequencer.extended_by_ns == pytest.approx(0.0)
 
 
-def test_builder_applies_minimum_shot_interval_floor() -> None:
-    """Given tiny shot interval, builder extends by aligned minimum floor."""
+def test_builder_applies_minimum_iteration_blank_floor() -> None:
+    """Given a tiny shot interval, builder passes the aligned minimum iteration blank."""
     payload = _make_payload(
         waveform_library={
             "wf_known": Quel3Waveform(
@@ -469,7 +480,6 @@ def test_builder_applies_minimum_shot_interval_floor() -> None:
                 length_ns=10.0,
             )
         },
-        n_iterations=1,
         shot_interval_ns=1.0,
     )
 
@@ -481,4 +491,5 @@ def test_builder_applies_minimum_shot_interval_floor() -> None:
         alias_bindings={"alias-RQ00": (400_000, 64)},
     )
 
-    assert sequencer.extended_by_ns == pytest.approx(1024.0)
+    assert sequencer.iter_blank_ns == pytest.approx(1024.0)
+    assert sequencer.extended_by_ns == pytest.approx(0.0)


### PR DESCRIPTION
## Summary

- expand the QuEL-3 protocols to cover the currently abstracted quelware-client APIs, including Session.extend, unit configuration, driver result access, resolver lookup, and sequencer alignment
- add typed unit-configuration and sequencer-factory protocols and export them from the interface package
- pass the aligned shot interval through iter_blank_ns so repeated executions preserve the intended interval without double-padding the timeline

## Compatibility

The protocol changes are additive and retain existing symbols. Low-level client internals such as agent and agent_container remain outside the Qubex abstraction boundary.

## Verification

- full test suite: 2012 passed
- focused QuEL-3 tests: 58 passed
- Ruff checks and formatting: passed for the changed project files
- Pyright: passed for repository sources, excluding unrelated untracked nested projects