### PR TITLE
fix(measurement): preserve transforms when packing schedules

### DIFF
--- a/src/qubex/measurement/services/measurement_execution_service.py
+++ b/src/qubex/measurement/services/measurement_execution_service.py
@@ -12,7 +12,7 @@ from typing import Any, Literal, TypeAlias, TypeVar, cast
 
 import numpy as np
 from numpy.typing import ArrayLike
-from qxpulse import PulseSchedule, RampType
+from qxpulse import PulseChannel, PulseSchedule, RampType
 
 from qubex.backend import (
     BackendController,
@@ -37,7 +37,7 @@ from qubex.measurement.measurement_schedule_builder import (
 )
 from qubex.measurement.measurement_schedule_runner import MeasurementScheduleRunner
 from qubex.measurement.models.capture_data import CaptureData
-from qubex.measurement.models.capture_schedule import CaptureSchedule
+from qubex.measurement.models.capture_schedule import Capture, CaptureSchedule
 from qubex.measurement.models.measure_result import (
     MeasureResult,
     MultipleMeasureResult,
@@ -1026,6 +1026,24 @@ class MeasurementExecutionService:
         target_registry = self._context.experiment_system.target_registry
         return str(target_registry.measurement_output_label(capture_channel))
 
+    @staticmethod
+    def _create_empty_packed_pulse_schedule(
+        pulse_schedule: PulseSchedule,
+    ) -> PulseSchedule:
+        """Build an empty neutral schedule with matching channel metadata."""
+        channels: list[PulseChannel] = []
+        for label in pulse_schedule.labels:
+            sequence = pulse_schedule.get_sequence(label, copy=False)
+            channel = PulseChannel(
+                label=label,
+                frequency=pulse_schedule.get_frequency(label),
+                target=pulse_schedule.get_target(label),
+                frame=pulse_schedule.get_frame(label),
+            )
+            channel.sequence._sampling_period = sequence.sampling_period  # noqa: SLF001
+            channels.append(channel)
+        return PulseSchedule(channels)
+
     def _merge_measurement_schedules(
         self,
         *,
@@ -1036,17 +1054,17 @@ class MeasurementExecutionService:
         if len(schedules) == 0:
             raise ValueError("At least one schedule is required.")
 
-        merged_pulse_schedule = schedules[0].pulse_schedule.copy()
-        merged_captures = [
-            capture.model_copy(update={"channels": capture.channels.copy()})
-            for capture in schedules[0].capture_schedule.captures
-        ]
+        merged_pulse_schedule = self._create_empty_packed_pulse_schedule(
+            schedules[0].pulse_schedule
+        )
+        merged_captures: list[Capture] = []
 
-        for schedule in schedules[1:]:
-            # TODO: Base packed shifts on the full capture timeline, not only pulse duration.
-            shift_duration = merged_pulse_schedule.duration + shot_interval
-            merged_pulse_schedule.barrier()
-            merged_pulse_schedule.pad(shift_duration)
+        for index, schedule in enumerate(schedules):
+            shift_duration = 0.0
+            if index > 0:
+                shift_duration = merged_pulse_schedule.duration + shot_interval
+                merged_pulse_schedule.barrier()
+                merged_pulse_schedule.pad(shift_duration)
             merged_pulse_schedule.call(schedule.pulse_schedule, copy=True)
             merged_captures.extend(
                 capture.model_copy(

--- a/tests/measurement/test_measurement_execution_service.py
+++ b/tests/measurement/test_measurement_execution_service.py
@@ -9,7 +9,14 @@ from typing import Any, ClassVar, cast
 
 import numpy as np
 import pytest
-from qxpulse import Blank, PulseSchedule, Rect, get_sampling_period, set_sampling_period
+from qxpulse import (
+    Blank,
+    PulseChannel,
+    PulseSchedule,
+    Rect,
+    get_sampling_period,
+    set_sampling_period,
+)
 
 from qubex.backend import BackendExecutionRequest
 from qubex.measurement.models import (
@@ -401,6 +408,82 @@ def test_merge_measurement_schedules_appends_same_channels() -> None:
         pytest.approx(106.0)
     )
     assert merged_schedule.pulse_schedule.is_valid()
+
+
+def test_merge_measurement_schedules_preserves_per_schedule_transforms() -> None:
+    """Packing should preserve each schedule's scale, phase, and detuning."""
+    service = MeasurementExecutionService.__new__(MeasurementExecutionService)
+    first_schedule = _make_schedule(
+        label="Q00", capture_start=1.0, capture_target="Q00"
+    )
+    second_schedule = _make_schedule(
+        label="Q00", capture_start=2.0, capture_target="Q00"
+    )
+    first_schedule = first_schedule.model_copy(
+        update={
+            "pulse_schedule": first_schedule.pulse_schedule.scaled(0.1)
+            .shifted(0.2)
+            .detuned(0.003)
+        }
+    )
+    second_schedule = second_schedule.model_copy(
+        update={
+            "pulse_schedule": second_schedule.pulse_schedule.scaled(0.3)
+            .shifted(0.4)
+            .detuned(0.005)
+        }
+    )
+
+    merged_schedule = service._merge_measurement_schedules(  # noqa: SLF001
+        schedules=[first_schedule, second_schedule],
+        shot_interval=100.0,
+    )
+
+    waveforms = merged_schedule.pulse_schedule.get_sequence(
+        "Q00",
+        copy=False,
+    ).get_flattened_waveforms(apply_frame_shifts=False)
+    pulses = [waveform for waveform in waveforms if not isinstance(waveform, Blank)]
+    assert all(waveform.duration > 0.0 for waveform in waveforms)
+    assert [pulse.scale for pulse in pulses] == pytest.approx([0.1, 0.3])
+    assert [pulse.phase for pulse in pulses] == pytest.approx([0.2, 0.4])
+    assert [pulse.detuning for pulse in pulses] == pytest.approx([0.003, 0.005])
+
+
+def test_merge_measurement_schedules_preserves_first_channel_metadata() -> None:
+    """Packing into an empty schedule should preserve first-channel metadata."""
+    service = MeasurementExecutionService.__new__(MeasurementExecutionService)
+    original_sampling_period = get_sampling_period()
+    try:
+        set_sampling_period(2.0)
+        with PulseSchedule(
+            [
+                PulseChannel(
+                    label="Q00",
+                    frequency=5.25,
+                    target="Q00",
+                    frame="drive",
+                )
+            ]
+        ) as pulse_schedule:
+            pulse_schedule.add("Q00", Rect(duration=4.0, amplitude=0.1))
+    finally:
+        set_sampling_period(original_sampling_period)
+    schedule = MeasurementSchedule(
+        pulse_schedule=pulse_schedule,
+        capture_schedule=CaptureSchedule(captures=[]),
+    )
+
+    merged_schedule = service._merge_measurement_schedules(  # noqa: SLF001
+        schedules=[schedule],
+        shot_interval=100.0,
+    )
+
+    merged_pulse_schedule = merged_schedule.pulse_schedule
+    assert merged_pulse_schedule.get_frequencies() == {"Q00": 5.25}
+    assert merged_pulse_schedule.get_targets() == {"Q00": "Q00"}
+    assert merged_pulse_schedule.get_frames() == {"Q00": "drive"}
+    assert merged_pulse_schedule.get_sequence("Q00", copy=False).sampling_period == 2.0
 
 
 def test_split_merged_measurement_result_uses_capture_order_contract() -> None:


### PR DESCRIPTION
## Background

Packed schedule construction copied the first PulseSchedule into the accumulator. Its channel-level scale, phase, and detuning then acted as parent transforms for schedules appended later, corrupting packed sweeps such as resonator power sweeps.

## Changes

- Build a neutral empty PulseSchedule while preserving channel labels, frequencies, targets, frames, and sampling periods.
- Append every source schedule through the same PulseSchedule.call path so each local transform is applied exactly once.
- Add regression coverage for transform isolation, zero-duration waveform avoidance, and channel metadata preservation.

## Compatibility

This is an internal bug fix. It changes no public API, configuration format, or result schema.

## Validation

- uv run ruff check and uv run ruff format --check: passed with local untracked external directories excluded.
- Targeted pyright for the changed source and test files: 0 errors.
- Targeted measurement tests: 41 passed.
- Full pytest suite: 2010 passed, 17 warnings.

The repository-wide type check is not currently green for reasons outside this diff: uv run pyright src tests reports two pre-existing private-import errors in the unchanged tests/pulse/test_blank.py, while the root invocation additionally scans the local untracked packages/quelware-client directory and reports 34 errors there.