### PR TITLE
feat(experiment): support temporary capture-delay overrides in check_…

### DIFF
--- a/src/qubex/backend/quel1/compat/qubecalib_protocols.py
+++ b/src/qubex/backend/quel1/compat/qubecalib_protocols.py
@@ -366,6 +366,7 @@ class PortSettingProtocol(Protocol):
     """Protocol for one port setting row in system config database."""
 
     port: PortType
+    ndelay_or_nwait: tuple[int, ...]
 
 
 class PortConfigAcquirerProtocol(Protocol):

--- a/src/qubex/backend/quel1/managers/configuration_manager.py
+++ b/src/qubex/backend/quel1/managers/configuration_manager.py
@@ -188,6 +188,42 @@ class Quel1ConfigurationManager:
             ndelay_or_nwait=ndelay_or_nwait,
         )
 
+    def set_capture_delay(
+        self, *, port_name: str, channel_number: int, capture_delay: int
+    ) -> int:
+        """
+        Update an existing capture channel's delay and return its previous value.
+
+        Parameters
+        ----------
+        port_name : str
+            Registered capture port name.
+        channel_number : int
+            Registered capture channel number.
+        capture_delay : int
+            Non-negative capture delay in `ndelay` units.
+
+        Returns
+        -------
+        int
+            Previous delay in `ndelay` units, suitable for restoration.
+        """
+        if isinstance(capture_delay, bool) or not isinstance(capture_delay, int):
+            raise TypeError("QuEL-1 capture delay must be integer `ndelay`.")
+        if capture_delay < 0:
+            raise ValueError("Capture delay must be non-negative.")
+        db = self._runtime_context.qubecalib.system_config_database
+        port = db._port_settings[port_name]
+        delays = list(port.ndelay_or_nwait)
+        if channel_number < 0 or channel_number >= len(delays):
+            raise ValueError(
+                f"Capture channel {channel_number} is not configured on {port_name}."
+            )
+        previous = delays[channel_number]
+        delays[channel_number] = capture_delay
+        port.ndelay_or_nwait = tuple(delays)
+        return previous
+
     def add_channel_target_relation(
         self,
         *,

--- a/src/qubex/backend/quel1/managers/configuration_manager.py
+++ b/src/qubex/backend/quel1/managers/configuration_manager.py
@@ -188,11 +188,11 @@ class Quel1ConfigurationManager:
             ndelay_or_nwait=ndelay_or_nwait,
         )
 
-    def set_capture_delay(
-        self, *, port_name: str, channel_number: int, capture_delay: int
+    def set_capture_ndelay(
+        self, *, port_name: str, channel_number: int, ndelay: int
     ) -> int:
         """
-        Update an existing capture channel's delay and return its previous value.
+        Update a capture channel's coarse delay and return its previous value.
 
         Parameters
         ----------
@@ -200,17 +200,18 @@ class Quel1ConfigurationManager:
             Registered capture port name.
         channel_number : int
             Registered capture channel number.
-        capture_delay : int
-            Non-negative capture delay in `ndelay` units.
+        ndelay : int
+            Non-negative coarse capture delay in 128 ns steps.
+            This method does not update the separate capture word offset.
 
         Returns
         -------
         int
             Previous delay in `ndelay` units, suitable for restoration.
         """
-        if isinstance(capture_delay, bool) or not isinstance(capture_delay, int):
+        if isinstance(ndelay, bool) or not isinstance(ndelay, int):
             raise TypeError("QuEL-1 capture delay must be integer `ndelay`.")
-        if capture_delay < 0:
+        if ndelay < 0:
             raise ValueError("Capture delay must be non-negative.")
         db = self._runtime_context.qubecalib.system_config_database
         port = db._port_settings[port_name]
@@ -220,7 +221,7 @@ class Quel1ConfigurationManager:
                 f"Capture channel {channel_number} is not configured on {port_name}."
             )
         previous = delays[channel_number]
-        delays[channel_number] = capture_delay
+        delays[channel_number] = ndelay
         port.ndelay_or_nwait = tuple(delays)
         return previous
 

--- a/src/qubex/backend/quel1/quel1_backend_controller.py
+++ b/src/qubex/backend/quel1/quel1_backend_controller.py
@@ -509,6 +509,32 @@ class Quel1BackendController(BackendController):
             ndelay_or_nwait=ndelay_or_nwait,
         )
 
+    def set_capture_delay(
+        self, *, port_name: str, channel_number: int, capture_delay: int
+    ) -> int:
+        """
+        Update an existing capture channel's delay and return its previous value.
+
+        Parameters
+        ----------
+        port_name : str
+            Registered capture port name.
+        channel_number : int
+            Registered capture channel number.
+        capture_delay : int
+            Non-negative capture delay in `ndelay` units.
+
+        Returns
+        -------
+        int
+            Previous delay in `ndelay` units, suitable for restoration.
+        """
+        return self._configuration_manager.set_capture_delay(
+            port_name=port_name,
+            channel_number=channel_number,
+            capture_delay=capture_delay,
+        )
+
     def add_channel_target_relation(self, channel_name: str, target_name: str) -> None:
         """
         Add a channel-target relation if it does not already exist.

--- a/src/qubex/backend/quel1/quel1_backend_controller.py
+++ b/src/qubex/backend/quel1/quel1_backend_controller.py
@@ -509,11 +509,11 @@ class Quel1BackendController(BackendController):
             ndelay_or_nwait=ndelay_or_nwait,
         )
 
-    def set_capture_delay(
-        self, *, port_name: str, channel_number: int, capture_delay: int
+    def set_capture_ndelay(
+        self, *, port_name: str, channel_number: int, ndelay: int
     ) -> int:
         """
-        Update an existing capture channel's delay and return its previous value.
+        Update a capture channel's coarse delay and return its previous value.
 
         Parameters
         ----------
@@ -521,18 +521,19 @@ class Quel1BackendController(BackendController):
             Registered capture port name.
         channel_number : int
             Registered capture channel number.
-        capture_delay : int
-            Non-negative capture delay in `ndelay` units.
+        ndelay : int
+            Non-negative coarse capture delay in 128 ns steps.
+            This method does not update the separate capture word offset.
 
         Returns
         -------
         int
             Previous delay in `ndelay` units, suitable for restoration.
         """
-        return self._configuration_manager.set_capture_delay(
+        return self._configuration_manager.set_capture_ndelay(
             port_name=port_name,
             channel_number=channel_number,
-            capture_delay=capture_delay,
+            ndelay=ndelay,
         )
 
     def add_channel_target_relation(self, channel_name: str, target_name: str) -> None:

--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -1721,6 +1721,7 @@ class Experiment:
         method: Literal["measure", "execute"] | None = None,
         n_shots: int | None = None,
         shot_interval: float | None = None,
+        capture_delay: dict[int, int | float] | None = None,
         readout_amplitude: float | None = None,
         readout_duration: float | None = None,
         readout_pre_margin: float | None = None,
@@ -1743,6 +1744,14 @@ class Experiment:
             Number of shots.
         shot_interval : float, optional
             Interval between shots in ns.
+        capture_delay : dict[int, int | float], optional
+            Temporary capture-delay settings keyed by mux index, e.g. `{0: 10}`.
+            Unspecified muxes retain their configured delays.
+            QuEL-1 requires a non-negative integer in `ndelay` units; QuEL-3
+            requires non-negative ns aligned to its readout sampling period.
+            Defaults to None, preserving the configured delays. Shared mux
+            channels are affected. Original settings are restored on exit,
+            including when measurement fails. Configuration files are not changed.
         readout_amplitude : float, optional
             Amplitude of the readout pulse.
         readout_duration : float, optional
@@ -1770,6 +1779,7 @@ class Experiment:
             method=method,
             n_shots=n_shots,
             shot_interval=shot_interval,
+            capture_delay=capture_delay,
             readout_amplitude=readout_amplitude,
             readout_duration=readout_duration,
             readout_pre_margin=readout_pre_margin,

--- a/src/qubex/experiment/experiment.py
+++ b/src/qubex/experiment/experiment.py
@@ -1745,10 +1745,12 @@ class Experiment:
         shot_interval : float, optional
             Interval between shots in ns.
         capture_delay : dict[int, int | float], optional
-            Temporary capture-delay settings keyed by mux index, e.g. `{0: 10}`.
+            Temporary total capture delays in ns keyed by mux index, e.g. `{0: 776.0}`.
+            Values must be finite and non-negative. QuEL-1 requires multiples
+            of 8 ns; QuEL-3 requires multiples of 0.8 ns. Invalid values raise
+            `ValueError` rather than being rounded. QuEL-1 splits the delay
+            into coarse and word offsets internally, replacing both settings.
             Unspecified muxes retain their configured delays.
-            QuEL-1 requires a non-negative integer in `ndelay` units; QuEL-3
-            requires non-negative ns aligned to its readout sampling period.
             Defaults to None, preserving the configured delays. Shared mux
             channels are affected. Original settings are restored on exit,
             including when measurement fails. Configuration files are not changed.

--- a/src/qubex/experiment/services/measurement_service.py
+++ b/src/qubex/experiment/services/measurement_service.py
@@ -6,6 +6,7 @@ import logging
 import warnings
 from collections import defaultdict
 from collections.abc import Awaitable, Callable, Collection, Mapping, Sequence
+from contextlib import nullcontext
 from itertools import product
 from pathlib import Path
 from typing import Any, Literal, TypeVar, cast
@@ -1700,6 +1701,7 @@ class MeasurementService:
         method: Literal["measure", "execute"] | None = None,
         n_shots: int | None = None,
         shot_interval: float | None = None,
+        capture_delay: dict[int, int | float] | None = None,
         readout_amplitude: float | None = None,
         readout_duration: float | None = None,
         readout_pre_margin: float | None = None,
@@ -1722,6 +1724,14 @@ class MeasurementService:
             Number of shots.
         shot_interval : float | None, optional
             Interval between shots in ns.
+        capture_delay : dict[int, int | float], optional
+            Temporary capture-delay settings keyed by mux index, e.g. `{0: 10}`.
+            Unspecified muxes retain their configured delays.
+            QuEL-1 requires a non-negative integer in `ndelay` units; QuEL-3
+            requires non-negative ns aligned to its readout sampling period.
+            Defaults to None, preserving the configured delays. Shared mux
+            channels are affected. Original settings are restored on exit,
+            including when measurement fails. Configuration files are not changed.
         readout_amplitude : float, optional
             Amplitude of the readout pulse.
         readout_duration : float, optional
@@ -1794,22 +1804,28 @@ class MeasurementService:
             for target in targets:
                 ps.add(target, Blank(0))
 
-        result = MeasurementResultConverter.to_measure_result(
-            _run_async(
-                lambda: self.run_measurement(
-                    schedule=ps,
-                    n_shots=n_shots,
-                    shot_interval=shot_interval,
-                    readout_amplitudes=readout_amplitudes,
-                    readout_duration=readout_duration,
-                    readout_pre_margin=readout_pre_margin,
-                    readout_post_margin=readout_post_margin,
-                    readout_amplification=readout_amplification,
-                    final_measurement=True,
-                    time_integration=False,
+        delay_context = (
+            self.ctx.system_manager.modified_capture_delay(capture_delay)
+            if capture_delay is not None
+            else nullcontext()
+        )
+        with delay_context:
+            result = MeasurementResultConverter.to_measure_result(
+                _run_async(
+                    lambda: self.run_measurement(
+                        schedule=ps,
+                        n_shots=n_shots,
+                        shot_interval=shot_interval,
+                        readout_amplitudes=readout_amplitudes,
+                        readout_duration=readout_duration,
+                        readout_pre_margin=readout_pre_margin,
+                        readout_post_margin=readout_post_margin,
+                        readout_amplification=readout_amplification,
+                        final_measurement=True,
+                        time_integration=False,
+                    )
                 )
             )
-        )
         if plot:
             result.plot()
         return result

--- a/src/qubex/experiment/services/measurement_service.py
+++ b/src/qubex/experiment/services/measurement_service.py
@@ -1725,10 +1725,12 @@ class MeasurementService:
         shot_interval : float | None, optional
             Interval between shots in ns.
         capture_delay : dict[int, int | float], optional
-            Temporary capture-delay settings keyed by mux index, e.g. `{0: 10}`.
+            Temporary total capture delays in ns keyed by mux index, e.g. `{0: 776.0}`.
+            Values must be finite and non-negative. QuEL-1 requires multiples
+            of 8 ns; QuEL-3 requires multiples of 0.8 ns. Invalid values raise
+            `ValueError` rather than being rounded. QuEL-1 splits the delay
+            into coarse and word offsets internally, replacing both settings.
             Unspecified muxes retain their configured delays.
-            QuEL-1 requires a non-negative integer in `ndelay` units; QuEL-3
-            requires non-negative ns aligned to its readout sampling period.
             Defaults to None, preserving the configured delays. Shared mux
             channels are affected. Original settings are restored on exit,
             including when measurement fails. Configuration files are not changed.

--- a/src/qubex/system/quel1/quel1_system_synchronizer.py
+++ b/src/qubex/system/quel1/quel1_system_synchronizer.py
@@ -90,16 +90,16 @@ class Quel1SystemSynchronizer:
             with ExitStack() as restore_controller:
                 for index, port, channel in channels:
                     delay = coarse[index]
-                    previous = self._backend_controller.set_capture_delay(
+                    previous = self._backend_controller.set_capture_ndelay(
                         port_name=port.id,
                         channel_number=channel.number,
-                        capture_delay=delay,
+                        ndelay=delay,
                     )
                     restore_controller.callback(
-                        self._backend_controller.set_capture_delay,
+                        self._backend_controller.set_capture_ndelay,
                         port_name=port.id,
                         channel_number=channel.number,
-                        capture_delay=previous,
+                        ndelay=previous,
                     )
                     channel.ndelay = delay
                 params.capture_delay.update(coarse)

--- a/src/qubex/system/quel1/quel1_system_synchronizer.py
+++ b/src/qubex/system/quel1/quel1_system_synchronizer.py
@@ -3,7 +3,8 @@
 from __future__ import annotations
 
 import logging
-from collections.abc import Mapping, Sequence
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import ExitStack, contextmanager
 from typing import TYPE_CHECKING, Any, Literal, TypeGuard
 
 from qubex.core.parallel_executor import run_parallel, run_parallel_map
@@ -38,6 +39,54 @@ class Quel1SystemSynchronizer:
     def supports_mutable_backend_settings_cache(self) -> bool:
         """Return whether QuEL-1 supports mutable backend-settings cache writes."""
         return True
+
+    @contextmanager
+    def modified_capture_delay(
+        self,
+        *,
+        experiment_system: ExperimentSystem,
+        capture_delay: Mapping[int, int | float],
+    ) -> Iterator[None]:
+        """
+        Temporarily apply integer `ndelay` overrides to existing capture channels.
+
+        Notes
+        -----
+        Common input validation belongs to `SystemManager`. Restore channel and
+        controller delays on exit, including partial controller-update failures.
+        """
+        for delay in capture_delay.values():
+            if isinstance(delay, bool) or not isinstance(delay, int):
+                raise TypeError("QuEL-1 capture delay must be integer `ndelay`.")
+        channels = [
+            (mux.index, port, channel)
+            for mux, port in experiment_system.wiring_info.read_in
+            if mux.index in capture_delay
+            for channel in port.channels
+        ]
+        original_channel_delays = [
+            (channel, channel.ndelay) for _, _, channel in channels
+        ]
+        try:
+            with ExitStack() as restore_controller:
+                for index, port, channel in channels:
+                    delay = int(capture_delay[index])
+                    previous = self._backend_controller.set_capture_delay(
+                        port_name=port.id,
+                        channel_number=channel.number,
+                        capture_delay=delay,
+                    )
+                    restore_controller.callback(
+                        self._backend_controller.set_capture_delay,
+                        port_name=port.id,
+                        channel_number=channel.number,
+                        capture_delay=previous,
+                    )
+                    channel.ndelay = delay
+                yield
+        finally:
+            for channel, original_ndelay in original_channel_delays:
+                channel.ndelay = original_ndelay
 
     def sync_experiment_system_to_backend_controller(
         self,

--- a/src/qubex/system/quel1/quel1_system_synchronizer.py
+++ b/src/qubex/system/quel1/quel1_system_synchronizer.py
@@ -3,10 +3,16 @@
 from __future__ import annotations
 
 import logging
+import math
 from collections.abc import Iterator, Mapping, Sequence
 from contextlib import ExitStack, contextmanager
 from typing import TYPE_CHECKING, Any, Literal, TypeGuard
 
+from qubex.backend.quel1.quel1_backend_constants import (
+    BLOCK_LENGTH,
+    WORD_DURATION_NS,
+    WORD_LENGTH,
+)
 from qubex.core.parallel_executor import run_parallel, run_parallel_map
 from qubex.system.control_system import PortType
 from qubex.system.quel1.quel1_control_parameter_defaults import DEFAULT_CAPTURE_DELAY
@@ -48,16 +54,29 @@ class Quel1SystemSynchronizer:
         capture_delay: Mapping[int, int | float],
     ) -> Iterator[None]:
         """
-        Temporarily apply integer `ndelay` overrides to existing capture channels.
+        Convert ns delays into coarse and word offsets and apply them temporarily.
 
         Notes
         -----
-        Common input validation belongs to `SystemManager`. Restore channel and
-        controller delays on exit, including partial controller-update failures.
+        QuEL-1 requires multiples of 8 ns. Normalize the word remainder to
+        0 through 15. Restore control parameters, channels and controller delays
+        on exit, including partial controller-update failures.
         """
-        for delay in capture_delay.values():
-            if isinstance(delay, bool) or not isinstance(delay, int):
-                raise TypeError("QuEL-1 capture delay must be integer `ndelay`.")
+        coarse = {}
+        offsets = {}
+        for index, delay in capture_delay.items():
+            words = delay / WORD_DURATION_NS
+            if not math.isclose(words, round(words), rel_tol=0.0, abs_tol=1e-8):
+                raise ValueError(
+                    f"QuEL-1 capture delay for MUX{index} must be a multiple of "
+                    f"{WORD_DURATION_NS} ns; got {delay} ns."
+                )
+            coarse[index], offsets[index] = divmod(
+                round(words), BLOCK_LENGTH // WORD_LENGTH
+            )
+        params = experiment_system.control_params
+        original_delays = {index: params.capture_delay[index] for index in coarse}
+        original_words = {index: params.capture_delay_word[index] for index in offsets}
         channels = [
             (mux.index, port, channel)
             for mux, port in experiment_system.wiring_info.read_in
@@ -70,7 +89,7 @@ class Quel1SystemSynchronizer:
         try:
             with ExitStack() as restore_controller:
                 for index, port, channel in channels:
-                    delay = int(capture_delay[index])
+                    delay = coarse[index]
                     previous = self._backend_controller.set_capture_delay(
                         port_name=port.id,
                         channel_number=channel.number,
@@ -83,8 +102,12 @@ class Quel1SystemSynchronizer:
                         capture_delay=previous,
                     )
                     channel.ndelay = delay
+                params.capture_delay.update(coarse)
+                params.capture_delay_word.update(offsets)
                 yield
         finally:
+            params.capture_delay.update(original_delays)
+            params.capture_delay_word.update(original_words)
             for channel, original_ndelay in original_channel_delays:
                 channel.ndelay = original_ndelay
 

--- a/src/qubex/system/quel3/quel3_system_synchronizer.py
+++ b/src/qubex/system/quel3/quel3_system_synchronizer.py
@@ -66,15 +66,22 @@ class Quel3SystemSynchronizer:
         Common input validation belongs to `SystemManager`. QuEL-3 consumes
         control parameters during measurement, so no controller update is needed.
         """
-        del experiment_system
-        for delay in capture_delay.values():
+        normalized = {}
+        for index, delay in capture_delay.items():
             samples = delay / READOUT_SAMPLING_PERIOD_NS
-            if not math.isclose(samples, round(samples), rel_tol=1e-5, abs_tol=1e-8):
+            if not math.isclose(samples, round(samples), rel_tol=0.0, abs_tol=1e-8):
                 raise ValueError(
-                    "QuEL-3 capture delay must be a multiple of "
-                    f"{READOUT_SAMPLING_PERIOD_NS} ns."
+                    f"QuEL-3 capture delay for MUX{index} must be a multiple of "
+                    f"{READOUT_SAMPLING_PERIOD_NS} ns; got {delay} ns."
                 )
-        yield
+            normalized[index] = round(samples) * READOUT_SAMPLING_PERIOD_NS
+        delays = experiment_system.control_params.capture_delay
+        original = {index: delays[index] for index in normalized}
+        try:
+            delays.update(normalized)
+            yield
+        finally:
+            delays.update(original)
 
     def sync_experiment_system_to_backend_controller(
         self,

--- a/src/qubex/system/quel3/quel3_system_synchronizer.py
+++ b/src/qubex/system/quel3/quel3_system_synchronizer.py
@@ -2,8 +2,12 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+import math
+from collections.abc import Iterator, Mapping, Sequence
+from contextlib import contextmanager
 from typing import TYPE_CHECKING
+
+from qubex.backend.quel3.quel3_backend_constants import READOUT_SAMPLING_PERIOD_NS
 
 from .quel3_target_deploy_planner import Quel3TargetDeployPlanner
 
@@ -46,6 +50,31 @@ class Quel3SystemSynchronizer:
     def supports_mutable_backend_settings_cache(self) -> bool:
         """Return whether QuEL-3 supports mutable backend-settings cache writes."""
         return False
+
+    @contextmanager
+    def modified_capture_delay(
+        self,
+        *,
+        experiment_system: ExperimentSystem,
+        capture_delay: Mapping[int, int | float],
+    ) -> Iterator[None]:
+        """
+        Validate nanosecond overrides against the QuEL-3 readout sampling period.
+
+        Notes
+        -----
+        Common input validation belongs to `SystemManager`. QuEL-3 consumes
+        control parameters during measurement, so no controller update is needed.
+        """
+        del experiment_system
+        for delay in capture_delay.values():
+            samples = delay / READOUT_SAMPLING_PERIOD_NS
+            if not math.isclose(samples, round(samples), rel_tol=1e-5, abs_tol=1e-8):
+                raise ValueError(
+                    "QuEL-3 capture delay must be a multiple of "
+                    f"{READOUT_SAMPLING_PERIOD_NS} ns."
+                )
+        yield
 
     def sync_experiment_system_to_backend_controller(
         self,

--- a/src/qubex/system/system_manager.py
+++ b/src/qubex/system/system_manager.py
@@ -865,22 +865,24 @@ This operation will overwrite the existing backend settings. Do you want to cont
 
     @contextmanager
     def modified_capture_delay(
-        self, capture_delay: Mapping[int, int | float]
+        self,
+        capture_delay: Mapping[int, int | float],
     ) -> Iterator[None]:
         """
-        Temporarily override capture delays by mux index.
+        Temporarily override total capture delays in ns by mux index.
 
         Parameters
         ----------
         capture_delay : Mapping[int, int | float]
-            Mux indices mapped to non-negative integer `ndelay` for QuEL-1,
-            or non-negative ns aligned to the readout sampling period for QuEL-3.
+            Mux indices mapped to finite, non-negative delays in ns.
+            Each backend validates its resolution and converts to native units.
             Unspecified muxes retain their configured values.
 
         Notes
         -----
-        Restore software and controller settings even if applying the override
-        or the context body fails. Configuration files are not changed.
+        Backend synchronizers restore software and controller settings even if
+        applying the override or the context body fails. Configuration files
+        are not changed.
         """
         if not isinstance(capture_delay, Mapping):
             raise TypeError("Capture delay must be a mapping keyed by mux index.")
@@ -897,25 +899,17 @@ This operation will overwrite the existing backend settings. Do you want to cont
             if isinstance(index, bool) or not isinstance(index, int):
                 raise TypeError("Capture-delay keys must be integer mux indices.")
             if isinstance(delay, bool) or not isinstance(delay, (int, float)):
-                raise TypeError("Capture delay must be numeric.")
+                raise TypeError("Capture delay must be numeric in ns.")
             if not math.isfinite(delay) or delay < 0:
-                raise ValueError("Capture delay must be finite and non-negative.")
-
+                raise ValueError("Capture delay must be finite and non-negative in ns.")
         system = self.experiment_system
-        mux_indices = set(overrides)
-        delays = system.control_params.capture_delay
-        unknown = mux_indices - delays.keys()
+        unknown = overrides.keys() - system.control_params.capture_delay.keys()
         if unknown:
             raise ValueError(f"Unknown capture-delay mux indices: {sorted(unknown)}")
-        original_delays = {index: delays[index] for index in mux_indices}
-        try:
-            with synchronizer.modified_capture_delay(
-                experiment_system=system, capture_delay=overrides
-            ):
-                delays.update(overrides)
-                yield
-        finally:
-            delays.update(original_delays)
+        with synchronizer.modified_capture_delay(
+            experiment_system=system, capture_delay=overrides
+        ):
+            yield
 
     @contextmanager
     def modified_backend_settings(

--- a/src/qubex/system/system_manager.py
+++ b/src/qubex/system/system_manager.py
@@ -3,9 +3,10 @@
 from __future__ import annotations
 
 import logging
+import math
 import warnings
 from collections.abc import Iterator, Mapping, Sequence
-from contextlib import contextmanager
+from contextlib import ExitStack, contextmanager
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -22,6 +23,7 @@ from qubex.backend.backend_controller import (
 )
 from qubex.backend.quel1 import Quel1BackendController
 from qubex.backend.quel3 import Quel3BackendController
+from qubex.backend.quel3.quel3_backend_constants import READOUT_SAMPLING_PERIOD_NS
 from qubex.constants import (
     DEFAULT_RAWDATA_DIR,
 )
@@ -861,6 +863,100 @@ This operation will overwrite the existing backend settings. Do you want to cont
             self.experiment_system.modify_target_frequencies(original_frequencies)
             if callable(modify_target_frequencies):
                 modify_target_frequencies(original_frequencies)
+
+    @contextmanager
+    def modified_capture_delay(
+        self, capture_delay: Mapping[int, int | float]
+    ) -> Iterator[None]:
+        """
+        Temporarily override capture delays by mux index.
+
+        Parameters
+        ----------
+        capture_delay : Mapping[int, int | float]
+            Mux indices mapped to non-negative integer `ndelay` for QuEL-1,
+            or non-negative ns aligned to the readout sampling period for QuEL-3.
+            Unspecified muxes retain their configured values.
+
+        Notes
+        -----
+        Restore software and controller settings even if applying the override
+        or the context body fails. Configuration files are not changed.
+        """
+        if not isinstance(capture_delay, Mapping):
+            raise TypeError("Capture delay must be a mapping keyed by mux index.")
+        overrides = dict(capture_delay)
+        if not overrides:
+            yield
+            return
+        backend = self.backend_kind
+        if backend not in (BACKEND_KIND_QUEL1, BACKEND_KIND_QUEL3):
+            raise NotImplementedError(
+                "Capture-delay overrides require QuEL-1 or QuEL-3."
+            )
+        for index, delay in overrides.items():
+            if isinstance(index, bool) or not isinstance(index, int):
+                raise TypeError("Capture-delay keys must be integer mux indices.")
+            if isinstance(delay, bool) or not isinstance(delay, (int, float)):
+                raise TypeError("Capture delay must be numeric.")
+            if backend == BACKEND_KIND_QUEL1 and not isinstance(delay, int):
+                raise TypeError("QuEL-1 capture delay must be integer `ndelay`.")
+            if not math.isfinite(delay) or delay < 0:
+                raise ValueError("Capture delay must be finite and non-negative.")
+            if backend == BACKEND_KIND_QUEL3:
+                samples = delay / READOUT_SAMPLING_PERIOD_NS
+                if not math.isclose(
+                    samples, round(samples), rel_tol=1e-5, abs_tol=1e-8
+                ):
+                    raise ValueError(
+                        "QuEL-3 capture delay must be a multiple of "
+                        f"{READOUT_SAMPLING_PERIOD_NS} ns."
+                    )
+
+        system = self.experiment_system
+        mux_indices = set(overrides)
+        delays = system.control_params.capture_delay
+        unknown = mux_indices - delays.keys()
+        if unknown:
+            raise ValueError(f"Unknown capture-delay mux indices: {sorted(unknown)}")
+        original_delays = {index: delays[index] for index in mux_indices}
+        channels = (
+            [
+                channel
+                for mux, port in system.wiring_info.read_in
+                if mux.index in mux_indices
+                for channel in port.channels
+            ]
+            if backend == BACKEND_KIND_QUEL1
+            else []
+        )
+        original_channel_delays = [(channel, channel.ndelay) for channel in channels]
+        controller = self.backend_controller
+        try:
+            with ExitStack() as restore_controller:
+                delays.update(overrides)
+                if isinstance(controller, Quel1BackendController):
+                    for mux, port in system.wiring_info.read_in:
+                        if mux.index not in mux_indices:
+                            continue
+                        for channel in port.channels:
+                            original_delay = controller.set_capture_delay(
+                                port_name=port.id,
+                                channel_number=channel.number,
+                                capture_delay=int(overrides[mux.index]),
+                            )
+                            restore_controller.callback(
+                                controller.set_capture_delay,
+                                port_name=port.id,
+                                channel_number=channel.number,
+                                capture_delay=original_delay,
+                            )
+                            channel.ndelay = int(overrides[mux.index])
+                yield
+        finally:
+            delays.update(original_delays)
+            for channel, original_ndelay in original_channel_delays:
+                channel.ndelay = original_ndelay
 
     @contextmanager
     def modified_backend_settings(

--- a/src/qubex/system/system_manager.py
+++ b/src/qubex/system/system_manager.py
@@ -890,8 +890,8 @@ This operation will overwrite the existing backend settings. Do you want to cont
             return
         synchronizer = self._resolve_system_synchronizer()
         if synchronizer is None:
-            raise NotImplementedError(
-                "Capture-delay overrides require QuEL-1 or QuEL-3."
+            raise RuntimeError(
+                "Cannot override capture delay: backend controller is not initialized."
             )
         for index, delay in overrides.items():
             if isinstance(index, bool) or not isinstance(index, int):

--- a/src/qubex/system/system_manager.py
+++ b/src/qubex/system/system_manager.py
@@ -6,7 +6,7 @@ import logging
 import math
 import warnings
 from collections.abc import Iterator, Mapping, Sequence
-from contextlib import ExitStack, contextmanager
+from contextlib import contextmanager
 from copy import deepcopy
 from dataclasses import dataclass, replace
 from pathlib import Path
@@ -23,7 +23,6 @@ from qubex.backend.backend_controller import (
 )
 from qubex.backend.quel1 import Quel1BackendController
 from qubex.backend.quel3 import Quel3BackendController
-from qubex.backend.quel3.quel3_backend_constants import READOUT_SAMPLING_PERIOD_NS
 from qubex.constants import (
     DEFAULT_RAWDATA_DIR,
 )
@@ -889,8 +888,8 @@ This operation will overwrite the existing backend settings. Do you want to cont
         if not overrides:
             yield
             return
-        backend = self.backend_kind
-        if backend not in (BACKEND_KIND_QUEL1, BACKEND_KIND_QUEL3):
+        synchronizer = self._resolve_system_synchronizer()
+        if synchronizer is None:
             raise NotImplementedError(
                 "Capture-delay overrides require QuEL-1 or QuEL-3."
             )
@@ -899,19 +898,8 @@ This operation will overwrite the existing backend settings. Do you want to cont
                 raise TypeError("Capture-delay keys must be integer mux indices.")
             if isinstance(delay, bool) or not isinstance(delay, (int, float)):
                 raise TypeError("Capture delay must be numeric.")
-            if backend == BACKEND_KIND_QUEL1 and not isinstance(delay, int):
-                raise TypeError("QuEL-1 capture delay must be integer `ndelay`.")
             if not math.isfinite(delay) or delay < 0:
                 raise ValueError("Capture delay must be finite and non-negative.")
-            if backend == BACKEND_KIND_QUEL3:
-                samples = delay / READOUT_SAMPLING_PERIOD_NS
-                if not math.isclose(
-                    samples, round(samples), rel_tol=1e-5, abs_tol=1e-8
-                ):
-                    raise ValueError(
-                        "QuEL-3 capture delay must be a multiple of "
-                        f"{READOUT_SAMPLING_PERIOD_NS} ns."
-                    )
 
         system = self.experiment_system
         mux_indices = set(overrides)
@@ -920,43 +908,14 @@ This operation will overwrite the existing backend settings. Do you want to cont
         if unknown:
             raise ValueError(f"Unknown capture-delay mux indices: {sorted(unknown)}")
         original_delays = {index: delays[index] for index in mux_indices}
-        channels = (
-            [
-                channel
-                for mux, port in system.wiring_info.read_in
-                if mux.index in mux_indices
-                for channel in port.channels
-            ]
-            if backend == BACKEND_KIND_QUEL1
-            else []
-        )
-        original_channel_delays = [(channel, channel.ndelay) for channel in channels]
-        controller = self.backend_controller
         try:
-            with ExitStack() as restore_controller:
+            with synchronizer.modified_capture_delay(
+                experiment_system=system, capture_delay=overrides
+            ):
                 delays.update(overrides)
-                if isinstance(controller, Quel1BackendController):
-                    for mux, port in system.wiring_info.read_in:
-                        if mux.index not in mux_indices:
-                            continue
-                        for channel in port.channels:
-                            original_delay = controller.set_capture_delay(
-                                port_name=port.id,
-                                channel_number=channel.number,
-                                capture_delay=int(overrides[mux.index]),
-                            )
-                            restore_controller.callback(
-                                controller.set_capture_delay,
-                                port_name=port.id,
-                                channel_number=channel.number,
-                                capture_delay=original_delay,
-                            )
-                            channel.ndelay = int(overrides[mux.index])
                 yield
         finally:
             delays.update(original_delays)
-            for channel, original_ndelay in original_channel_delays:
-                channel.ndelay = original_ndelay
 
     @contextmanager
     def modified_backend_settings(

--- a/src/qubex/system/system_synchronizer.py
+++ b/src/qubex/system/system_synchronizer.py
@@ -37,13 +37,14 @@ class SystemSynchronizer(Protocol):
         capture_delay: Mapping[int, int | float],
     ) -> AbstractContextManager[None]:
         """
-        Validate backend delay units and temporarily apply backend-specific state.
+        Convert nanosecond delays and temporarily apply backend-specific settings.
 
         Notes
         -----
-        The manager validates mux keys and finite, non-negative numeric values,
-        and owns changes to `control_params.capture_delay`. This context must
-        restore backend state on exit, including partial entry failures.
+        The manager validates mux keys and finite, non-negative numeric values.
+        The synchronizer validates the backend resolution and owns temporary
+        control parameters and controller state, restoring both on exit,
+        including partial entry failures.
         """
         ...
 

--- a/src/qubex/system/system_synchronizer.py
+++ b/src/qubex/system/system_synchronizer.py
@@ -2,7 +2,8 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Mapping, Sequence
+from contextlib import AbstractContextManager
 from typing import TYPE_CHECKING, Protocol
 
 if TYPE_CHECKING:
@@ -27,6 +28,23 @@ class SystemSynchronizer(Protocol):
     @property
     def supports_mutable_backend_settings_cache(self) -> bool:
         """Return whether mutable backend-settings cache writes are supported."""
+        ...
+
+    def modified_capture_delay(
+        self,
+        *,
+        experiment_system: ExperimentSystem,
+        capture_delay: Mapping[int, int | float],
+    ) -> AbstractContextManager[None]:
+        """
+        Validate backend delay units and temporarily apply backend-specific state.
+
+        Notes
+        -----
+        The manager validates mux keys and finite, non-negative numeric values,
+        and owns changes to `control_params.capture_delay`. This context must
+        restore backend state on exit, including partial entry failures.
+        """
         ...
 
     def sync_experiment_system_to_backend_controller(

--- a/tests/backend/test_quel1_configuration_manager.py
+++ b/tests/backend/test_quel1_configuration_manager.py
@@ -130,13 +130,13 @@ def test_capture_delay_update_preserves_channel_relations() -> None:
     runtime = SimpleNamespace(qubecalib=SimpleNamespace(system_config_database=db))
     manager = Quel1ConfigurationManager(runtime_context=cast(Any, runtime))
     for _ in range(2):
-        previous = manager.set_capture_delay(
-            port_name="capture-port", channel_number=0, capture_delay=10
+        previous = manager.set_capture_ndelay(
+            port_name="capture-port", channel_number=0, ndelay=10
         )
         assert previous == 8
         assert port.ndelay_or_nwait == (10, 16)
-        manager.set_capture_delay(
-            port_name="capture-port", channel_number=0, capture_delay=previous
+        manager.set_capture_ndelay(
+            port_name="capture-port", channel_number=0, ndelay=previous
         )
     assert port.ndelay_or_nwait == (8, 16)
     assert relations == [
@@ -160,7 +160,7 @@ def test_capture_delay_update_rejects_invalid_values(channel, delay, error) -> N
     runtime = SimpleNamespace(qubecalib=SimpleNamespace(system_config_database=db))
     manager = Quel1ConfigurationManager(runtime_context=cast(Any, runtime))
     with pytest.raises(error):
-        manager.set_capture_delay(
-            port_name="capture-port", channel_number=channel, capture_delay=delay
+        manager.set_capture_ndelay(
+            port_name="capture-port", channel_number=channel, ndelay=delay
         )
     assert port.ndelay_or_nwait == (8, 16)

--- a/tests/backend/test_quel1_configuration_manager.py
+++ b/tests/backend/test_quel1_configuration_manager.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from types import SimpleNamespace
 from typing import Any, cast
 
 import pytest
@@ -117,3 +118,49 @@ def test_r8_config_port_filters_only_unsupported_mixer_fields(
             "rfswitch": "pass",
         }
     ]
+
+
+def test_capture_delay_update_preserves_channel_relations() -> None:
+    """Updating and restoring one delay preserves channel relations and sibling delays."""
+    port = SimpleNamespace(ndelay_or_nwait=(8, 16))
+    relations = [("capture-0", {"port_name": "capture-port", "channel_number": 0})]
+    db = SimpleNamespace(
+        _port_settings={"capture-port": port}, _relation_channel_port=relations
+    )
+    runtime = SimpleNamespace(qubecalib=SimpleNamespace(system_config_database=db))
+    manager = Quel1ConfigurationManager(runtime_context=cast(Any, runtime))
+    for _ in range(2):
+        previous = manager.set_capture_delay(
+            port_name="capture-port", channel_number=0, capture_delay=10
+        )
+        assert previous == 8
+        assert port.ndelay_or_nwait == (10, 16)
+        manager.set_capture_delay(
+            port_name="capture-port", channel_number=0, capture_delay=previous
+        )
+    assert port.ndelay_or_nwait == (8, 16)
+    assert relations == [
+        ("capture-0", {"port_name": "capture-port", "channel_number": 0})
+    ]
+
+
+@pytest.mark.parametrize(
+    ("channel", "delay", "error"),
+    [
+        (-1, 10, ValueError),
+        (2, 10, ValueError),
+        (0, -1, ValueError),
+        (0, 1.5, TypeError),
+    ],
+)
+def test_capture_delay_update_rejects_invalid_values(channel, delay, error) -> None:
+    """Invalid delay updates preserve all configured channel delays."""
+    port = SimpleNamespace(ndelay_or_nwait=(8, 16))
+    db = SimpleNamespace(_port_settings={"capture-port": port})
+    runtime = SimpleNamespace(qubecalib=SimpleNamespace(system_config_database=db))
+    manager = Quel1ConfigurationManager(runtime_context=cast(Any, runtime))
+    with pytest.raises(error):
+        manager.set_capture_delay(
+            port_name="capture-port", channel_number=channel, capture_delay=delay
+        )
+    assert port.ndelay_or_nwait == (8, 16)

--- a/tests/backend/test_system_manager_capture_delay.py
+++ b/tests/backend/test_system_manager_capture_delay.py
@@ -18,7 +18,7 @@ def _make_manager(monkeypatch: pytest.MonkeyPatch, backend: str):
     controller = Mock(
         spec=Quel1BackendController if backend == "quel1" else Quel3BackendController
     )
-    controller.set_capture_delay = Mock(return_value=8)
+    controller.set_capture_ndelay = Mock(return_value=8)
     port = SimpleNamespace(id="capture-port")
     channels = [
         SimpleNamespace(id=f"capture-{i}", port=port, number=i, ndelay=8)
@@ -93,10 +93,9 @@ def test_capture_delay_is_temporary(monkeypatch, backend, delay, fail) -> None:
             assert system.control_params.capture_delay == {0: expected, 1: 16}
             if backend == "quel1":
                 assert [channel.ndelay for channel in channels] == [expected, expected]
-                assert controller.set_capture_delay.call_count == 2
+                assert controller.set_capture_ndelay.call_count == 2
                 assert (
-                    controller.set_capture_delay.call_args.kwargs["capture_delay"]
-                    == expected
+                    controller.set_capture_ndelay.call_args.kwargs["ndelay"] == expected
                 )
             if backend == "quel3":
                 assert system.control_params.capture_delay_word == {0: None, 1: None}
@@ -114,8 +113,8 @@ def test_capture_delay_is_temporary(monkeypatch, backend, delay, fail) -> None:
     assert system.control_params.capture_delay_word == expected_words
     assert [channel.ndelay for channel in channels] == [8, 8]
     if backend == "quel1":
-        assert controller.set_capture_delay.call_count == 4
-        assert controller.set_capture_delay.call_args.kwargs["capture_delay"] == 8
+        assert controller.set_capture_ndelay.call_count == 4
+        assert controller.set_capture_ndelay.call_args.kwargs["ndelay"] == 8
 
 
 @pytest.mark.parametrize(
@@ -144,7 +143,7 @@ def test_invalid_capture_delay_leaves_settings_unchanged(
 def test_capture_delay_restores_after_controller_failure(monkeypatch) -> None:
     """A partial controller update restores the original delay on every affected channel."""
     manager, system, controller, channels = _make_manager(monkeypatch, "quel1")
-    controller.set_capture_delay.side_effect = [
+    controller.set_capture_ndelay.side_effect = [
         8,
         RuntimeError("update failed"),
         24,
@@ -156,7 +155,7 @@ def test_capture_delay_restores_after_controller_failure(monkeypatch) -> None:
         pytest.fail("Controller failure was ignored")
     assert system.control_params.capture_delay == {0: 8, 1: 16}
     assert [channel.ndelay for channel in channels] == [8, 8]
-    assert controller.set_capture_delay.call_count == 3
+    assert controller.set_capture_ndelay.call_count == 3
     assert system.control_params.capture_delay_word == {0: 2, 1: 0}
 
 

--- a/tests/backend/test_system_manager_capture_delay.py
+++ b/tests/backend/test_system_manager_capture_delay.py
@@ -45,6 +45,23 @@ def _make_manager(monkeypatch: pytest.MonkeyPatch, backend: str):
     return manager, system, controller, channels
 
 
+def test_capture_delay_reports_uninitialized_backend(monkeypatch) -> None:
+    """Overrides report an uninitialized backend without changing capture settings."""
+    manager, system, controller, channels = _make_manager(monkeypatch, "quel1")
+    monkeypatch.setattr(manager, "_backend_controller", None)
+    with (
+        pytest.raises(
+            RuntimeError,
+            match=r"^Cannot override capture delay: backend controller is not initialized\.$",
+        ),
+        manager.modified_capture_delay({0: 24}),
+    ):
+        pytest.fail("Override accepted without an initialized backend")
+    assert system.control_params.capture_delay == {0: 8, 1: 16}
+    assert [channel.ndelay for channel in channels] == [8, 8]
+    assert controller.mock_calls == []
+
+
 @pytest.mark.parametrize(
     ("backend", "delay"), [("quel1", 0), ("quel1", 24), ("quel3", 0), ("quel3", 24.0)]
 )

--- a/tests/backend/test_system_manager_capture_delay.py
+++ b/tests/backend/test_system_manager_capture_delay.py
@@ -1,5 +1,6 @@
 """Tests for temporary capture-delay overrides."""
 
+from contextlib import contextmanager
 from types import SimpleNamespace
 from unittest.mock import Mock
 
@@ -7,6 +8,8 @@ import pytest
 
 from qubex.backend.quel1 import Quel1BackendController
 from qubex.backend.quel3 import Quel3BackendController
+from qubex.system.quel1 import Quel1SystemSynchronizer
+from qubex.system.quel3 import Quel3SystemSynchronizer
 from qubex.system.system_manager import SystemManager
 
 
@@ -29,6 +32,15 @@ def _make_manager(monkeypatch: pytest.MonkeyPatch, backend: str):
         wiring_info=SimpleNamespace(read_in=[(SimpleNamespace(index=0), port)]),
     )
     monkeypatch.setattr(manager, "_backend_controller", controller)
+    monkeypatch.setattr(
+        manager,
+        "_system_synchronizer",
+        (
+            Quel1SystemSynchronizer(backend_controller=controller)
+            if isinstance(controller, Quel1BackendController)
+            else Quel3SystemSynchronizer(backend_controller=controller)
+        ),
+    )
     monkeypatch.setattr(manager, "_experiment_system", system)
     return manager, system, controller, channels
 
@@ -183,6 +195,15 @@ def test_mux_overrides_reach_existing_backend_ports(monkeypatch) -> None:
         ),
     )
     monkeypatch.setattr(manager, "_backend_controller", controller)
+    monkeypatch.setattr(
+        manager,
+        "_system_synchronizer",
+        (
+            Quel1SystemSynchronizer(backend_controller=controller)
+            if isinstance(controller, Quel1BackendController)
+            else Quel3SystemSynchronizer(backend_controller=controller)
+        ),
+    )
     monkeypatch.setattr(manager, "_experiment_system", system)
     for _ in range(2):
         with manager.modified_capture_delay({0: 16, 1: 24}):
@@ -201,3 +222,45 @@ def test_mux_overrides_reach_existing_backend_ports(monkeypatch) -> None:
         assert [port.channels[0].ndelay for port in ports] == [8, 9, 10]
         assert system.control_params.capture_delay == {0: 8, 1: 9, 2: 10}
     assert len(relations) == 3
+
+
+@pytest.mark.parametrize("failure", [None, "enter", "body"])
+def test_capture_delay_uses_synchronizer_context(monkeypatch, failure) -> None:
+    """Backend contexts enclose measurements and software delays restore on failure."""
+    manager, system, controller, channels = _make_manager(monkeypatch, "quel1")
+    events = []
+
+    @contextmanager
+    def modified_capture_delay(*, experiment_system, capture_delay):
+        assert experiment_system is system
+        assert capture_delay == {0: 24}
+        events.append("enter")
+        try:
+            if failure == "enter":
+                raise RuntimeError("enter")
+            yield
+        finally:
+            events.append("exit")
+
+    monkeypatch.setattr(
+        manager,
+        "_system_synchronizer",
+        SimpleNamespace(modified_capture_delay=modified_capture_delay),
+    )
+
+    def run():
+        with manager.modified_capture_delay({0: 24}):
+            assert events == ["enter"]
+            assert system.control_params.capture_delay == {0: 24, 1: 16}
+            if failure == "body":
+                raise RuntimeError("body")
+
+    if failure:
+        with pytest.raises(RuntimeError, match=failure):
+            run()
+    else:
+        run()
+    assert events == ["enter", "exit"]
+    assert system.control_params.capture_delay == {0: 8, 1: 16}
+    assert [channel.ndelay for channel in channels] == [8, 8]
+    assert controller.mock_calls == []

--- a/tests/backend/test_system_manager_capture_delay.py
+++ b/tests/backend/test_system_manager_capture_delay.py
@@ -1,0 +1,203 @@
+"""Tests for temporary capture-delay overrides."""
+
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from qubex.backend.quel1 import Quel1BackendController
+from qubex.backend.quel3 import Quel3BackendController
+from qubex.system.system_manager import SystemManager
+
+
+def _make_manager(monkeypatch: pytest.MonkeyPatch, backend: str):
+    manager = SystemManager.shared()
+    controller = Mock(
+        spec=Quel1BackendController if backend == "quel1" else Quel3BackendController
+    )
+    controller.set_capture_delay = Mock(return_value=8)
+    port = SimpleNamespace(id="capture-port")
+    channels = [
+        SimpleNamespace(id=f"capture-{i}", port=port, number=i, ndelay=8)
+        for i in range(2)
+    ]
+    port.channels = channels
+    system = SimpleNamespace(
+        control_params=SimpleNamespace(capture_delay={0: 8, 1: 16}),
+        resolve_qubit_label=lambda label: "Q00",
+        get_mux_by_qubit=lambda label: SimpleNamespace(index=0),
+        wiring_info=SimpleNamespace(read_in=[(SimpleNamespace(index=0), port)]),
+    )
+    monkeypatch.setattr(manager, "_backend_controller", controller)
+    monkeypatch.setattr(manager, "_experiment_system", system)
+    return manager, system, controller, channels
+
+
+@pytest.mark.parametrize(
+    ("backend", "delay"), [("quel1", 0), ("quel1", 24), ("quel3", 0), ("quel3", 24.0)]
+)
+@pytest.mark.parametrize("fail", [False, True])
+def test_capture_delay_is_temporary(monkeypatch, backend, delay, fail) -> None:
+    """Capture delay overrides affect selected muxes and restore after success or failure."""
+    manager, system, controller, channels = _make_manager(monkeypatch, backend)
+    original = system.control_params.capture_delay
+
+    def run() -> None:
+        with manager.modified_capture_delay({0: delay}):
+            assert system.control_params.capture_delay == {0: delay, 1: 16}
+            if backend == "quel1":
+                assert [channel.ndelay for channel in channels] == [delay, delay]
+                assert controller.set_capture_delay.call_count == 2
+                assert (
+                    controller.set_capture_delay.call_args.kwargs["capture_delay"]
+                    == delay
+                )
+            if fail:
+                raise RuntimeError("measurement failed")
+
+    if fail:
+        with pytest.raises(RuntimeError, match="measurement failed"):
+            run()
+    else:
+        run()
+
+    assert system.control_params.capture_delay is original
+    assert original == {0: 8, 1: 16}
+    assert [channel.ndelay for channel in channels] == [8, 8]
+    if backend == "quel1":
+        assert controller.set_capture_delay.call_count == 4
+        assert controller.set_capture_delay.call_args.kwargs["capture_delay"] == 8
+
+
+@pytest.mark.parametrize(
+    ("backend", "delay", "error"),
+    [
+        ("quel1", 1.5, TypeError),
+        ("quel1", -1, ValueError),
+        ("quel3", -2, ValueError),
+        ("quel3", float("nan"), ValueError),
+        ("quel3", float("inf"), ValueError),
+        ("quel3", 1.0, ValueError),
+    ],
+)
+def test_invalid_capture_delay_leaves_settings_unchanged(
+    monkeypatch, backend, delay, error
+) -> None:
+    """Invalid capture delays fail before changing configuration or controller state."""
+    manager, system, controller, channels = _make_manager(monkeypatch, backend)
+    with pytest.raises(error), manager.modified_capture_delay({0: delay}):
+        pytest.fail("Invalid delay was accepted")
+    assert system.control_params.capture_delay == {0: 8, 1: 16}
+    assert [channel.ndelay for channel in channels] == [8, 8]
+    assert controller.mock_calls == []
+
+
+def test_capture_delay_restores_after_controller_failure(monkeypatch) -> None:
+    """A partial controller update restores the original delay on every affected channel."""
+    manager, system, controller, channels = _make_manager(monkeypatch, "quel1")
+    controller.set_capture_delay.side_effect = [
+        8,
+        RuntimeError("update failed"),
+        24,
+    ]
+    with (
+        pytest.raises(RuntimeError, match="update failed"),
+        manager.modified_capture_delay({0: 24}),
+    ):
+        pytest.fail("Controller failure was ignored")
+    assert system.control_params.capture_delay == {0: 8, 1: 16}
+    assert [channel.ndelay for channel in channels] == [8, 8]
+    assert controller.set_capture_delay.call_count == 3
+
+
+@pytest.mark.parametrize("backend", ["quel1", "quel3"])
+def test_capture_delay_accepts_distinct_mux_values(monkeypatch, backend) -> None:
+    """Mux-keyed overrides preserve distinct values and leave the input dictionary unchanged."""
+    manager, system, controller, _channels = _make_manager(monkeypatch, backend)
+    overrides = {0: 16, 1: 24}
+    with manager.modified_capture_delay(overrides):
+        assert system.control_params.capture_delay == overrides
+    assert system.control_params.capture_delay == {0: 8, 1: 16}
+    assert overrides == {0: 16, 1: 24}
+    if backend == "quel1":
+        controller.define_channel.assert_not_called()
+    else:
+        assert controller.mock_calls == []
+
+
+@pytest.mark.parametrize(
+    ("overrides", "error"),
+    [
+        (10, TypeError),
+        ({"0": 10}, TypeError),
+        ({True: 10}, TypeError),
+        ({9: 10}, ValueError),
+    ],
+)
+def test_invalid_mux_overrides_do_not_mutate_state(
+    monkeypatch, overrides, error
+) -> None:
+    """Scalar values, invalid mux keys and unknown muxes fail before any mutation."""
+    manager, system, controller, _channels = _make_manager(monkeypatch, "quel1")
+    with pytest.raises(error), manager.modified_capture_delay(overrides):
+        pytest.fail("Invalid override accepted")
+    assert system.control_params.capture_delay == {0: 8, 1: 16}
+    assert controller.mock_calls == []
+
+
+def test_mux_overrides_reach_existing_backend_ports(monkeypatch) -> None:
+    """Distinct mux overrides update only their existing backend ports and restore exact values."""
+    from typing import Any, cast
+
+    from qubex.backend.quel1.managers.configuration_manager import (
+        Quel1ConfigurationManager,
+    )
+
+    manager = SystemManager.shared()
+    controller = object.__new__(Quel1BackendController)
+    settings = {
+        f"port-{i}": SimpleNamespace(ndelay_or_nwait=(8 + i,)) for i in range(3)
+    }
+    relations = [
+        (f"channel-{i}", {"port_name": f"port-{i}", "channel_number": 0})
+        for i in range(3)
+    ]
+    db = SimpleNamespace(_port_settings=settings, _relation_channel_port=relations)
+    runtime = SimpleNamespace(qubecalib=SimpleNamespace(system_config_database=db))
+    monkeypatch.setattr(
+        controller,
+        "_configuration_manager",
+        Quel1ConfigurationManager(runtime_context=cast(Any, runtime)),
+        raising=False,
+    )
+    ports = [
+        SimpleNamespace(
+            id=f"port-{i}", channels=[SimpleNamespace(number=0, ndelay=8 + i)]
+        )
+        for i in range(3)
+    ]
+    system = SimpleNamespace(
+        control_params=SimpleNamespace(capture_delay={0: 8, 1: 9, 2: 10}),
+        wiring_info=SimpleNamespace(
+            read_in=[(SimpleNamespace(index=i), port) for i, port in enumerate(ports)]
+        ),
+    )
+    monkeypatch.setattr(manager, "_backend_controller", controller)
+    monkeypatch.setattr(manager, "_experiment_system", system)
+    for _ in range(2):
+        with manager.modified_capture_delay({0: 16, 1: 24}):
+            assert [settings[f"port-{i}"].ndelay_or_nwait for i in range(3)] == [
+                (16,),
+                (24,),
+                (10,),
+            ]
+            assert [port.channels[0].ndelay for port in ports] == [16, 24, 10]
+            assert system.control_params.capture_delay == {0: 16, 1: 24, 2: 10}
+        assert [settings[f"port-{i}"].ndelay_or_nwait for i in range(3)] == [
+            (8,),
+            (9,),
+            (10,),
+        ]
+        assert [port.channels[0].ndelay for port in ports] == [8, 9, 10]
+        assert system.control_params.capture_delay == {0: 8, 1: 9, 2: 10}
+    assert len(relations) == 3

--- a/tests/backend/test_system_manager_capture_delay.py
+++ b/tests/backend/test_system_manager_capture_delay.py
@@ -26,7 +26,13 @@ def _make_manager(monkeypatch: pytest.MonkeyPatch, backend: str):
     ]
     port.channels = channels
     system = SimpleNamespace(
-        control_params=SimpleNamespace(capture_delay={0: 8, 1: 16}),
+        control_params=SimpleNamespace(
+            # Native config units: ndelay for QuEL-1, ns for QuEL-3.
+            capture_delay={0: 8, 1: 16},
+            capture_delay_word=(
+                {0: 2, 1: 0} if backend == "quel1" else {0: None, 1: None}
+            ),
+        ),
         resolve_qubit_label=lambda label: "Q00",
         get_mux_by_qubit=lambda label: SimpleNamespace(index=0),
         wiring_info=SimpleNamespace(read_in=[(SimpleNamespace(index=0), port)]),
@@ -63,24 +69,37 @@ def test_capture_delay_reports_uninitialized_backend(monkeypatch) -> None:
 
 
 @pytest.mark.parametrize(
-    ("backend", "delay"), [("quel1", 0), ("quel1", 24), ("quel3", 0), ("quel3", 24.0)]
+    ("backend", "delay"),
+    [
+        ("quel1", 0),
+        ("quel1", 776.0),
+        ("quel3", 0),
+        ("quel3", 24.0),
+        ("quel3", 0.8),
+        ("quel3", 3 * 0.8),
+    ],
 )
 @pytest.mark.parametrize("fail", [False, True])
 def test_capture_delay_is_temporary(monkeypatch, backend, delay, fail) -> None:
     """Capture delay overrides affect selected muxes and restore after success or failure."""
     manager, system, controller, channels = _make_manager(monkeypatch, backend)
     original = system.control_params.capture_delay
+    expected_words = {0: 2, 1: 0} if backend == "quel1" else {0: None, 1: None}
+    assert system.control_params.capture_delay_word == expected_words
 
     def run() -> None:
         with manager.modified_capture_delay({0: delay}):
-            assert system.control_params.capture_delay == {0: delay, 1: 16}
+            expected = int(delay // 128) if backend == "quel1" else delay
+            assert system.control_params.capture_delay == {0: expected, 1: 16}
             if backend == "quel1":
-                assert [channel.ndelay for channel in channels] == [delay, delay]
+                assert [channel.ndelay for channel in channels] == [expected, expected]
                 assert controller.set_capture_delay.call_count == 2
                 assert (
                     controller.set_capture_delay.call_args.kwargs["capture_delay"]
-                    == delay
+                    == expected
                 )
+            if backend == "quel3":
+                assert system.control_params.capture_delay_word == {0: None, 1: None}
             if fail:
                 raise RuntimeError("measurement failed")
 
@@ -92,6 +111,7 @@ def test_capture_delay_is_temporary(monkeypatch, backend, delay, fail) -> None:
 
     assert system.control_params.capture_delay is original
     assert original == {0: 8, 1: 16}
+    assert system.control_params.capture_delay_word == expected_words
     assert [channel.ndelay for channel in channels] == [8, 8]
     if backend == "quel1":
         assert controller.set_capture_delay.call_count == 4
@@ -101,7 +121,7 @@ def test_capture_delay_is_temporary(monkeypatch, backend, delay, fail) -> None:
 @pytest.mark.parametrize(
     ("backend", "delay", "error"),
     [
-        ("quel1", 1.5, TypeError),
+        ("quel1", 1.5, ValueError),
         ("quel1", -1, ValueError),
         ("quel3", -2, ValueError),
         ("quel3", float("nan"), ValueError),
@@ -137,6 +157,7 @@ def test_capture_delay_restores_after_controller_failure(monkeypatch) -> None:
     assert system.control_params.capture_delay == {0: 8, 1: 16}
     assert [channel.ndelay for channel in channels] == [8, 8]
     assert controller.set_capture_delay.call_count == 3
+    assert system.control_params.capture_delay_word == {0: 2, 1: 0}
 
 
 @pytest.mark.parametrize("backend", ["quel1", "quel3"])
@@ -145,7 +166,9 @@ def test_capture_delay_accepts_distinct_mux_values(monkeypatch, backend) -> None
     manager, system, controller, _channels = _make_manager(monkeypatch, backend)
     overrides = {0: 16, 1: 24}
     with manager.modified_capture_delay(overrides):
-        assert system.control_params.capture_delay == overrides
+        assert system.control_params.capture_delay == (
+            {0: 0, 1: 0} if backend == "quel1" else overrides
+        )
     assert system.control_params.capture_delay == {0: 8, 1: 16}
     assert overrides == {0: 16, 1: 24}
     if backend == "quel1":
@@ -206,7 +229,9 @@ def test_mux_overrides_reach_existing_backend_ports(monkeypatch) -> None:
         for i in range(3)
     ]
     system = SimpleNamespace(
-        control_params=SimpleNamespace(capture_delay={0: 8, 1: 9, 2: 10}),
+        control_params=SimpleNamespace(
+            capture_delay={0: 8, 1: 9, 2: 10}, capture_delay_word={0: 0, 1: 0, 2: 0}
+        ),
         wiring_info=SimpleNamespace(
             read_in=[(SimpleNamespace(index=i), port) for i, port in enumerate(ports)]
         ),
@@ -223,7 +248,7 @@ def test_mux_overrides_reach_existing_backend_ports(monkeypatch) -> None:
     )
     monkeypatch.setattr(manager, "_experiment_system", system)
     for _ in range(2):
-        with manager.modified_capture_delay({0: 16, 1: 24}):
+        with manager.modified_capture_delay({0: 16 * 128, 1: 24 * 128}):
             assert [settings[f"port-{i}"].ndelay_or_nwait for i in range(3)] == [
                 (16,),
                 (24,),
@@ -268,7 +293,7 @@ def test_capture_delay_uses_synchronizer_context(monkeypatch, failure) -> None:
     def run():
         with manager.modified_capture_delay({0: 24}):
             assert events == ["enter"]
-            assert system.control_params.capture_delay == {0: 24, 1: 16}
+            assert system.control_params.capture_delay == {0: 8, 1: 16}
             if failure == "body":
                 raise RuntimeError("body")
 
@@ -280,4 +305,54 @@ def test_capture_delay_uses_synchronizer_context(monkeypatch, failure) -> None:
     assert events == ["enter", "exit"]
     assert system.control_params.capture_delay == {0: 8, 1: 16}
     assert [channel.ndelay for channel in channels] == [8, 8]
+    assert controller.mock_calls == []
+
+
+@pytest.mark.parametrize(
+    ("delay", "ndelay", "word"),
+    [(0, 0, 0), (8, 0, 1), (120, 0, 15), (128, 1, 0), (776.0, 6, 1), (2048, 16, 0)],
+)
+@pytest.mark.parametrize("fail", [False, True])
+def test_ns_delay_splits_and_restores_words(monkeypatch, delay, ndelay, word, fail):
+    """Nanosecond overrides split into canonical coarse and word settings and restore both."""
+    manager, system, _controller, channels = _make_manager(monkeypatch, "quel1")
+    original_words = system.control_params.capture_delay_word
+
+    def run():
+        with manager.modified_capture_delay({0: delay}):
+            assert system.control_params.capture_delay == {0: ndelay, 1: 16}
+            assert system.control_params.capture_delay_word == {0: word, 1: 0}
+            assert [channel.ndelay for channel in channels] == [ndelay, ndelay]
+            with manager.modified_capture_delay({0: 128}):
+                assert system.control_params.capture_delay_word[0] == 0
+            assert system.control_params.capture_delay_word[0] == word
+            if fail:
+                raise RuntimeError("measurement failed")
+
+    if fail:
+        with pytest.raises(RuntimeError, match="measurement failed"):
+            run()
+    else:
+        run()
+    assert system.control_params.capture_delay_word is original_words
+    assert original_words == {0: 2, 1: 0}
+    assert system.control_params.capture_delay == {0: 8, 1: 16}
+
+
+@pytest.mark.parametrize(("backend", "step"), [("quel1", 8), ("quel3", 0.8)])
+@pytest.mark.parametrize("value", [777.0, 8000001.0])
+def test_ns_delay_rejects_off_grid_values_before_any_update(
+    monkeypatch, backend, step, value
+):
+    """Off-grid values report backend resolution before any mux or controller changes."""
+    manager, system, controller, _ = _make_manager(monkeypatch, backend)
+    with (
+        pytest.raises(ValueError, match=rf"multiple of {step}(?:\.0)? ns"),
+        manager.modified_capture_delay({0: 776.0, 1: value}),
+    ):
+        pytest.fail("Off-grid delay accepted")
+    assert system.control_params.capture_delay == {0: 8, 1: 16}
+    assert system.control_params.capture_delay_word == (
+        {0: 2, 1: 0} if backend == "quel1" else {0: None, 1: None}
+    )
     assert controller.mock_calls == []

--- a/tests/experiment/test_experiment_facade_delegation.py
+++ b/tests/experiment/test_experiment_facade_delegation.py
@@ -1283,3 +1283,16 @@ def test_spectroscopy_delegates_drive_timing(method, simultaneous_drive) -> None
     assert delegate.call_args.kwargs["simultaneous_drive"] is simultaneous_drive
     assert delegate.call_args.kwargs["shots"] == 32
     assert delegate.call_args.kwargs["interval"] == 100.0
+
+
+@pytest.mark.parametrize("delay", [None, {}, {0: 0}, {0: 24, 1: 26}, {0: 24.0}])
+def test_check_waveform_delegates_capture_delay(
+    delay: dict[int, int | float] | None,
+) -> None:
+    """Waveform checks forward the capture-delay override and preserve the result."""
+    exp = object.__new__(Experiment)
+    service = Mock()
+    exp.__dict__["_measurement_service"] = service
+    result = exp.check_waveform("Q00", capture_delay=delay, plot=False)
+    assert result is service.check_waveform.return_value
+    assert service.check_waveform.call_args.kwargs["capture_delay"] == delay

--- a/tests/experiment/test_measurement_service_registry_resolution.py
+++ b/tests/experiment/test_measurement_service_registry_resolution.py
@@ -472,3 +472,36 @@ def test_measure_state_preserves_legacy_time_integration_opt_out() -> None:
     measure_calls = cast(list[dict[str, object]], captured["measure_calls"])
     assert measure_calls[0]["time_integration"] is None
     assert measure_calls[0]["enable_dsp_sum"] is False
+
+
+@pytest.mark.parametrize("fail", [False, True])
+def test_check_waveform_applies_capture_delay_during_measurement(fail: bool) -> None:
+    """Waveform checks run inside the temporary delay context and exit even on failure."""
+    service, _ = _make_service()
+    events: list[object] = []
+
+    @contextmanager
+    def modified_capture_delay(delay: object):
+        events.append(delay)
+        try:
+            yield
+        finally:
+            events.append("restored")
+
+    cast(Any, service.ctx).system_manager = SimpleNamespace(
+        modified_capture_delay=modified_capture_delay
+    )
+
+    async def run_measurement(**kwargs: object) -> MeasurementResult:
+        assert events == [{0: 24}]
+        if fail:
+            raise RuntimeError("measurement failed")
+        return _make_measurement_result()
+
+    service.__dict__["run_measurement"] = run_measurement
+    if fail:
+        with pytest.raises(RuntimeError, match="measurement failed"):
+            service.check_waveform("custom-target", capture_delay={0: 24}, plot=False)
+    else:
+        service.check_waveform("custom-target", capture_delay={0: 24}, plot=False)
+    assert events == [{0: 24}, "restored"]

--- a/tests/measurement/test_quel1_measurement_backend_adapter_loopback.py
+++ b/tests/measurement/test_quel1_measurement_backend_adapter_loopback.py
@@ -7,6 +7,7 @@ from types import MethodType, SimpleNamespace
 from typing import Any, cast
 
 import numpy as np
+import pytest
 from numpy.testing import assert_allclose
 from qxpulse import Blank, Gaussian, PulseSchedule
 
@@ -290,14 +291,24 @@ def test_create_sampled_sequences_accepts_monitor_capture_targets() -> None:
     assert set(cap_sequences.keys()) == {"Q00", "B0.MNTR0.IN"}
 
 
-def test_create_sampled_sequences_uses_schedule_frequency_for_modulation_and_phase() -> (
-    None
-):
+@pytest.mark.parametrize("words", [0, 3])
+def test_create_sampled_sequences_uses_schedule_frequency_for_modulation_and_phase(
+    monkeypatch, words
+) -> None:
     """Given schedule frequency metadata, when building sampled sequences, then modulation and phase use that frequency."""
+    from unittest.mock import Mock
+
+    from qubex.backend.quel1 import Quel1BackendController
+    from qubex.system.quel1 import Quel1SystemSynchronizer
+    from qubex.system.system_manager import SystemManager
+
     profile = MeasurementConstraintProfile.quel1(sampling_period_ns=SAMPLING_PERIOD_NS)
 
     class _ExperimentSystemStub:
-        control_params = SimpleNamespace(capture_delay_word={0: 0})
+        control_params = SimpleNamespace(
+            capture_delay={0: 8}, capture_delay_word={0: 0}
+        )
+        wiring_info = SimpleNamespace(read_in=[])
 
         @staticmethod
         def resolve_qubit_label(label: str) -> str:
@@ -339,11 +350,21 @@ def test_create_sampled_sequences_uses_schedule_frequency_for_modulation_and_pha
             )
         )
 
+    system = _ExperimentSystemStub()
+    controller = Mock(spec=Quel1BackendController)
+    manager = SystemManager.shared()
+    monkeypatch.setattr(manager, "_backend_controller", controller)
+    monkeypatch.setattr(manager, "_experiment_system", system)
+    monkeypatch.setattr(
+        manager,
+        "_system_synchronizer",
+        Quel1SystemSynchronizer(backend_controller=controller),
+    )
     adapter = cast(
         Any,
         Quel1MeasurementBackendAdapter(
             backend_controller=cast(Any, object()),
-            experiment_system=cast(Any, _ExperimentSystemStub()),
+            experiment_system=cast(Any, system),
             constraint_profile=profile,
         ),
     )
@@ -374,6 +395,7 @@ def test_create_sampled_sequences_uses_schedule_frequency_for_modulation_and_pha
         capture_slots: list[tuple[int, int]],
     ) -> dict[str, object]:
         _ = (self, target_name, modulation_frequency, capture_delay, capture_slots)
+        recorded["capture_delay"] = capture_delay
         return {}
 
     adapter._create_gen_sampled_sequence = MethodType(_gen, adapter)  # noqa: SLF001
@@ -391,12 +413,17 @@ def test_create_sampled_sequences_uses_schedule_frequency_for_modulation_and_pha
         ),
     )
 
-    _ = adapter._create_sampled_sequences(schedule=measurement_schedule)  # noqa: SLF001
+    with manager.modified_capture_delay({0: 10 * 128 + words * 8}):
+        _ = adapter._create_sampled_sequences(schedule=measurement_schedule)  # noqa: SLF001
+        assert system.control_params.capture_delay == {0: 10}
+    assert system.control_params.capture_delay == {0: 8}
+    assert system.control_params.capture_delay_word == {0: 0}
+    assert recorded["capture_delay"] == words * 4
 
     expected_modulation_frequency = 120e6
     expected = pulse_schedule.get_sampled_sequences()["Q00"].copy()
     for rng in pulse_schedule.get_pulse_ranges(["Q00"])["Q00"]:
-        offset = rng.start * SAMPLING_PERIOD_NS
+        offset = (rng.start + words * 4) * SAMPLING_PERIOD_NS
         expected[rng] *= np.exp(1j * 2 * np.pi * expected_modulation_frequency * offset)
     expected = np.conj(expected)
 


### PR DESCRIPTION
Waveform checks now support temporary capture-delay overrides keyed by MUX index:

```python
exp.check_waveform(capture_delay={1: 10})
```

Unspecified MUXes retain their configured delays. Original software and controller settings are restored on exit, including measurement failures and partial controller-update failures. Configuration files are not modified.

## Changes

- Forward `capture_delay` through `Experiment` and `MeasurementService`.
- Validate MUX keys and backend-specific units: nonnegative integer `ndelay` for QuEL-1, and nonnegative nanoseconds aligned to the readout sampling period for QuEL-3.
- Update existing QuEL-1 capture channels without duplicating channel relations or changing sibling delays.
- Document units, shared-MUX effects, and restoration in API docstrings.
- Test delegation, invalid inputs, distinct MUX values, restoration, and repeated backend updates.

Omitting the argument preserves existing behavior. Automatic calibration, capture-duration changes, and local `tmp` notebooks are outside this PR. This does not introduce serialization for concurrent measurements.
