### PR TITLE
feat: expose spectroscopy drive timing options

### DIFF
--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -4887,6 +4887,7 @@ class Experiment:
         shot_interval: float | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
+        simultaneous_drive: bool | None = None,
     ) -> Result:
         """
         Scan qubit frequencies to locate resonances.
@@ -4902,10 +4903,14 @@ class Experiment:
         control_amplitude : float | None, optional
             Amplitude of the control pulse. If None, uses the value in
             `self.params.control_amplitude`.
+        simultaneous_drive : bool | None, optional
+            Whether control and readout pulses start together. False starts
+            readout after the control pulse ends. None defaults to True.
         """
         return self.characterization_service.scan_qubit_frequencies(
             target=target,
             frequency_range=frequency_range,
+            simultaneous_drive=simultaneous_drive,
             control_amplitude=control_amplitude,
             readout_amplitude=readout_amplitude,
             readout_frequency=readout_frequency,
@@ -4930,11 +4935,21 @@ class Experiment:
         shot_interval: float | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
+        simultaneous_drive: bool | None = None,
     ) -> Result:
-        """Estimate control amplitude from a resonance scan."""
+        """
+        Estimate control amplitude from a resonance scan.
+
+        Parameters
+        ----------
+        simultaneous_drive : bool | None, optional
+            Whether control and readout pulses start together. False starts
+            readout after the control pulse ends. None defaults to True.
+        """
         return self.characterization_service.estimate_control_amplitude(
             target=target,
             frequency_range=frequency_range,
+            simultaneous_drive=simultaneous_drive,
             control_amplitude=control_amplitude,
             readout_amplitude=readout_amplitude,
             target_rabi_rate=target_rabi_rate,
@@ -4956,11 +4971,21 @@ class Experiment:
         shot_interval: float | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
+        simultaneous_drive: bool | None = None,
     ) -> Result:
-        """Measure qubit resonance over a frequency sweep."""
+        """
+        Measure qubit resonance over a frequency sweep.
+
+        Parameters
+        ----------
+        simultaneous_drive : bool | None, optional
+            Whether control and readout pulses start together. False starts
+            readout after the control pulse ends. None defaults to True.
+        """
         return self.characterization_service.measure_qubit_resonance(
             target=target,
             frequency_range=frequency_range,
+            simultaneous_drive=simultaneous_drive,
             control_amplitude=control_amplitude,
             readout_amplitude=readout_amplitude,
             target_rabi_rate=target_rabi_rate,
@@ -4981,11 +5006,22 @@ class Experiment:
         shot_interval: float | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
+        *,
+        simultaneous_drive: bool | None = None,
     ) -> Result:
-        """Run qubit spectroscopy over frequency and power."""
+        """
+        Run qubit spectroscopy over frequency and power.
+
+        Parameters
+        ----------
+        simultaneous_drive : bool | None, optional
+            Whether control and readout pulses start together. False starts
+            readout after the control pulse ends. None defaults to True.
+        """
         return self.characterization_service.qubit_spectroscopy(
             target=target,
             frequency_range=frequency_range,
+            simultaneous_drive=simultaneous_drive,
             power_range=power_range,
             readout_amplitude=readout_amplitude,
             readout_frequency=readout_frequency,

--- a/src/qubex/experiment/services/characterization_service.py
+++ b/src/qubex/experiment/services/characterization_service.py
@@ -3196,6 +3196,9 @@ class CharacterizationService:
             Control frequency sweep range in GHz.
         control_amplitude
             Drive amplitude during the sweep.
+        simultaneous_drive : bool | None, optional
+            Whether control and readout pulses start together. False starts
+            readout after the control pulse ends. None defaults to True.
         """
         if simultaneous_drive is None:
             simultaneous_drive = True
@@ -3468,6 +3471,7 @@ class CharacterizationService:
         interval: float | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
+        simultaneous_drive: bool | None = None,
     ) -> Result:
         """
         Estimate control amplitude from a resonance scan.
@@ -3480,6 +3484,9 @@ class CharacterizationService:
             Frequency sweep range in GHz.
         target_rabi_rate
             Target Rabi rate used for scaling.
+        simultaneous_drive : bool | None, optional
+            Whether control and readout pulses start together. False starts
+            readout after the control pulse ends. None defaults to True.
         """
         if target_rabi_rate is None:
             target_rabi_rate = DEFAULT_RABI_FREQUENCY
@@ -3501,6 +3508,7 @@ class CharacterizationService:
         data = self.scan_qubit_frequencies(
             target,
             frequency_range=frequency_range,
+            simultaneous_drive=simultaneous_drive,
             control_amplitude=control_amplitude,
             readout_amplitude=readout_amplitude,
             shots=shots,
@@ -3585,6 +3593,7 @@ class CharacterizationService:
         interval: float | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
+        simultaneous_drive: bool | None = None,
     ) -> Result:
         """
         Measure qubit resonance and estimate control amplitude.
@@ -3598,6 +3607,9 @@ class CharacterizationService:
         target_rabi_rate
             Target Rabi rate used for scaling in GHz. If None, uses
             `qubex.experiment.experiment_constants.DEFAULT_RABI_FREQUENCY`.
+        simultaneous_drive : bool | None, optional
+            Whether control and readout pulses start together. False starts
+            readout after the control pulse ends. None defaults to True.
 
         Returns
         -------
@@ -3635,6 +3647,7 @@ class CharacterizationService:
         data = self.scan_qubit_frequencies(
             target,
             frequency_range=frequency_range,
+            simultaneous_drive=simultaneous_drive,
             control_amplitude=control_amplitude,
             readout_amplitude=readout_amplitude,
             shots=shots,
@@ -3716,6 +3729,8 @@ class CharacterizationService:
         interval: float | None = None,
         plot: bool | None = None,
         save_image: bool | None = None,
+        *,
+        simultaneous_drive: bool | None = None,
     ) -> Result:
         """
         Perform qubit spectroscopy over frequency and power.
@@ -3728,6 +3743,9 @@ class CharacterizationService:
             Control frequency sweep range in GHz.
         power_range
             Drive power sweep range in dB.
+        simultaneous_drive : bool | None, optional
+            Whether control and readout pulses start together. False starts
+            readout after the control pulse ends. None defaults to True.
         """
         if plot is None:
             plot = True
@@ -3750,6 +3768,7 @@ class CharacterizationService:
             result1d = self.scan_qubit_frequencies(
                 target,
                 frequency_range=frequency_range,
+                simultaneous_drive=simultaneous_drive,
                 control_amplitude=amplitude,
                 readout_amplitude=readout_amplitude,
                 readout_frequency=readout_frequency,

--- a/tests/experiment/test_experiment_facade_delegation.py
+++ b/tests/experiment/test_experiment_facade_delegation.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 from typing import Any, cast
+from unittest.mock import Mock
 
 import pytest
 
@@ -1236,3 +1237,35 @@ def test_get_dc_voltage_state_delegates_to_context() -> None:
         output="on",
     )
     assert context_stub.calls == [("get_dc_voltage_state", {"mux": 6})]
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "scan_qubit_frequencies",
+        "qubit_spectroscopy",
+        "measure_qubit_resonance",
+        "estimate_control_amplitude",
+    ],
+)
+@pytest.mark.parametrize("simultaneous_drive", [None, True, False])
+def test_spectroscopy_delegates_drive_timing(method, simultaneous_drive) -> None:
+    """Experiment should forward drive timing and shot settings to characterization."""
+    exp = object.__new__(Experiment)
+    service = Mock()
+    exp.__dict__["_characterization_service"] = service
+    delegate = getattr(service, method)
+
+    result = getattr(exp, method)(
+        "Q00",
+        frequency_range=[5.0, 5.01],
+        simultaneous_drive=simultaneous_drive,
+        n_shots=32,
+        shot_interval=100.0,
+    )
+
+    assert result is delegate.return_value
+    delegate.assert_called_once()
+    assert delegate.call_args.kwargs["simultaneous_drive"] is simultaneous_drive
+    assert delegate.call_args.kwargs["shots"] == 32
+    assert delegate.call_args.kwargs["interval"] == 100.0

--- a/tests/experiment/test_spectroscopy_drive_timing.py
+++ b/tests/experiment/test_spectroscopy_drive_timing.py
@@ -1,0 +1,85 @@
+"""Regression tests for spectroscopy drive timing through Experiment."""
+
+from contextlib import nullcontext
+from types import SimpleNamespace
+from typing import Any, cast
+from unittest.mock import Mock
+
+import pytest
+from qxpulse import PulseSchedule
+
+from qubex.experiment.experiment import Experiment
+from qubex.experiment.services.characterization_service import CharacterizationService
+
+
+@pytest.mark.parametrize(
+    "method",
+    [
+        "scan_qubit_frequencies",
+        "qubit_spectroscopy",
+        "measure_qubit_resonance",
+        "estimate_control_amplitude",
+    ],
+)
+@pytest.mark.parametrize("drive_mode", ["omitted", None, True, False])
+def test_experiment_spectroscopy_drive_timing(method, drive_mode, monkeypatch) -> None:
+    """Spectroscopy should separate control and readout only when explicitly requested."""
+    schedules: list[PulseSchedule] = []
+
+    def execute(*, schedule: PulseSchedule, **kwargs):
+        schedules.append(schedule)
+        return SimpleNamespace(data={"Q00": [SimpleNamespace(kerneled=1 + 1j)]})
+
+    ctx = SimpleNamespace(
+        resolve_qubit_label=lambda target: "Q00",
+        resolve_read_label=lambda target: "R00",
+        qubits={"Q00": SimpleNamespace(frequency=5.0)},
+        targets={"R00": SimpleNamespace(frequency=7.0)},
+        params=SimpleNamespace(
+            control_amplitude={"Q00": 0.1}, readout_amplitude={"Q00": 0.2}
+        ),
+        experiment_system=SimpleNamespace(
+            get_control_box_for_qubit=lambda target: SimpleNamespace(
+                traits=SimpleNamespace(ctrl_ssb="L")
+            )
+        ),
+        system_manager=SimpleNamespace(
+            modified_backend_settings=lambda **kwargs: nullcontext()
+        ),
+        modified_frequencies=lambda frequencies: nullcontext(),
+        reset_awg_and_capunits=lambda **kwargs: None,
+    )
+    service = CharacterizationService(
+        experiment_context=cast(Any, ctx),
+        measurement_service=cast(Any, SimpleNamespace(execute=execute)),
+        calibration_service=cast(Any, None),
+        pulse_service=cast(Any, None),
+    )
+    exp = object.__new__(Experiment)
+    exp.__dict__["_characterization_service"] = service
+    monkeypatch.setattr(
+        "qubex.experiment.services.characterization_service.fitting.fit_sqrt_lorentzian",
+        Mock(return_value={}),
+    )
+    kwargs: dict[str, Any] = dict(
+        frequency_range=[5.0, 5.01, 5.02], plot=False, save_image=False
+    )
+    if drive_mode != "omitted":
+        kwargs["simultaneous_drive"] = drive_mode
+    if method == "qubit_spectroscopy":
+        kwargs["power_range"] = [-30, -20]
+
+    if method == "estimate_control_amplitude":
+        with pytest.warns(DeprecationWarning, match="measure_qubit_resonance"):
+            getattr(exp, method)("Q00", **kwargs)
+    else:
+        getattr(exp, method)("Q00", **kwargs)
+
+    assert len(schedules) == (6 if method == "qubit_spectroscopy" else 3)
+    for schedule in schedules:
+        control = schedule.get_pulse_ranges()["Q00"][0]
+        readout = schedule.get_pulse_ranges()["R00"][0]
+        if drive_mode is False:
+            assert readout.start == control.stop
+        else:
+            assert readout.start == control.start


### PR DESCRIPTION
Expose `simultaneous_drive` through the public `Experiment` spectroscopy APIs so callers can start readout after the control pulse with `simultaneous_drive=False`. Previously the timing option was available on the underlying frequency-scan service but could not be selected through these public workflows.

- Forward the option through `scan_qubit_frequencies`, `qubit_spectroscopy`, `measure_qubit_resonance`, and the deprecated `estimate_control_amplitude` wrapper.
- Preserve simultaneous control/readout for omitted values, `None`, and `True`; existing positional arguments remain compatible.
- Document the option in source docstrings and test facade forwarding, shot settings, and actual pulse start/stop times across all four workflows.
