### PR TITLE
fix: reset virtual Z between packed schedules

### DIFF
--- a/src/qubex/measurement/services/measurement_execution_service.py
+++ b/src/qubex/measurement/services/measurement_execution_service.py
@@ -12,7 +12,7 @@ from typing import Any, Literal, TypeAlias, TypeVar, cast
 
 import numpy as np
 from numpy.typing import ArrayLike
-from qxpulse import PulseChannel, PulseSchedule, RampType
+from qxpulse import PulseChannel, PulseSchedule, RampType, VirtualZ
 
 from qubex.backend import (
     BackendController,
@@ -1050,7 +1050,7 @@ class MeasurementExecutionService:
         schedules: list[MeasurementSchedule],
         shot_interval: float,
     ) -> MeasurementSchedule:
-        """Build one measurement schedule by concatenating schedules separated by shot interval."""
+        """Concatenate schedules with neutral frames at experiment boundaries."""
         if len(schedules) == 0:
             raise ValueError("At least one schedule is required.")
 
@@ -1065,6 +1065,10 @@ class MeasurementExecutionService:
                 shift_duration = merged_pulse_schedule.duration + shot_interval
                 merged_pulse_schedule.barrier()
                 merged_pulse_schedule.pad(shift_duration)
+                frame_shifts = merged_pulse_schedule.get_final_frame_shifts()
+                for label, frame_shift in frame_shifts.items():
+                    if frame_shift != 0.0:
+                        merged_pulse_schedule.add(label, VirtualZ(frame_shift))
             merged_pulse_schedule.call(schedule.pulse_schedule, copy=True)
             merged_captures.extend(
                 capture.model_copy(

--- a/tests/measurement/test_measurement_execution_service.py
+++ b/tests/measurement/test_measurement_execution_service.py
@@ -14,6 +14,7 @@ from qxpulse import (
     PulseChannel,
     PulseSchedule,
     Rect,
+    VirtualZ,
     get_sampling_period,
     set_sampling_period,
 )
@@ -408,6 +409,38 @@ def test_merge_measurement_schedules_appends_same_channels() -> None:
         pytest.approx(106.0)
     )
     assert merged_schedule.pulse_schedule.is_valid()
+
+
+def test_merge_measurement_schedules_resets_virtual_z_between_schedules() -> None:
+    """Packing should keep one schedule's virtual Z from rotating the next schedule."""
+    service = MeasurementExecutionService.__new__(MeasurementExecutionService)
+    with PulseSchedule(["Q00"]) as first_pulse_schedule:
+        first_pulse_schedule.add("Q00", Rect(duration=4.0, amplitude=0.1))
+        first_pulse_schedule.add("Q00", VirtualZ(np.pi / 2))
+    with PulseSchedule(["Q00"]) as second_pulse_schedule:
+        second_pulse_schedule.add("Q00", Rect(duration=4.0, amplitude=0.2))
+    schedules = [
+        MeasurementSchedule(
+            pulse_schedule=pulse_schedule,
+            capture_schedule=CaptureSchedule(captures=[]),
+        )
+        for pulse_schedule in (first_pulse_schedule, second_pulse_schedule)
+    ]
+
+    merged_schedule = service._merge_measurement_schedules(  # noqa: SLF001
+        schedules=schedules,
+        shot_interval=100.0,
+    )
+
+    merged_waveforms = merged_schedule.pulse_schedule.get_sequence(
+        "Q00",
+        copy=False,
+    ).get_flattened_waveforms(apply_frame_shifts=True)
+    pulses = [
+        waveform for waveform in merged_waveforms if not isinstance(waveform, Blank)
+    ]
+    np.testing.assert_allclose(pulses[0].values, 0.1, rtol=0.0, atol=1e-12)
+    np.testing.assert_allclose(pulses[1].values, 0.2, rtol=0.0, atol=1e-12)
 
 
 def test_merge_measurement_schedules_preserves_per_schedule_transforms() -> None:


### PR DESCRIPTION
## Background

Schedule packing concatenates independent measurement schedules into one timeline. A virtual Z at the end of one schedule remained active and rotated pulses in the following schedule, making packed execution differ from separate execution.

## Changes

- Reset each channel accumulated frame shift before appending the next packed schedule.
- Add a regression test verifying that a virtual Z in the first schedule does not rotate the second schedule pulse.

## Impact

Packed measurement schedules now preserve the independent-frame semantics of unpacked execution. There are no public API or configuration changes.

## Compatibility

Schedule packing was introduced after v1.5.0rc2 and has not been released. No compatibility shim or migration is required.

## Validation

- uv run ruff check --fix
- uv run ruff format
- uv run pyright — 0 errors
- uv run pytest — 2011 passed

## Documentation

No documentation changes are required because this corrects unreleased internal packing behavior without changing the API or configuration.