### PR TITLE
fix(quel3): conjugate registered waveform IQ

### DIFF
--- a/src/qubex/backend/quel3/builders/sequencer_builder.py
+++ b/src/qubex/backend/quel3/builders/sequencer_builder.py
@@ -6,6 +6,8 @@ import math
 from collections.abc import Mapping
 from typing import TypeVar
 
+import numpy as np
+
 from qubex.backend.quel3.interfaces import (
     SequencerFactoryProtocol,
     SequencerProtocol,
@@ -98,9 +100,10 @@ class Quel3SequencerBuilder:
             )
 
         for waveform_name, waveform_def in payload.waveform_library.items():
+            # Convert the registered shape to quelware IQ coordinates.
             sequencer.register_waveform(
                 waveform_name,
-                waveform_def.iq_array,
+                np.conj(waveform_def.iq_array),
                 sampling_period_ns=waveform_def.sampling_period_ns,
             )
 
@@ -119,7 +122,7 @@ class Quel3SequencerBuilder:
                         sampling_period_fs,
                     ),
                     gain=event.gain,
-                    # Invert sign
+                    # Complete the conjugation for the per-event phase.
                     phase_offset_deg=-event.phase_offset_deg,
                 )
 

--- a/tests/backend/test_quel3_sequencer_builder.py
+++ b/tests/backend/test_quel3_sequencer_builder.py
@@ -158,8 +158,8 @@ def _make_payload(
     )
 
 
-def test_builder_registers_waveforms_and_forwards_events() -> None:
-    """Given payload library/events, when building, waveforms and events are forwarded."""
+def test_builder_conjugates_waveforms_and_inverts_event_phase() -> None:
+    """Given complex IQ and phase, builder should conjugate the complete waveform."""
     waveform_name = "wf_shared_0000"
     waveform_values = np.array([1.0 + 0.0j, 0.3 + 0.2j], dtype=np.complex128)
     timeline = Quel3FixedTimeline(
@@ -197,7 +197,7 @@ def test_builder_registers_waveforms_and_forwards_events() -> None:
     assert set(sequencer.registered_waveforms.keys()) == {waveform_name}
     registered = sequencer.registered_waveforms[waveform_name]
     assert registered.sampling_period_ns == pytest.approx(0.4)
-    assert np.array_equal(registered.values, waveform_values)
+    assert np.array_equal(registered.values, np.conj(waveform_values))
     assert sequencer.events == [
         _Event(
             instrument_alias="alias-RQ00",
@@ -207,6 +207,21 @@ def test_builder_registers_waveforms_and_forwards_events() -> None:
             phase_offset_deg=-90.0,
         )
     ]
+    event = sequencer.events[0]
+    logical_waveform = (
+        waveform_values
+        * timeline.events[0].gain
+        * np.exp(1j * np.deg2rad(timeline.events[0].phase_offset_deg))
+    )
+    registered_waveform = (
+        registered.values * event.gain * np.exp(1j * np.deg2rad(event.phase_offset_deg))
+    )
+    np.testing.assert_allclose(
+        registered_waveform,
+        np.conj(logical_waveform),
+        rtol=0.0,
+        atol=1e-12,
+    )
     assert sequencer.capture_windows == [
         _CaptureWindow(
             instrument_alias="alias-RQ00",


### PR DESCRIPTION
## Background

The QuEL-3 builder currently negates per-event phase but forwards registered complex IQ samples unchanged. That only implements part of the required conjugation and produces the wrong quadrature for waveforms with non-zero imaginary samples.

## Summary

- Conjugate registered waveform IQ at the Qubex-to-quelware boundary.
- Keep the existing per-event phase sign inversion so the complete logical waveform is conjugated.
- Add a regression test that reconstructs shape, gain, and phase and compares the result with the conjugated logical waveform.

## Impact

- Corrects QuEL-3 output for complex IQ shapes such as DRAG and detuned waveforms.
- Leaves payload models, waveform reuse, sampling-period handling, and public API signatures unchanged.

## Compatibility

This is a runtime correctness fix with no compatibility shim or API migration. Hardware calibrations that compensated for the previous IQ orientation may need to be rechecked. Documentation changes are intentionally excluded from this PR.

## Validation

- uv run pytest tests/backend/test_quel3_sequencer_builder.py -k conjugates_waveforms_and_inverts_event_phase — 1 passed
- uv run pytest tests/backend/test_quel3_sequencer_builder.py — 8 passed
- uv run pytest tests/measurement/test_quel3_measurement_backend_adapter.py — 30 passed
- uv run ruff check --fix — passed
- uv run ruff format — passed
- uv run pyright — 0 errors, 0 warnings
- uv run pytest — 2008 passed, 17 existing warnings

## Follow-up

A QuEL-3 hardware smoke test was not run in this environment.