### PR TITLE
feat(experiment): add classifier loading API

### DIFF
--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -634,6 +634,23 @@ class Experiment:
         """Load the calibration data from a given path or the default calibration note file."""
         return self.ctx.load_calib_note(path=path)
 
+    def load_classifier(self, path: Path | str | None = None) -> None:
+        """
+        Load state classifiers from a given path or the default classifier directory.
+
+        Parameters
+        ----------
+        path : Path | str | None, optional
+            Directory containing `<qubit>.pkl` files. Defaults to
+            `<classifier_dir>/<chip_id>`.
+
+        Notes
+        -----
+        Loaded classifiers are merged into the active classifier mapping.
+        Classifiers without a corresponding file remain unchanged.
+        """
+        return self.ctx.load_classifier(path=path)
+
     def get_qubit_label(self, index: int) -> str:
         """Get the qubit label from the given qubit index."""
         return self.ctx.get_qubit_label(index)

--- a/src/qubex/experiment/experiment_context.py
+++ b/src/qubex/experiment/experiment_context.py
@@ -233,10 +233,22 @@ class ExperimentContext:
         self._load_classifiers()
         self.print_environment(verbose=False)
 
-    def _load_classifiers(self):
+    def _resolve_classifier_dir(self, path: Path | str | None = None) -> Path:
+        """Resolve the directory containing classifier files."""
+        if path is None:
+            return self.classifier_dir / self.chip_id
+        return Path(path)
+
+    def _load_classifiers(self, path: Path | str | None = None) -> None:
+        """Load classifiers from disk and update the active classifier mapping."""
+        classifier_dir = self._resolve_classifier_dir(path)
+        if not classifier_dir.is_dir():
+            return
+
+        classifiers: TargetMap[StateClassifier] = {}
         for qubit in self.qubit_labels:
-            classifier_path = self.classifier_dir / self.chip_id / f"{qubit}.pkl"
-            if classifier_path.exists():
+            classifier_path = classifier_dir / f"{qubit}.pkl"
+            if classifier_path.is_file():
                 try:
                     classifier = StateClassifier.load(classifier_path)
                 except Exception as exc:
@@ -250,7 +262,11 @@ class ExperimentContext:
                         ),
                     )
                     continue
-                self._measurement.update_classifiers({qubit: classifier})
+                classifiers[qubit] = classifier
+
+        if classifiers:
+            self._measurement.update_classifiers(classifiers)
+            logger.info(f"State classifiers loaded from {classifier_dir}")
 
     @staticmethod
     def _is_classifier_compatibility_error(exc: BaseException) -> bool:
@@ -752,6 +768,39 @@ class ExperimentContext:
             raise CalibrationMissingError(
                 f"Failed to load calibration data from {path}: {e}"
             ) from e
+
+    def load_classifier(self, path: Path | str | None = None) -> None:
+        """
+        Load state classifiers from a given path or the default classifier directory.
+
+        Parameters
+        ----------
+        path : Path | str | None, optional
+            Directory containing `<qubit>.pkl` files. Defaults to
+            `<classifier_dir>/<chip_id>`.
+
+        Notes
+        -----
+        Loaded classifiers are merged into the active classifier mapping.
+        Classifiers without a corresponding file remain unchanged.
+        """
+        classifier_dir = self._resolve_classifier_dir(path)
+        if not classifier_dir.exists():
+            raise FileNotFoundError(
+                f"Classifier directory '{classifier_dir}' does not exist."
+            )
+        if not classifier_dir.is_dir():
+            raise NotADirectoryError(
+                f"Classifier path '{classifier_dir}' is not a directory."
+            )
+        if not any(
+            (classifier_dir / f"{qubit}.pkl").is_file() for qubit in self.qubit_labels
+        ):
+            raise FileNotFoundError(
+                f"No classifier files for configured qubits were found in "
+                f"'{classifier_dir}'."
+            )
+        self._load_classifiers(path=classifier_dir)
 
     def get_qubit_label(self, index: int) -> str:
         """Get the qubit label from the given qubit index."""

--- a/tests/experiment/test_experiment_context_classifier_loading.py
+++ b/tests/experiment/test_experiment_context_classifier_loading.py
@@ -19,21 +19,16 @@ class _MeasurementStub:
         self.classifiers.update(classifiers)
 
 
-class _TestExperimentContext(ExperimentContext):
-    def load_classifiers(self) -> None:
-        self._load_classifiers()
-
-
-def _make_context(tmp_path: Path) -> _TestExperimentContext:
+def _make_context(tmp_path: Path) -> ExperimentContext:
     """Create a minimal context instance for classifier-loading tests."""
-    context = object.__new__(_TestExperimentContext)
+    context = object.__new__(ExperimentContext)
     context.__dict__["_qubits"] = ["Q00", "Q01"]
     context.__dict__["_classifier_dir"] = tmp_path
     context.__dict__["_chip_id"] = "test-chip"
     context.__dict__["_measurement"] = _MeasurementStub()
 
     classifier_path = tmp_path / "test-chip"
-    classifier_path.mkdir()
+    classifier_path.mkdir(parents=True)
     for qubit in context.qubit_labels:
         (classifier_path / f"{qubit}.pkl").write_bytes(b"classifier")
 
@@ -57,7 +52,7 @@ def test_load_classifiers_warns_and_skips_compatibility_failure(
     monkeypatch.setattr(StateClassifier, "load", staticmethod(_load))
 
     caplog.set_level(logging.WARNING, logger="qubex.experiment.experiment_context")
-    context.load_classifiers()
+    context.load_classifier()
 
     assert "Failed to load state classifier for Q00" in caplog.text
     assert "compatibility issue" in caplog.text
@@ -74,11 +69,65 @@ def test_load_classifiers_propagates_non_compatibility_failure(
 ) -> None:
     """Given unrelated classifier load failure, when loading, then the original error is raised."""
     context = _make_context(tmp_path)
+    loaded_classifier = object()
 
-    def _load(_path: Path | str) -> object:
-        raise ValueError("broken classifier payload")
+    def _load(path: Path | str) -> object:
+        if Path(path).name == "Q01.pkl":
+            raise ValueError("broken classifier payload")
+        return loaded_classifier
 
     monkeypatch.setattr(StateClassifier, "load", staticmethod(_load))
 
     with pytest.raises(ValueError, match="broken classifier payload"):
-        context.load_classifiers()
+        context.load_classifier()
+
+    assert context.classifiers == {}
+
+
+def test_load_classifier_uses_custom_classifier_directory(
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given a custom classifier directory, when loading, then classifiers are read from that directory."""
+    default_dir = tmp_path / "default"
+    custom_dir = tmp_path / "custom" / "test-chip"
+    context = _make_context(default_dir)
+    custom_dir.mkdir(parents=True)
+    for qubit in context.qubit_labels:
+        (custom_dir / f"{qubit}.pkl").write_bytes(b"classifier")
+
+    loaded_paths: list[Path] = []
+
+    def _load(path: Path | str) -> object:
+        loaded_paths.append(Path(path))
+        return object()
+
+    monkeypatch.setattr(StateClassifier, "load", staticmethod(_load))
+
+    context.load_classifier(path=custom_dir)
+
+    assert loaded_paths == [
+        custom_dir / "Q00.pkl",
+        custom_dir / "Q01.pkl",
+    ]
+
+
+def test_load_classifier_rejects_missing_directory(tmp_path: Path) -> None:
+    """Given a missing classifier directory, when loading, then a file-not-found error is raised."""
+    context = _make_context(tmp_path / "default")
+    missing_dir = tmp_path / "missing"
+
+    with pytest.raises(FileNotFoundError, match=str(missing_dir)):
+        context.load_classifier(path=missing_dir)
+
+
+def test_load_classifier_rejects_directory_without_classifier_files(
+    tmp_path: Path,
+) -> None:
+    """Given an empty classifier directory, when loading, then a file-not-found error is raised."""
+    context = _make_context(tmp_path / "default")
+    empty_dir = tmp_path / "empty"
+    empty_dir.mkdir()
+
+    with pytest.raises(FileNotFoundError, match="No classifier files"):
+        context.load_classifier(path=empty_dir)

--- a/tests/experiment/test_experiment_facade_delegation.py
+++ b/tests/experiment/test_experiment_facade_delegation.py
@@ -126,6 +126,9 @@ class _ExperimentContextStub:
     def reload(self) -> None:
         self.calls.append(("reload", {}))
 
+    def load_classifier(self, path: object = None) -> None:
+        self.calls.append(("load_classifier", {"path": path}))
+
     def register_custom_target(self, **kwargs: Any) -> None:
         self.calls.append(("register_custom_target", kwargs))
 
@@ -420,6 +423,17 @@ def test_print_boxes_delegates_to_context() -> None:
     exp.print_boxes()
 
     assert context_stub.calls == [("print_boxes", {})]
+
+
+def test_load_classifier_delegates_to_context() -> None:
+    """Given a classifier path, when loading, then it delegates to experiment context."""
+    exp = object.__new__(Experiment)
+    context_stub = _ExperimentContextStub()
+    exp.__dict__["_experiment_context"] = context_stub
+
+    exp.load_classifier(path="custom-classifiers")
+
+    assert context_stub.calls == [("load_classifier", {"path": "custom-classifiers"})]
 
 
 def test_clifford_generator_property_delegates_to_benchmarking_service() -> None:


### PR DESCRIPTION
## Background

Experiment previously loaded saved state classifiers only during context initialization. Users need an explicit facade API to reload classifier files from disk.

## Summary

- Add Experiment.load_classifier as a thin facade over ExperimentContext.
- Resolve and validate classifier directories before explicit loads.
- Load classifiers before updating the active mapping to avoid partial updates on non-compatibility failures.
- Preserve the existing warning-and-skip behavior for pickle compatibility errors.
- Add coverage for facade delegation, custom paths, invalid directories, compatibility failures, and atomic updates.

## API impact

The new load_classifier(path=None) API loads files from classifier_dir/chip_id by default or from a supplied directory containing per-qubit pickle files. Successfully loaded classifiers replace only matching entries in the active classifier mapping; unmatched existing entries remain unchanged.

## Compatibility

This is a new, unreleased API, so no compatibility shim or migration is required. Automatic classifier loading during ExperimentContext initialization remains best-effort when the default directory is absent.

## Validation

- uv run ruff check --fix: passed
- uv run ruff format: passed
- uv run pyright: 0 errors
- focused experiment tests: 45 passed
- uv run pytest: 2014 passed, 17 existing deprecation warnings

## Follow-ups

- Target selection via targets and returning the loaded TargetMap are not included in this PR.
- No handwritten documentation page lists this API; source docstrings were updated for generated API reference. A separate MkDocs build was not run.