### PR TITLE
fix(core): cancel async bridge task on interrupt

### DIFF
--- a/src/qubex/core/async_bridge.py
+++ b/src/qubex/core/async_bridge.py
@@ -145,6 +145,9 @@ class AsyncBridge:
             raise TimeoutError(
                 "Timed out while waiting for asynchronous bridge execution."
             ) from error
+        except BaseException:
+            bridge_future.cancel()
+            raise
 
     def close(self) -> None:
         """Stop the dedicated bridge loop and close this bridge."""

--- a/tests/core/test_async_bridge.py
+++ b/tests/core/test_async_bridge.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import _thread
 import asyncio
 import contextvars
 import threading
@@ -76,36 +77,36 @@ def test_run_inside_running_loop_cancels_on_timeout(bridge: AsyncBridge) -> None
 
 def test_run_inside_running_loop_cancels_on_keyboard_interrupt(
     bridge: AsyncBridge,
-    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given an interrupted wait, bridge should cancel its background task."""
+    started = threading.Event()
+    cancelled = threading.Event()
 
-    class _InterruptingFuture:
-        def __init__(self) -> None:
-            self.cancelled = False
+    async def _hang_forever() -> None:
+        started.set()
+        try:
+            await asyncio.Event().wait()
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
 
-        def result(self, timeout: float | None = None) -> None:
-            del timeout
-            raise KeyboardInterrupt
-
-        def cancel(self) -> bool:
-            self.cancelled = True
-            return True
-
-    interrupting_future = _InterruptingFuture()
-    monkeypatch.setattr(
-        bridge,
-        "_submit",
-        lambda **_: interrupting_future,
-    )
+    def _interrupt_after_start() -> None:
+        assert started.wait(timeout=1.0)
+        _thread.interrupt_main()
 
     async def _invoke() -> None:
         with pytest.raises(KeyboardInterrupt):
-            bridge.run(lambda: asyncio.sleep(0), timeout=1.0)
+            bridge.run(lambda: _hang_forever(), timeout=1.0)
 
-    asyncio.run(_invoke())
+    interrupter = threading.Thread(target=_interrupt_after_start)
+    interrupter.start()
+    try:
+        asyncio.run(_invoke())
+    finally:
+        interrupter.join(timeout=1.0)
 
-    assert interrupting_future.cancelled is True
+    assert not interrupter.is_alive()
+    assert cancelled.wait(timeout=1.0)
 
 
 def test_run_inside_running_loop_propagates_cancelled_error(

--- a/tests/core/test_async_bridge.py
+++ b/tests/core/test_async_bridge.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
-import _thread
 import asyncio
 import contextvars
+import signal
 import threading
 import time
 from collections.abc import Generator
+from types import FrameType
 
 import pytest
 
@@ -75,6 +76,10 @@ def test_run_inside_running_loop_cancels_on_timeout(bridge: AsyncBridge) -> None
     assert cancelled.wait(timeout=1.0)
 
 
+@pytest.mark.skipif(
+    not hasattr(signal, "pthread_kill") or not hasattr(signal, "SIGUSR1"),
+    reason="requires thread-directed signal support",
+)
 def test_run_inside_running_loop_cancels_on_keyboard_interrupt(
     bridge: AsyncBridge,
 ) -> None:
@@ -90,20 +95,33 @@ def test_run_inside_running_loop_cancels_on_keyboard_interrupt(
             cancelled.set()
             raise
 
+    def _raise_keyboard_interrupt(
+        signal_number: int,
+        frame: FrameType | None,
+    ) -> None:
+        del signal_number, frame
+        raise KeyboardInterrupt
+
+    main_thread_id = threading.get_ident()
+
     def _interrupt_after_start() -> None:
-        assert started.wait(timeout=1.0)
-        _thread.interrupt_main()
+        assert started.wait(timeout=10.0)
+        signal.pthread_kill(main_thread_id, signal.SIGUSR1)
 
     async def _invoke() -> None:
         with pytest.raises(KeyboardInterrupt):
-            bridge.run(lambda: _hang_forever(), timeout=1.0)
+            bridge.run(lambda: _hang_forever(), timeout=10.0)
 
-    interrupter = threading.Thread(target=_interrupt_after_start)
-    interrupter.start()
+    previous_handler = signal.signal(signal.SIGUSR1, _raise_keyboard_interrupt)
     try:
-        asyncio.run(_invoke())
+        interrupter = threading.Thread(target=_interrupt_after_start)
+        interrupter.start()
+        try:
+            asyncio.run(_invoke())
+        finally:
+            interrupter.join(timeout=1.0)
     finally:
-        interrupter.join(timeout=1.0)
+        signal.signal(signal.SIGUSR1, previous_handler)
 
     assert not interrupter.is_alive()
     assert cancelled.wait(timeout=1.0)

--- a/tests/core/test_async_bridge.py
+++ b/tests/core/test_async_bridge.py
@@ -74,6 +74,40 @@ def test_run_inside_running_loop_cancels_on_timeout(bridge: AsyncBridge) -> None
     assert cancelled.wait(timeout=1.0)
 
 
+def test_run_inside_running_loop_cancels_on_keyboard_interrupt(
+    bridge: AsyncBridge,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Given an interrupted wait, bridge should cancel its background task."""
+
+    class _InterruptingFuture:
+        def __init__(self) -> None:
+            self.cancelled = False
+
+        def result(self, timeout: float | None = None) -> None:
+            del timeout
+            raise KeyboardInterrupt
+
+        def cancel(self) -> bool:
+            self.cancelled = True
+            return True
+
+    interrupting_future = _InterruptingFuture()
+    monkeypatch.setattr(
+        bridge,
+        "_submit",
+        lambda **_: interrupting_future,
+    )
+
+    async def _invoke() -> None:
+        with pytest.raises(KeyboardInterrupt):
+            bridge.run(lambda: asyncio.sleep(0), timeout=1.0)
+
+    asyncio.run(_invoke())
+
+    assert interrupting_future.cancelled is True
+
+
 def test_run_inside_running_loop_propagates_cancelled_error(
     bridge: AsyncBridge,
 ) -> None:

--- a/tests/core/test_async_bridge.py
+++ b/tests/core/test_async_bridge.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import concurrent.futures
 import contextvars
 import signal
 import threading
@@ -82,10 +83,23 @@ def test_run_inside_running_loop_cancels_on_timeout(bridge: AsyncBridge) -> None
 )
 def test_run_inside_running_loop_cancels_on_keyboard_interrupt(
     bridge: AsyncBridge,
+    monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Given an interrupted wait, bridge should cancel its background task."""
     started = threading.Event()
+    waiting = threading.Event()
     cancelled = threading.Event()
+    original_result = concurrent.futures.Future.result
+
+    def _wait_for_result(
+        future: concurrent.futures.Future[None],
+        timeout: float | None = None,
+    ) -> None:
+        # Signal only once run() has entered its protected result wait.
+        waiting.set()
+        return original_result(future, timeout=timeout)
+
+    monkeypatch.setattr(concurrent.futures.Future, "result", _wait_for_result)
 
     async def _hang_forever() -> None:
         started.set()
@@ -106,6 +120,7 @@ def test_run_inside_running_loop_cancels_on_keyboard_interrupt(
 
     def _interrupt_after_start() -> None:
         assert started.wait(timeout=10.0)
+        assert waiting.wait(timeout=10.0)
         signal.pthread_kill(main_thread_id, signal.SIGUSR1)
 
     async def _invoke() -> None:


### PR DESCRIPTION
## Background

In environments with an already-running event loop, including Jupyter notebooks, synchronous APIs run their coroutine on the `AsyncBridge` background loop. If the caller is interrupted while waiting for the result, the background task previously remained active because only timeout errors cancelled the submitted future.

## Summary

- cancel the submitted bridge future when result waiting exits through `BaseException`, including `KeyboardInterrupt`
- re-raise the original interruption unchanged
- add a regression test for cancellation during an interrupted wait

## Impact

Interrupted synchronous calls now propagate cancellation to their background task, allowing coroutine cleanup handlers to run. The `AsyncBridge` API signature and successful-call behavior are unchanged.

## Compatibility

This is a behavioral bug fix with no migration required.

## Verification

- `uv run ruff check --fix`: passed
- `uv run ruff format`: passed, no changes
- `uv run pyright`: passed with 0 errors
- `uv run pytest`: 2011 passed, 17 existing deprecation warnings
