### PR TITLE
feat(quel3): clear instruments by unit and tolerate duplicate aliases on connect

### DIFF
--- a/src/qubex/backend/quel3/instrument_cache.py
+++ b/src/qubex/backend/quel3/instrument_cache.py
@@ -2,10 +2,13 @@
 
 from __future__ import annotations
 
+import logging
 from collections.abc import Callable, Iterable, Sequence
 
 from qubex.backend.quel3.interfaces.client import InstrumentInfoProtocol
 from qubex.backend.quel3.models import InstrumentConfiguration, InstrumentSpec
+
+logger = logging.getLogger(__name__)
 
 
 class InstrumentCache:
@@ -92,10 +95,21 @@ class InstrumentCache:
         self._instruments = {}
 
     def replace_all(
-        self, *, instrument_infos: Iterable[InstrumentInfoProtocol]
+        self,
+        *,
+        instrument_infos: Iterable[InstrumentInfoProtocol],
+        allow_duplicate_aliases: bool = False,
     ) -> None:
-        """Replace all instruments after validating the complete candidate state."""
-        self._instruments = self._index(instrument_infos)
+        """
+        Replace all instruments after validating the complete candidate state.
+
+        With `allow_duplicate_aliases=True`, warn and retain the last input for
+        each normalized alias. Other identity checks remain strict. Failed
+        validation leaves the previous cache unchanged.
+        """
+        self._instruments = self._index(
+            instrument_infos, allow_duplicate_aliases=allow_duplicate_aliases
+        )
 
     def replace_ports(
         self,
@@ -140,7 +154,10 @@ class InstrumentCache:
 
     @classmethod
     def _index(
-        cls, instrument_infos: Iterable[InstrumentInfoProtocol]
+        cls,
+        instrument_infos: Iterable[InstrumentInfoProtocol],
+        *,
+        allow_duplicate_aliases: bool = False,
     ) -> dict[str, InstrumentInfoProtocol]:
         """Build a validated alias index without copying hardware information."""
         instruments: dict[str, InstrumentInfoProtocol] = {}
@@ -152,7 +169,18 @@ class InstrumentCache:
                 )
             alias = cls.alias_for(info)
             if alias in instruments:
-                raise ValueError(f"Duplicate instrument alias `{alias}`.")
+                if not allow_duplicate_aliases:
+                    raise ValueError(f"Duplicate instrument alias `{alias}`.")
+                previous = instruments[alias]
+                logger.warning(
+                    "Duplicate instrument alias `%s`; replacing resource `%s` "
+                    "on port `%s` with resource `%s` on port `%s` in the cache.",
+                    alias,
+                    previous.id,
+                    previous.port_id,
+                    info.id,
+                    info.port_id,
+                )
             if info.id in resource_ids:
                 raise ValueError(f"Duplicate instrument resource ID `{info.id}`.")
             instruments[alias] = info

--- a/src/qubex/backend/quel3/managers/configuration_manager.py
+++ b/src/qubex/backend/quel3/managers/configuration_manager.py
@@ -112,6 +112,92 @@ class Quel3ConfigurationManager:
         """Return configured quelware personal access token path."""
         return self._runtime_config.pat_path
 
+    def clear_instruments(
+        self,
+        *,
+        unit_label: str,
+        instrument_cache: InstrumentCache,
+        parallel: bool = True,
+    ) -> None:
+        """
+        Delete all instruments on one unit and invalidate that unit's cache.
+
+        Parameters
+        ----------
+        unit_label : str
+            Exact label of a discovered unit. Required; no all-unit default.
+        instrument_cache : InstrumentCache
+            Controller-owned cache whose selected unit should be invalidated.
+        parallel : bool, default=True
+            Whether to discard instruments on different ports concurrently.
+
+        Raises
+        ------
+        ValueError
+            The unit label is empty or was not discovered.
+
+        Notes
+        -----
+        Discover ports independently of the cache. Invalidate only the selected
+        unit before writing, even if it has no ports. Other units are retained.
+        Session acquisition and deletion requests are not retried by this
+        manager. Errors propagate unchanged and partial deletions are not
+        rolled back. A failed write leaves the selected unit uncached.
+        """
+        if not unit_label.strip():
+            raise ValueError("Unit label must not be empty.")
+        _run_async(
+            lambda: self._clear_instruments(
+                unit_label=unit_label,
+                instrument_cache=instrument_cache,
+                parallel=parallel,
+            )
+        )
+
+    async def _clear_instruments(
+        self,
+        *,
+        unit_label: str,
+        instrument_cache: InstrumentCache,
+        parallel: bool,
+    ) -> None:
+        """Discover one unit's ports and discard their instruments in one session."""
+        client_factory = self._load_quelware_client_factory()
+        async with client_factory(
+            self._runtime_config.endpoint, self._runtime_config.port
+        ) as client:
+            if unit_label not in client.list_unit_labels():
+                raise ValueError(f"QuEL-3 unit was not discovered: {unit_label!r}.")
+            resources = await client.list_resource_infos()
+            port_ids = tuple(
+                dict.fromkeys(
+                    resource.id
+                    for resource in resources
+                    if str(
+                        getattr(resource.category, "name", resource.category)
+                    ).rsplit(".", maxsplit=1)[-1]
+                    == "PORT"
+                    and resource.id.startswith(f"{unit_label}:")
+                )
+            )
+            instrument_cache.replace_units(
+                unit_labels=(unit_label,), instrument_infos=()
+            )
+            if not port_ids:
+                return
+            async with client.create_session(port_ids) as session:
+                if parallel:
+                    results = await asyncio.gather(
+                        *(session.discard_instruments(port_id) for port_id in port_ids),
+                        return_exceptions=True,
+                    )
+                    for result in results:
+                        if isinstance(result, BaseException):
+                            raise result
+                else:
+                    for port_id in port_ids:
+                        await session.discard_instruments(port_id)
+
     def deploy_instruments(
         self,
         *,

--- a/src/qubex/backend/quel3/quel3_backend_controller.py
+++ b/src/qubex/backend/quel3/quel3_backend_controller.py
@@ -241,7 +241,9 @@ class Quel3BackendController(BackendController):
         Each call validates the selected unit labels and replaces the cache with
         instruments from those units. `box_names` contains QuEL-3 unit labels;
         a string selects one unit, `None` selects all units, and an empty list
-        probes the endpoint without loading instruments. Connection, unit-label
+        probes the endpoint without loading instruments. Duplicate normalized
+        aliases emit a warning and keep the last instrument in readback order,
+        without changing hardware. Connection, unit-label
         validation, or readback failure leaves the controller disconnected with
         an empty cache and propagates the error.
         """
@@ -252,8 +254,15 @@ class Quel3BackendController(BackendController):
                 unit_labels=unit_labels,
                 parallel=parallel,
             )
-            self.refresh_instrument_cache(
-                unit_labels=unit_labels, parallel=True if parallel is None else parallel
+            if unit_labels is not None and not unit_labels:
+                return
+            instrument_infos = self._hardware_state_reader.read_instrument_infos(
+                unit_labels=() if unit_labels is None else unit_labels,
+                parallel=True if parallel is None else parallel,
+            )
+            self._instrument_cache.replace_all(
+                instrument_infos=instrument_infos,
+                allow_duplicate_aliases=True,
             )
         except Exception:
             self.disconnect()
@@ -263,6 +272,34 @@ class Quel3BackendController(BackendController):
         """Disconnect backend resources."""
         self._connection_manager.disconnect()
         self._instrument_cache.clear()
+
+    def clear_instruments(self, *, unit_label: str, parallel: bool = True) -> None:
+        """
+        Delete every instrument on the specified unit and invalidate its cache.
+
+        Parameters
+        ----------
+        unit_label : str
+            Exact label of the unit whose instruments should be deleted.
+        parallel : bool, default=True
+            Whether to delete instruments on different ports concurrently.
+
+        Raises
+        ------
+        ValueError
+            The unit label is empty or was not discovered.
+
+        Notes
+        -----
+        Other units and their cached instruments are retained. The selected
+        unit is uncached before writing and stays uncached on failure. Partial
+        deletions are not rolled back. This operation is independent of connect.
+        """
+        self._configuration_manager.clear_instruments(
+            unit_label=unit_label,
+            instrument_cache=self._instrument_cache,
+            parallel=parallel,
+        )
 
     def deploy_instrument(
         self,

--- a/tests/backend/test_quel3_backend_controller_connect.py
+++ b/tests/backend/test_quel3_backend_controller_connect.py
@@ -131,7 +131,7 @@ def test_failed_connect_discards_stale_cache_and_connection_status(
     connection.fail = failure == "connection"
     reader.fail = failure == "read"
     if failure == "validation":
-        reader.infos = (_info("unit-a:new-1"), _info("unit-a:new-2"))
+        reader.infos = (_info(""),)
 
     with pytest.raises((RuntimeError, ValueError)):
         controller.connect()
@@ -216,3 +216,72 @@ def test_connection_manager_validates_selected_units(
 
     assert connection.is_connected
     assert probes == [True]
+
+
+@pytest.mark.parametrize("port_id", ["unit-a:tx_p01", "unit-b:tx_p01"])
+@pytest.mark.parametrize("parallel", [False, True])
+def test_connect_warns_and_executes_last_duplicate_alias(
+    port_id: str, parallel: bool, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Connecting should warn on duplicate aliases and execute the last observed instrument."""
+    first = _info("unit-a:first")
+    last = cast(
+        InstrumentInfoProtocol,
+        SimpleNamespace(
+            id=f"{port_id.partition(':')[0]}:last",
+            port_id=port_id,
+            definition=SimpleNamespace(alias=f"{port_id.partition(':')[0]}: Q00 "),
+            config=SimpleNamespace(sampling_period_fs=400_000, samples_per_tick=4),
+        ),
+    )
+    calls: list[object] = []
+    observed: list[InstrumentInfoProtocol] = []
+
+    def execute_sync(
+        *, request: object, instrument_cache: InstrumentCache, parallel: bool
+    ) -> str:
+        observed.append(instrument_cache.get("Q00"))
+        return "executed"
+
+    controller = Quel3BackendController(
+        connection_manager=cast(Any, _ConnectionManager(calls)),
+        hardware_state_reader=cast(Any, _Reader(calls, (first, last))),
+        execution_manager=cast(
+            Any, SimpleNamespace(sampling_period_ns=0.4, execute_sync=execute_sync)
+        ),
+    )
+
+    controller.connect(parallel=parallel)
+    assert (
+        controller.execute_sync(request=BackendExecutionRequest(payload=object()))
+        == "executed"
+    )
+
+    assert controller.is_connected
+    assert observed == [last]
+    assert observed[0] is last
+    assert "Q00" in caplog.text
+    assert first.id in caplog.text
+    assert last.id in caplog.text
+    assert first.port_id in caplog.text
+    assert last.port_id in caplog.text
+    assert any(record.levelname == "WARNING" for record in caplog.records)
+    with pytest.raises(ValueError, match="Duplicate instrument alias"):
+        controller.refresh_instrument_cache()
+
+
+def test_connect_with_empty_selection_clears_cache_without_reading() -> None:
+    """An empty unit selection should connect without reading any instruments."""
+    calls: list[object] = []
+    controller = Quel3BackendController(
+        connection_manager=cast(Any, _ConnectionManager(calls)),
+        hardware_state_reader=cast(Any, _Reader(calls, (_info("unit-a:old"),))),
+    )
+    controller.refresh_instrument_cache()
+    calls.clear()
+
+    controller.connect([])
+
+    assert controller.is_connected
+    assert calls == [("connect", [], None)]
+    assert controller.get_instrument_configuration().instruments == ()

--- a/tests/backend/test_quel3_clear_instruments.py
+++ b/tests/backend/test_quel3_clear_instruments.py
@@ -1,0 +1,207 @@
+"""Tests for deleting instruments from one QuEL-3 unit."""
+
+from __future__ import annotations
+
+import asyncio
+from types import SimpleNamespace
+from typing import Any, cast
+
+import pytest
+
+from qubex.backend.quel3 import Quel3BackendController
+from qubex.backend.quel3.instrument_cache import InstrumentCache
+from qubex.backend.quel3.interfaces.client import InstrumentInfoProtocol
+from qubex.backend.quel3.managers import Quel3ConfigurationManager
+
+
+def _info(unit: str) -> InstrumentInfoProtocol:
+    return cast(
+        InstrumentInfoProtocol,
+        SimpleNamespace(
+            id=f"{unit}:instrument",
+            port_id=f"{unit}:p0",
+            definition=SimpleNamespace(
+                alias=unit,
+                role="TRANSMITTER",
+                mode="FIXED_TIMELINE",
+                profile=SimpleNamespace(
+                    frequency_range_min=4e9, frequency_range_max=6e9
+                ),
+            ),
+        ),
+    )
+
+
+class _Client:
+    def __init__(self) -> None:
+        self.ports = ["unit-a:p0", "unit-a:p1", "unit-ab:p0", "unit-b:p0"]
+        self.started: list[str] = []
+        self.finished: list[str] = []
+        self.sessions: list[tuple[str, ...]] = []
+        self.closed = False
+        self.finished_at_close: tuple[str, ...] = ()
+        self.fail = False
+        self.session_error: RuntimeError | None = None
+        self.discard_error = RuntimeError("discard failed")
+
+    async def __aenter__(self) -> _Client:
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        pass
+
+    def list_unit_labels(self) -> list[str]:
+        return ["unit-a", "unit-ab", "unit-b"]
+
+    async def list_resource_infos(self) -> list[SimpleNamespace]:
+        return [
+            SimpleNamespace(id=port, category=SimpleNamespace(name="PORT"))
+            for port in self.ports
+        ] + [SimpleNamespace(id="unit-a:instrument", category="INSTRUMENT")]
+
+    def create_session(self, resource_ids: Any, **kwargs: Any) -> Any:
+        self.sessions.append(tuple(resource_ids))
+        client = self
+
+        class _SessionContext:
+            async def __aenter__(self) -> _Client:
+                if client.session_error is not None:
+                    raise client.session_error
+                return client
+
+            async def __aexit__(self, *args: object) -> None:
+                client.closed = True
+                client.finished_at_close = tuple(client.finished)
+
+        return _SessionContext()
+
+    async def discard_instruments(self, port_id: str) -> None:
+        self.started.append(port_id)
+        if self.fail and port_id == "unit-a:p0":
+            raise self.discard_error
+        await asyncio.sleep(0)
+        self.finished.append(port_id)
+
+
+@pytest.fixture
+def runtime(
+    monkeypatch: pytest.MonkeyPatch,
+) -> tuple[Quel3ConfigurationManager, _Client]:
+    """Provide a configuration manager backed by an in-memory quelware client."""
+    client = _Client()
+    manager = Quel3ConfigurationManager()
+    monkeypatch.setattr(
+        manager, "_load_quelware_client_factory", lambda: lambda *args: client
+    )
+    return manager, client
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+@pytest.mark.parametrize("has_ports", [False, True])
+def test_clear_only_discards_selected_unit_and_preserves_other_cache(
+    runtime: tuple[Quel3ConfigurationManager, _Client], parallel: bool, has_ports: bool
+) -> None:
+    """Clearing should discard every selected unit port and preserve all other units."""
+    manager, client = runtime
+    if not has_ports:
+        client.ports = ["unit-ab:p0", "unit-b:p0"]
+    cache = InstrumentCache()
+    other = _info("unit-ab")
+    cache.replace_all(instrument_infos=(_info("unit-a"), other))
+
+    assert (
+        manager.clear_instruments(
+            unit_label="unit-a", instrument_cache=cache, parallel=parallel
+        )
+        is None
+    )
+
+    expected = ["unit-a:p0", "unit-a:p1"] if has_ports else []
+    assert client.started == expected
+    assert client.finished == expected
+    assert client.sessions == ([tuple(expected)] if has_ports else [])
+    assert client.closed is has_ports
+    assert cache.snapshot() == {"unit-ab": other}
+
+
+@pytest.mark.parametrize("unit_label", ["", "   ", "missing"])
+def test_invalid_unit_leaves_hardware_and_cache_unchanged(
+    runtime: tuple[Quel3ConfigurationManager, _Client], unit_label: str
+) -> None:
+    """An empty or undiscovered unit should fail without deleting instruments or cache."""
+    manager, client = runtime
+    cache = InstrumentCache()
+    old = _info("unit-a")
+    cache.replace_all(instrument_infos=(old,))
+
+    with pytest.raises(ValueError, match=r"must not be empty|was not discovered"):
+        manager.clear_instruments(unit_label=unit_label, instrument_cache=cache)
+
+    assert cache.snapshot() == {"unit-a": old}
+    assert client.started == []
+    assert client.sessions == []
+
+
+@pytest.mark.parametrize("parallel", [False, True])
+def test_failed_clear_invalidates_unit_and_closes_after_pending_requests(
+    runtime: tuple[Quel3ConfigurationManager, _Client],
+    parallel: bool,
+) -> None:
+    """A failed deletion should invalidate only its unit and finish pending work before cleanup."""
+    manager, client = runtime
+    client.fail = True
+    cache = InstrumentCache()
+    other = _info("unit-b")
+    cache.replace_all(instrument_infos=(_info("unit-a"), other))
+
+    with pytest.raises(RuntimeError, match="discard failed") as caught:
+        manager.clear_instruments(
+            unit_label="unit-a", instrument_cache=cache, parallel=parallel
+        )
+
+    assert caught.value is client.discard_error
+    assert cache.snapshot() == {"unit-b": other}
+    assert client.closed
+    assert client.started == (["unit-a:p0", "unit-a:p1"] if parallel else ["unit-a:p0"])
+    assert client.finished_at_close == (("unit-a:p1",) if parallel else ())
+    assert len(client.sessions) == 1
+
+
+def test_clear_propagates_session_failure_without_retry(
+    runtime: tuple[Quel3ConfigurationManager, _Client],
+) -> None:
+    """Session acquisition should fail once and propagate the original error."""
+    manager, client = runtime
+    client.session_error = RuntimeError("resource busy")
+    cache = InstrumentCache()
+    other = _info("unit-b")
+    cache.replace_all(instrument_infos=(_info("unit-a"), other))
+
+    with pytest.raises(RuntimeError, match="resource busy") as caught:
+        manager.clear_instruments(unit_label="unit-a", instrument_cache=cache)
+
+    assert caught.value is client.session_error
+    assert len(client.sessions) == 1
+    assert client.started == []
+    assert cache.snapshot() == {"unit-b": other}
+
+
+def test_controller_clear_updates_its_execution_cache(
+    runtime: tuple[Quel3ConfigurationManager, _Client],
+) -> None:
+    """Controller deletion should remove only the selected unit from its execution cache."""
+    manager, client = runtime
+    infos = (_info("unit-a"), _info("unit-b"))
+    controller = Quel3BackendController(
+        configuration_manager=manager,
+        hardware_state_reader=cast(
+            Any, SimpleNamespace(read_instrument_infos=lambda **kwargs: infos)
+        ),
+    )
+    controller.refresh_instrument_cache()
+    controller.clear_instruments(unit_label="unit-a", parallel=False)
+
+    assert [
+        spec.alias for spec in controller.get_instrument_configuration().instruments
+    ] == ["unit-b"]
+    assert client.started == ["unit-a:p0", "unit-a:p1"]

--- a/tests/backend/test_quel3_instrument_cache.py
+++ b/tests/backend/test_quel3_instrument_cache.py
@@ -78,6 +78,26 @@ def test_duplicate_alias_rejects_replacement_atomically() -> None:
     assert cache.snapshot() == {"Q00": first}
 
 
+@pytest.mark.parametrize("allow_duplicate_aliases", [False, True])
+def test_alias_overwrite_does_not_hide_invalid_resource_ids(
+    allow_duplicate_aliases: bool,
+) -> None:
+    """Alias overwrite should still reject repeated resource IDs atomically."""
+    old = _info("old", "unit-a:old", "unit-a:p0")
+    first = _info("Q00", "unit-a:1", "unit-a:p0")
+    second = _info("Q01", "unit-a:1", "unit-a:p1")
+    cache = InstrumentCache()
+    cache.replace_all(instrument_infos=(old,))
+
+    with pytest.raises(ValueError, match="Duplicate instrument resource ID"):
+        cache.replace_all(
+            instrument_infos=(first, second),
+            allow_duplicate_aliases=allow_duplicate_aliases,
+        )
+
+    assert cache.snapshot() == {"old": old}
+
+
 @pytest.mark.parametrize(
     ("alias", "resource_id", "port_id"),
     [


### PR DESCRIPTION
Add `clear_instruments(unit_label=...)` to the QuEL-3 controller and configuration manager. It calls `session.discard_instruments()` on every port of the selected unit, invalidates that unit's cache before deletion, and preserves other units. Session management uses a plain `async with`, without manager-level retries or exception wrapping.

Connecting to existing instruments with duplicate normalized aliases now logs a warning and retains the last instrument in readback order. The `connect()` signature and unit-selection behavior are unchanged; explicit refresh, deployment, and configuration validation retain their strict duplicate checks.

API docstrings are updated. Follow-up documentation: add the deletion example and the connect-only alias exception to `docs/developer-notes/quel3-configuration-design.md`.

Validation after rebasing onto the latest `develop`:

- `uv run ruff check --fix` and `uv run ruff format`: passed.
- `uv run pyright`: 0 errors, 0 warnings.
- `uv run pytest`: 2,213 passed, 17 warnings.
- `uv run mkdocs build`: passed with warnings.

Tests cover unit isolation, invalid labels, session acquisition without retries, partial deletion failures, pending-request completion before cleanup, duplicate-alias selection and warnings, and empty connection selections. Full pytest and Pyright ran outside the sandbox after diagnosing environment-related failures. Hardware validation was not performed.
