### PR TITLE
fix: validate 2Q RB classifiers before measurement

### DIFF
--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -5251,7 +5251,14 @@ class Experiment:
         plot: bool | None = None,
         save_image: bool | None = None,
     ) -> Result:
-        """Run randomized benchmarking for the specified targets."""
+        """
+        Run randomized benchmarking for the specified targets.
+
+        Notes
+        -----
+        Two-qubit randomized benchmarking requires state classifiers for both
+        the control and target qubits.
+        """
         return self.benchmarking_service.randomized_benchmarking(
             targets=targets,
             n_cliffords_range=n_cliffords_range,

--- a/src/qubex/experiment/services/benchmarking_service.py
+++ b/src/qubex/experiment/services/benchmarking_service.py
@@ -508,7 +508,14 @@ class BenchmarkingService:
         save_image: bool | None = None,
         reset_awg_and_capunits: bool | None = None,
     ) -> Result:
-        """Run two-qubit randomized benchmarking."""
+        """
+        Run two-qubit randomized benchmarking.
+
+        Notes
+        -----
+        Two-qubit randomized benchmarking requires state classifiers for both
+        the control and target qubits.
+        """
         if in_parallel is None:
             in_parallel = False
         if mitigate_readout is None:
@@ -534,6 +541,18 @@ class BenchmarkingService:
             if self.ctx.experiment_system.get_target(target).is_cr
             and target in self.ctx.calib_note.cr_params
         ]
+
+        missing_classifiers = list(
+            dict.fromkeys(
+                qubit
+                for target in targets
+                for qubit in self.ctx.cr_pair(target)
+                if self.ctx.classifiers.get(qubit) is None
+            )
+        )
+        if missing_classifiers:
+            missing = ", ".join(missing_classifiers)
+            raise ValueError(f"Classifier not found for {missing}.")
 
         if n_cliffords_range is not None:
             n_cliffords_range = np.array(n_cliffords_range, dtype=int)

--- a/tests/experiment/test_benchmarking_service_classifier_validation.py
+++ b/tests/experiment/test_benchmarking_service_classifier_validation.py
@@ -1,0 +1,55 @@
+"""Tests for classifier validation in randomized benchmarking."""
+
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+from qxpulse import PulseSchedule
+
+from qubex.experiment.services.benchmarking_service import BenchmarkingService
+
+
+@pytest.mark.parametrize("missing_classifier", ["Q17", "Q18"])
+def test_randomized_benchmarking_2q_checks_classifiers_before_measurement(
+    missing_classifier: str,
+) -> None:
+    """Given a missing 2Q classifier, when RB starts, then it fails before measurement."""
+    measurement_calls: list[object] = []
+    classifiers = {
+        qubit: object() for qubit in ("Q17", "Q18") if qubit != missing_classifier
+    }
+
+    def measure(**_kwargs: object) -> None:
+        measurement_calls.append(object())
+        raise ValueError(f"Classifier not found for {missing_classifier}.")
+
+    service = cast(Any, object.__new__(BenchmarkingService))
+    service.__dict__["_experiment_context"] = SimpleNamespace(
+        classifiers=classifiers,
+        state_centers={"Q17": {0: 0j}, "Q18": {0: 0j}},
+        experiment_system=SimpleNamespace(
+            get_target=lambda _label: SimpleNamespace(is_cr=True)
+        ),
+        calib_note=SimpleNamespace(cr_params={"CR17-18": object()}),
+        cr_pair=lambda _label: ("Q17", "Q18"),
+    )
+    service.__dict__["_measurement_service"] = SimpleNamespace(measure=measure)
+    service.__dict__["_pulse_service"] = SimpleNamespace()
+    service.__dict__["rb_sequence_2q"] = lambda **_kwargs: PulseSchedule(["Q17", "Q18"])
+
+    with pytest.raises(
+        ValueError,
+        match=rf"^Classifier not found for {missing_classifier}\.$",
+    ):
+        service.randomized_benchmarking(
+            targets="CR17-18",
+            n_cliffords_range=[0],
+            n_trials=1,
+            seeds=[0],
+            plot=False,
+            save_image=False,
+        )
+
+    assert measurement_calls == []


### PR DESCRIPTION
## Background

Two-qubit randomized benchmarking reported missing state classifiers only after quantum computer execution had completed.

## Summary

- validate state classifiers for both control and target qubits before starting 2Q RB measurement
- include the missing qubit labels in the validation error
- document the classifier prerequisite in the RB docstrings
- add regression coverage for missing control and target classifiers

## User impact

2Q randomized benchmarking now fails immediately with a clear ValueError when a required classifier is unavailable, avoiding unnecessary hardware execution.

## Compatibility

No public API signatures or result shapes change. Valid workflows continue unchanged; only the timing of the existing missing-classifier failure moves before measurement.

## Validation

- uv run ruff check --fix
- uv run ruff format
- uv run pyright: 0 errors
- uv run pytest: 2012 passed, 17 warnings