### PR TITLE
feat(contrib): add paired interleaved randomized benchmarking

### DIFF
--- a/src/qubex/contrib/__init__.py
+++ b/src/qubex/contrib/__init__.py
@@ -76,6 +76,11 @@ from .experiment.multipartite_entanglement import (
     partial_transpose,
     visualize_graph,
 )
+from .experiment.paired_interleaved_randomized_benchmarking import (
+    analyze_paired_irb,
+    measure_paired_irb,
+    paired_interleaved_randomized_benchmarking,
+)
 from .experiment.purity_benchmarking import (
     interleaved_purity_benchmarking,
     ipb_experiment,
@@ -123,6 +128,7 @@ from .experiment.thermal_excitation_characterization import (
 
 __all__ = [
     "analyze_chevron_matched_transform",
+    "analyze_paired_irb",
     "calibrate_cr_pi_pulse",
     "calibrate_gf_hpi_pulse",
     "calibrate_gf_pi_pulse",
@@ -173,6 +179,7 @@ __all__ = [
     "measure_cr_crosstalk",
     "measure_ghz_state",
     "measure_graph_state",
+    "measure_paired_irb",
     "measure_thermal_excitation",
     "measurement_induced_decay_experiment",
     "measurement_induced_dephasing",
@@ -180,6 +187,7 @@ __all__ = [
     "mqc_experiment",
     "obtain_anharmonicity_with_cr",
     "obtain_gf_rabi_params",
+    "paired_interleaved_randomized_benchmarking",
     "parity_oscillation",
     "partial_transpose",
     "pb_experiment_1q",

--- a/src/qubex/contrib/experiment/__init__.py
+++ b/src/qubex/contrib/experiment/__init__.py
@@ -69,6 +69,11 @@ from .multipartite_entanglement import (
     partial_transpose,
     visualize_graph,
 )
+from .paired_interleaved_randomized_benchmarking import (
+    analyze_paired_irb,
+    measure_paired_irb,
+    paired_interleaved_randomized_benchmarking,
+)
 from .purity_benchmarking import (
     interleaved_purity_benchmarking,
     ipb_experiment,
@@ -105,6 +110,7 @@ from .thermal_excitation_characterization import (
 
 __all__ = [
     "analyze_chevron_matched_transform",
+    "analyze_paired_irb",
     "calibrate_cr_pi_pulse",
     "calibrate_gf_hpi_pulse",
     "calibrate_gf_pi_pulse",
@@ -154,6 +160,7 @@ __all__ = [
     "measure_cr_crosstalk",
     "measure_ghz_state",
     "measure_graph_state",
+    "measure_paired_irb",
     "measure_thermal_excitation",
     "measurement_induced_decay_experiment",
     "measurement_induced_dephasing",
@@ -161,6 +168,7 @@ __all__ = [
     "mqc_experiment",
     "obtain_anharmonicity_with_cr",
     "obtain_gf_rabi_params",
+    "paired_interleaved_randomized_benchmarking",
     "parity_oscillation",
     "partial_transpose",
     "pb_experiment_1q",

--- a/src/qubex/contrib/experiment/paired_interleaved_randomized_benchmarking.py
+++ b/src/qubex/contrib/experiment/paired_interleaved_randomized_benchmarking.py
@@ -54,8 +54,9 @@ _DEFAULT_BOOTSTRAP_SEED = 0
 _DEFAULT_ACQUISITION_SEED: int | None = None
 _DEFAULT_PAIRS_PER_SWEEP = 1
 _DEFAULT_SWEEP_TIMEOUT_SECONDS = 300.0
-_DEFAULT_MAIN_REMAINING_FRACTIONS = (0.90, 0.70, 0.50, 0.30, 0.15)
-_ADDITIONAL_MAIN_REMAINING_FRACTIONS = (0.80, 0.60, 0.40, 0.20, 0.10, 0.05)
+_DEFAULT_AUTO_RANGE_REMAINING_FRACTION = 0.10
+_DEFAULT_MAIN_REMAINING_FRACTIONS = (0.90, 0.70, 0.50, 0.30, 0.15, 0.05)
+_ADDITIONAL_MAIN_REMAINING_FRACTIONS = (0.80, 0.60, 0.40, 0.20, 0.10, 0.02)
 _MIN_RECOMMENDED_TRIALS = 20
 _MIN_RECOMMENDED_CLIFFORD_POINTS = 6
 _MIN_AUTO_RANGE_FIT_POINTS = 6
@@ -3838,6 +3839,14 @@ def _run_single_target_auto_range(
             RuntimeWarning,
             stacklevel=3,
         )
+    if main_grid_selection.maximum_anchor_added:
+        warnings.warn(
+            "Paired-IRB main-grid tail target extends beyond `max_n_cliffords`; "
+            f"using the maximum Clifford length {maximum} as the tail anchor. "
+            "Increase `max_n_cliffords` if a deeper decay tail is required.",
+            RuntimeWarning,
+            stacklevel=3,
+        )
     reference_fit, interleaved_fit = (
         (
             pilot_assessment.reference.fit,
@@ -4057,6 +4066,15 @@ def _run_parallel_auto_range(
                 "Parallel paired-IRB main-grid selection is falling back to the "
                 f"pilot candidate grid for `{target}`: "
                 f"{selection.fallback_reason}.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+        if selection.maximum_anchor_added:
+            warnings.warn(
+                "Parallel paired-IRB main-grid tail target for "
+                f"`{target}` extends beyond `max_n_cliffords`; using the maximum "
+                f"Clifford length {maximum} as the tail anchor. Increase "
+                "`max_n_cliffords` if a deeper decay tail is required.",
                 RuntimeWarning,
                 stacklevel=3,
             )
@@ -4653,7 +4671,7 @@ def paired_interleaved_randomized_benchmarking(
     n_cliffords_range: ArrayLike | None = None,
     auto_range: bool = True,
     pilot_n_trials: int = 6,
-    auto_range_remaining_fraction: float = 0.2,
+    auto_range_remaining_fraction: float = _DEFAULT_AUTO_RANGE_REMAINING_FRACTION,
     main_remaining_fractions: Collection[float] = _DEFAULT_MAIN_REMAINING_FRACTIONS,
     n_trials: int | None = None,
     seeds: ArrayLike | Mapping[str, ArrayLike] | None = None,
@@ -4721,12 +4739,15 @@ def paired_interleaved_randomized_benchmarking(
         when `max(p_ref**m, p_irb**m)` is no greater than this value at its
         current maximum length, both fits are valid, and both arms have endpoint
         decay significance of at least 3. Ignored when no pilot is run. Defaults
-        to 0.2.
+        to 0.10 so the pilot observes the decay well into its tail before main-grid
+        selection.
     main_remaining_fractions : Collection[float], optional
         Ordered, strictly decreasing contrast fractions used to place the main
         Clifford lengths for both fitted decay parameters while auto-range is
         active. Sets and frozensets are rejected. Ignored when no pilot is run.
-        Defaults to `(0.90, 0.70, 0.50, 0.30, 0.15)`.
+        Defaults to `(0.90, 0.70, 0.50, 0.30, 0.15, 0.05)` so the main fit
+        includes a point with only about 5% fitted contrast remaining, which
+        better constrains the free asymptote `C`.
     n_trials : int | None, optional
         Paired trials per main-measurement length. Must be at least 2 and
         defaults to 30. Two or three trials permit the point estimate but not
@@ -4869,7 +4890,7 @@ def paired_interleaved_randomized_benchmarking(
     else:
         # Pilot-only options are intentionally ignored when no pilot is run.
         resolved_pilot_trials = 6
-        resolved_remaining_fraction = 0.2
+        resolved_remaining_fraction = _DEFAULT_AUTO_RANGE_REMAINING_FRACTION
         resolved_main_remaining_fractions = _DEFAULT_MAIN_REMAINING_FRACTIONS
     if use_auto_range and seeds is not None:
         raise ValueError("`auto_range=True` cannot be combined with explicit `seeds`.")

--- a/src/qubex/contrib/experiment/paired_interleaved_randomized_benchmarking.py
+++ b/src/qubex/contrib/experiment/paired_interleaved_randomized_benchmarking.py
@@ -1,0 +1,4947 @@
+"""
+Run statistically paired interleaved randomized benchmarking.
+
+The numerical fit intentionally remains a private, workflow-local prototype in
+`qubex.contrib`. It should move to `qxfitting` if this workflow is promoted from
+contrib or a second production caller needs the same fit API.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import math
+import warnings
+from collections.abc import Collection, Mapping, Sequence
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from itertools import pairwise
+from numbers import Real
+from typing import Any, Literal, cast
+
+import numpy as np
+import plotly.graph_objects as go
+from numpy.typing import ArrayLike, NDArray
+from qxpulse import PulseSchedule, Waveform
+from scipy.optimize import OptimizeWarning, curve_fit
+
+import qubex.visualization as viz
+from qubex.clifford.clifford import Clifford
+from qubex.core.async_bridge import get_shared_async_bridge
+from qubex.experiment import Experiment
+from qubex.experiment.experiment_constants import (
+    DEFAULT_INTERVAL,
+    DEFAULT_MAX_N_CLIFFORDS_1Q,
+    DEFAULT_MAX_N_CLIFFORDS_2Q,
+    DEFAULT_RB_N_TRIALS,
+    DEFAULT_SHOTS,
+)
+from qubex.experiment.models import Result
+from qubex.measurement import MeasurementResult, MeasurementResultConverter
+from qubex.typing import TargetMap
+
+_Protocol = Literal["reference", "interleaved"]
+_ErrorBar = Literal["sem", "std"] | None
+_InterleavedOverride = (
+    Waveform | PulseSchedule | TargetMap[Waveform | PulseSchedule] | None
+)
+_X90Override = Waveform | TargetMap[Waveform] | None
+_ZX90Override = PulseSchedule | TargetMap[PulseSchedule] | None
+_ResolvedInterleavedWaveform = Waveform | PulseSchedule | None
+
+_DEFAULT_BOOTSTRAP_SAMPLES = 2_000
+_DEFAULT_BOOTSTRAP_SEED = 0
+_DEFAULT_ACQUISITION_SEED: int | None = None
+_DEFAULT_PAIRS_PER_SWEEP = 1
+_DEFAULT_SWEEP_TIMEOUT_SECONDS = 300.0
+_DEFAULT_MAIN_REMAINING_FRACTIONS = (0.90, 0.70, 0.50, 0.30, 0.15)
+_ADDITIONAL_MAIN_REMAINING_FRACTIONS = (0.80, 0.60, 0.40, 0.20, 0.10, 0.05)
+_MIN_RECOMMENDED_TRIALS = 20
+_MIN_RECOMMENDED_CLIFFORD_POINTS = 6
+_MIN_AUTO_RANGE_FIT_POINTS = 6
+_MIN_MAIN_GRID_POINTS = 6
+_MAX_MAIN_GRID_POINTS = 14
+_MIN_PARALLEL_RETAINED_POINTS_PER_TARGET = 6
+_MIN_PILOT_DECAY_SIGNIFICANCE = 3.0
+_MIN_PILOT_AMPLITUDE = 0.05
+_MIN_PILOT_R_SQUARED = 0.5
+_PILOT_BOUND_ATOL = 2e-4
+_NEAR_DUPLICATE_RELATIVE_SEPARATION = 0.05
+_MIN_RELATIVE_MERGE_LENGTH = 10
+_MIN_ABSOLUTE_LOG_DECAY = 1e-12
+_MIN_BOOTSTRAP_SUCCESS_RATE = 0.8
+_MIN_BOOTSTRAP_SAMPLES_PER_STRATUM = 2
+_MAX_BOOTSTRAP_ANY_BOUND_FRACTION = 0.10
+_MAX_BOOTSTRAP_P_BOUND_FRACTION = 0.05
+_RAW_SCHEMA_VERSION = 1
+_EMPIRICAL_SEM_FLOOR_FRACTION = 0.25
+_ALL_ZERO_SEM_FLOOR = 1e-3
+_PROTOCOL_REFERENCE: _Protocol = "reference"
+_PROTOCOL_INTERLEAVED: _Protocol = "interleaved"
+
+logger = logging.getLogger(__name__)
+
+
+# -----------------------------------------------------------------------------
+# Internal data structures
+# -----------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class _DecayFitResult:
+    """Store one pure numerical weighted RB-decay fit."""
+
+    amplitude: float
+    decay_parameter: float
+    offset: float
+    covariance: NDArray[np.float64] | None
+    standard_errors: NDArray[np.float64] | None
+    predicted: NDArray[np.float64]
+    residuals: NDArray[np.float64]
+    weighted_residuals: NDArray[np.float64]
+    chi_square: float
+    reduced_chi_square: float | None
+    r_squared: float | None
+    parameters_at_bound: tuple[str, ...]
+
+    @property
+    def covariance_valid(self) -> bool:
+        """Return whether covariance-derived diagnostics are available."""
+        return self.covariance is not None and self.standard_errors is not None
+
+
+@dataclass(frozen=True)
+class _PilotDecayFitResult:
+    """Store one fixed-offset fit used only to estimate a pilot decay scale."""
+
+    amplitude: float
+    decay_parameter: float
+    offset: float
+    predicted: NDArray[np.float64]
+    residuals: NDArray[np.float64]
+    r_squared: float | None
+    parameters_at_bound: tuple[str, ...]
+
+    @property
+    def amplitude_lower_bound_hit(self) -> bool:
+        """Return whether the fitted pilot contrast is effectively zero."""
+        return bool(np.isclose(self.amplitude, 0.0, atol=_PILOT_BOUND_ATOL, rtol=0.0))
+
+    @property
+    def amplitude_upper_bound_hit(self) -> bool:
+        """Return whether the fitted contrast reaches its physical maximum."""
+        return bool(
+            np.isclose(
+                self.amplitude,
+                1.0 - self.offset,
+                atol=_PILOT_BOUND_ATOL,
+                rtol=0.0,
+            )
+        )
+
+
+@dataclass(frozen=True)
+class _PilotArmAssessment:
+    """Store one pilot arm's fit, observed decay, and validity decision."""
+
+    fit: _PilotDecayFitResult | None
+    decay_significance: float
+    invalid_reasons: tuple[str, ...]
+
+    @property
+    def valid(self) -> bool:
+        """Return whether this arm can guide stopping and main-grid design."""
+        return not self.invalid_reasons
+
+
+@dataclass(frozen=True)
+class _PilotDecayAssessment:
+    """Store paired pilot-fit quality without reusing main-fit inference."""
+
+    reference: _PilotArmAssessment
+    interleaved: _PilotArmAssessment
+
+    @property
+    def valid_fits(
+        self,
+    ) -> tuple[_PilotDecayFitResult, _PilotDecayFitResult] | None:
+        """Return both fits only when both arms have observable valid decay."""
+        if not self.reference.valid or not self.interleaved.valid:
+            return None
+        reference_fit = self.reference.fit
+        interleaved_fit = self.interleaved.fit
+        if reference_fit is None or interleaved_fit is None:
+            return None
+        return reference_fit, interleaved_fit
+
+    @property
+    def blocking_reason(self) -> str | None:
+        """Return the primary reason this assessment cannot stop the pilot."""
+        reasons = (
+            *self.reference.invalid_reasons,
+            *self.interleaved.invalid_reasons,
+        )
+        if not reasons:
+            return None
+        if any(reason != "insufficient_observed_decay" for reason in reasons):
+            return "fit_unusable"
+        return "insufficient_observed_decay"
+
+
+@dataclass(frozen=True)
+class _TargetSpec:
+    """Store the resolved target kind and measured qubit labels."""
+
+    is_two_qubit: bool
+    dimension: int
+    qubits: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class _TrialStatistics:
+    """Store per-length statistics and numerical fitting weights."""
+
+    mean: NDArray[np.float64]
+    std: NDArray[np.float64]
+    sem: NDArray[np.float64]
+    sem_used: NDArray[np.float64]
+    sem_floor_count: int
+
+
+@dataclass(frozen=True)
+class _TrialMoments:
+    """Store per-length moments before SEM regularization."""
+
+    mean: NDArray[np.float64]
+    std: NDArray[np.float64]
+    sem: NDArray[np.float64]
+
+
+@dataclass(frozen=True)
+class _PairedStatistics:
+    """Store both arms regularized with one common SEM floor."""
+
+    reference: _TrialStatistics
+    interleaved: _TrialStatistics
+    sem_floor: float
+    fit_covariance_scale_empirical: bool
+
+
+@dataclass(frozen=True)
+class _BootstrapResult:
+    """Store successful paired-bootstrap estimates and execution counts."""
+
+    seed: int | None
+    n_requested: int
+    fidelities: NDArray[np.float64]
+    p_reference: NDArray[np.float64]
+    p_interleaved: NDArray[np.float64]
+    p_correlation: float | None
+    stratum_counts: tuple[dict[str, int], ...]
+    reference_any_bound_count: int
+    interleaved_any_bound_count: int
+    reference_p_bound_count: int
+    interleaved_p_bound_count: int
+
+    @property
+    def n_success(self) -> int:
+        """Return the number of successful bootstrap replicates."""
+        return len(self.fidelities)
+
+    @property
+    def execution_skipped(self) -> bool:
+        """Return whether invalid strata prevented bootstrap fitting."""
+        return self.n_requested > 0 and not self.resampling_valid
+
+    @property
+    def n_attempted(self) -> int:
+        """Return the number of bootstrap fits actually attempted."""
+        return 0 if self.execution_skipped else self.n_requested
+
+    @property
+    def n_failed(self) -> int:
+        """Return the number of attempted bootstrap replicates that failed."""
+        return self.n_attempted - self.n_success
+
+    @property
+    def success_rate(self) -> float | None:
+        """Return the successful fraction among attempted bootstrap replicates."""
+        if self.n_attempted == 0:
+            return None
+        return self.n_success / self.n_attempted
+
+    @property
+    def optimizer_valid(self) -> bool:
+        """Return whether enough bootstrap replicates converged."""
+        success_rate = self.success_rate
+        return (
+            self.n_success >= 2
+            and success_rate is not None
+            and success_rate >= _MIN_BOOTSTRAP_SUCCESS_RATE
+        )
+
+    @property
+    def resampling_valid(self) -> bool:
+        """Return whether every AB/BA stratum can vary under resampling."""
+        return all(
+            counts["reference_first"] >= _MIN_BOOTSTRAP_SAMPLES_PER_STRATUM
+            and counts["interleaved_first"] >= _MIN_BOOTSTRAP_SAMPLES_PER_STRATUM
+            for counts in self.stratum_counts
+        )
+
+    @property
+    def invalid_reasons(self) -> tuple[str, ...]:
+        """Return the reason primary bootstrap uncertainty is unavailable."""
+        if self.n_requested == 0:
+            return ("bootstrap_disabled",)
+        if not self.resampling_valid:
+            return ("insufficient_samples_per_stratum",)
+        if not self.optimizer_valid:
+            return ("insufficient_optimizer_success",)
+        return ()
+
+    @property
+    def valid(self) -> bool:
+        """Return whether resampling and optimization permit primary uncertainty."""
+        return self.resampling_valid and self.optimizer_valid
+
+    def _bound_fraction(self, count: int) -> float | None:
+        """Return a bound-hit fraction among successful replicates."""
+        if self.n_success == 0:
+            return None
+        return count / self.n_success
+
+    @property
+    def reference_any_bound_fraction(self) -> float | None:
+        """Return the reference any-parameter bound-hit fraction."""
+        return self._bound_fraction(self.reference_any_bound_count)
+
+    @property
+    def interleaved_any_bound_fraction(self) -> float | None:
+        """Return the interleaved any-parameter bound-hit fraction."""
+        return self._bound_fraction(self.interleaved_any_bound_count)
+
+    @property
+    def reference_p_bound_fraction(self) -> float | None:
+        """Return the reference decay-parameter bound-hit fraction."""
+        return self._bound_fraction(self.reference_p_bound_count)
+
+    @property
+    def interleaved_p_bound_fraction(self) -> float | None:
+        """Return the interleaved decay-parameter bound-hit fraction."""
+        return self._bound_fraction(self.interleaved_p_bound_count)
+
+    @property
+    def parameter_bound_quality_valid(self) -> bool | None:
+        """Return whether successful fits avoid excessive parameter-bound hits."""
+        if self.n_requested == 0 or self.n_success == 0:
+            return None
+        fractions = (
+            self.reference_any_bound_fraction,
+            self.interleaved_any_bound_fraction,
+            self.reference_p_bound_fraction,
+            self.interleaved_p_bound_fraction,
+        )
+        if any(value is None for value in fractions):
+            return None
+        reference_any, interleaved_any, reference_p, interleaved_p = cast(
+            tuple[float, float, float, float],
+            fractions,
+        )
+        return (
+            reference_any <= _MAX_BOOTSTRAP_ANY_BOUND_FRACTION
+            and interleaved_any <= _MAX_BOOTSTRAP_ANY_BOUND_FRACTION
+            and reference_p <= _MAX_BOOTSTRAP_P_BOUND_FRACTION
+            and interleaved_p <= _MAX_BOOTSTRAP_P_BOUND_FRACTION
+        )
+
+    @property
+    def fidelity_std(self) -> float | None:
+        """Return sample SD across successful estimates for diagnostics."""
+        if self.n_success < 2:
+            return None
+        return float(np.std(self.fidelities, ddof=1))
+
+    def _fidelity_interval(
+        self, quantiles: tuple[float, float]
+    ) -> tuple[float, float] | None:
+        """Return one percentile interval across successful estimates."""
+        if self.n_success < 2:
+            return None
+        bounds = np.quantile(self.fidelities, quantiles)
+        return float(bounds[0]), float(bounds[1])
+
+    @property
+    def fidelity_ci68(self) -> tuple[float, float] | None:
+        """Return the diagnostic 68% percentile interval."""
+        return self._fidelity_interval((0.16, 0.84))
+
+    @property
+    def fidelity_ci95(self) -> tuple[float, float] | None:
+        """Return the diagnostic 95% percentile interval."""
+        return self._fidelity_interval((0.025, 0.975))
+
+    def to_payload(self) -> dict[str, object]:
+        """Return the public bootstrap result payload."""
+        return {
+            "seed": self.seed,
+            "n_requested": self.n_requested,
+            "n_attempted": self.n_attempted,
+            "n_success": self.n_success,
+            "n_failed": self.n_failed,
+            "success_rate": self.success_rate,
+            "optimizer_valid": self.optimizer_valid,
+            "resampling_valid": self.resampling_valid,
+            "execution_skipped": self.execution_skipped,
+            "valid": self.valid,
+            "invalid_reasons": self.invalid_reasons,
+            "minimum_samples_per_stratum": _MIN_BOOTSTRAP_SAMPLES_PER_STRATUM,
+            "parameter_bound_quality_valid": self.parameter_bound_quality_valid,
+            "parameter_bound_quality_thresholds": {
+                "any_bound_fraction_max": _MAX_BOOTSTRAP_ANY_BOUND_FRACTION,
+                "p_bound_fraction_max": _MAX_BOOTSTRAP_P_BOUND_FRACTION,
+            },
+            "fidelity_std": self.fidelity_std,
+            "fidelity_ci68": self.fidelity_ci68,
+            "fidelity_ci95": self.fidelity_ci95,
+            "fidelities": self.fidelities,
+            "p_reference": self.p_reference,
+            "p_interleaved": self.p_interleaved,
+            "p_correlation": self.p_correlation,
+            "resampling_method": "ab_ba_stratified_paired",
+            "stratum_counts": self.stratum_counts,
+            "reference_any_bound_count": self.reference_any_bound_count,
+            "reference_any_bound_fraction": self.reference_any_bound_fraction,
+            "interleaved_any_bound_count": self.interleaved_any_bound_count,
+            "interleaved_any_bound_fraction": self.interleaved_any_bound_fraction,
+            "reference_p_bound_count": self.reference_p_bound_count,
+            "reference_p_bound_fraction": self.reference_p_bound_fraction,
+            "interleaved_p_bound_count": self.interleaved_p_bound_count,
+            "interleaved_p_bound_fraction": self.interleaved_p_bound_fraction,
+        }
+
+
+@dataclass(frozen=True)
+class _RawIRBData:
+    """Store validated raw paired data and its metadata."""
+
+    n_cliffords: NDArray[np.int64]
+    reference_trials: NDArray[np.float64]
+    interleaved_trials: NDArray[np.float64]
+    first_protocols: NDArray[np.str_]
+    dimension: int
+    acquisition: Mapping[str, object]
+    metadata: Mapping[str, object]
+
+
+@dataclass(frozen=True)
+class _AnalysisOptions:
+    """Store validated options shared by analysis entry points."""
+
+    n_bootstrap: int
+    bootstrap_seed: int | None
+    sem_floor: float | None
+    error_bar: _ErrorBar
+    plot: bool
+    save_image: bool
+
+
+@dataclass(frozen=True)
+class _PairPlan:
+    """Describe one randomized acquisition pair."""
+
+    length_index: int
+    trial_index: int
+    n_cliffords: int
+    seed: int
+    first_protocol: _Protocol
+
+    @property
+    def protocols(self) -> tuple[_Protocol, _Protocol]:
+        """Return the adjacent protocol order for this pair."""
+        if self.first_protocol == _PROTOCOL_REFERENCE:
+            return (_PROTOCOL_REFERENCE, _PROTOCOL_INTERLEAVED)
+        return (_PROTOCOL_INTERLEAVED, _PROTOCOL_REFERENCE)
+
+
+@dataclass(frozen=True)
+class _SingleAcquisitionContext:
+    """Store validated settings reused across single-target acquisitions."""
+
+    target_spec: _TargetSpec
+    interleaved_clifford: Clifford
+    interleaved_clifford_name: str
+    interleaved_waveform: _ResolvedInterleavedWaveform
+    pairs_per_sweep: int
+    x90: _X90Override
+    zx90: PulseSchedule | None
+    mitigate_readout: bool
+    n_shots: int
+    shot_interval: float
+    time_integration: bool
+    sweep_timeout: float
+
+
+@dataclass(frozen=True)
+class _AutoRangeOutcome:
+    """Store a selected main grid and auditable pilot metadata."""
+
+    selected_main_grid: NDArray[np.int64]
+    metadata: dict[str, object]
+
+
+@dataclass(frozen=True)
+class _ParallelAutoRangeOutcome:
+    """Store one shared grid and per-target pilot metadata."""
+
+    selected_main_grid: NDArray[np.int64]
+    metadata_by_target: dict[str, dict[str, object]]
+
+
+@dataclass(frozen=True)
+class _MainGridSelection:
+    """Store one decay-adapted main-grid decision."""
+
+    reference_grid: NDArray[np.int64]
+    interleaved_grid: NDArray[np.int64]
+    selected_grid: NDArray[np.int64]
+    additional_fractions_used: tuple[float, ...]
+    supplemental_integer_grid: NDArray[np.int64]
+    near_duplicate_merging_applied: bool
+    thinning_applied: bool
+    maximum_anchor_added: bool
+    fallback_used: bool
+    fallback_reason: str | None
+
+
+# -----------------------------------------------------------------------------
+# Numerical primitives, validation, and target resolution
+# -----------------------------------------------------------------------------
+
+
+def _rb_decay(
+    n_cliffords: NDArray[np.float64],
+    amplitude: float,
+    decay_parameter: float,
+    offset: float,
+) -> NDArray[np.float64]:
+    """Evaluate the single-exponential RB survival model."""
+    return amplitude * decay_parameter**n_cliffords + offset
+
+
+def _validate_positive_integer(value: object, *, name: str) -> int:
+    """Return a strictly positive integer after validation."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"`{name}` must be a positive integer.")
+    resolved = int(value)
+    if resolved <= 0:
+        raise ValueError(f"`{name}` must be a positive integer.")
+    return resolved
+
+
+def _validate_nonnegative_integer(value: object, *, name: str) -> int:
+    """Return a nonnegative integer after validation."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, (int, np.integer)):
+        raise TypeError(f"`{name}` must be a nonnegative integer.")
+    resolved = int(value)
+    if resolved < 0:
+        raise ValueError(f"`{name}` must be a nonnegative integer.")
+    return resolved
+
+
+def _resolve_paired_n_trials(value: object) -> int:
+    """Resolve the main paired-trial count and enforce analyzable data."""
+    resolved = _validate_positive_integer(
+        DEFAULT_RB_N_TRIALS if value is None else value,
+        name="n_trials",
+    )
+    if resolved < 2:
+        raise ValueError("`n_trials` must be at least 2 for paired analysis.")
+    return resolved
+
+
+def _validate_optional_rng_seed(value: object, *, name: str) -> int | None:
+    """Return a NumPy-compatible optional RNG seed."""
+    if value is None:
+        return None
+    resolved = _validate_nonnegative_integer(value, name=name)
+    if resolved >= 2**64:
+        raise ValueError(f"`{name}` must be smaller than 2**64.")
+    return resolved
+
+
+def _validate_positive_real(value: object, *, name: str) -> float:
+    """Return a positive finite floating-point value."""
+    if isinstance(value, (bool, np.bool_)) or not isinstance(value, Real):
+        raise TypeError(f"`{name}` must be a positive real number.")
+    resolved = float(value)
+    if not np.isfinite(resolved) or resolved <= 0:
+        raise ValueError(f"`{name}` must be positive and finite.")
+    return resolved
+
+
+def _validate_open_unit_interval(value: object, *, name: str) -> float:
+    """Return a finite floating-point value strictly between zero and one."""
+    resolved = _validate_positive_real(value, name=name)
+    if resolved >= 1.0:
+        raise ValueError(f"`{name}` must be smaller than 1.")
+    return resolved
+
+
+def _resolve_main_remaining_fractions(
+    values: Collection[float],
+) -> tuple[float, ...]:
+    """Validate the descending contrast targets used for main-grid design."""
+    if isinstance(values, (set, frozenset)):
+        raise TypeError(
+            "`main_remaining_fractions` must preserve order; use a list, "
+            "tuple, or array instead of a set."
+        )
+    if isinstance(values, Mapping):
+        raise TypeError(
+            "`main_remaining_fractions` must be a one-dimensional collection "
+            "of values, not a mapping."
+        )
+    if isinstance(values, (str, bytes)) or not isinstance(values, Collection):
+        raise TypeError("`main_remaining_fractions` must be a collection of reals.")
+    if len(values) == 0:
+        raise ValueError("`main_remaining_fractions` must not be empty.")
+    resolved = tuple(
+        _validate_open_unit_interval(
+            value,
+            name=f"main_remaining_fractions[{index}]",
+        )
+        for index, value in enumerate(values)
+    )
+    if any(left <= right for left, right in pairwise(resolved)):
+        raise ValueError("`main_remaining_fractions` must be strictly decreasing.")
+    return resolved
+
+
+def _validate_boolean(value: object, *, name: str) -> bool:
+    """Return a Boolean without silently accepting truthy objects."""
+    if not isinstance(value, (bool, np.bool_)):
+        raise TypeError(f"`{name}` must be a boolean.")
+    return bool(value)
+
+
+def _normalize_targets(targets: Sequence[str] | str) -> tuple[str, ...]:
+    """Return a nonempty ordered tuple of distinct target labels."""
+    if isinstance(targets, str):
+        resolved = (targets,)
+    elif isinstance(targets, (set, frozenset)):
+        raise TypeError(
+            "`targets` must preserve order; use a list or tuple instead of a set."
+        )
+    elif isinstance(targets, Sequence):
+        resolved = tuple(targets)
+    else:
+        raise TypeError("`targets` must be a target label or an ordered sequence.")
+    if not resolved:
+        raise ValueError("`targets` must contain at least one target label.")
+    if not all(isinstance(target, str) for target in resolved):
+        raise TypeError("Every entry in `targets` must be a string.")
+    if len(set(resolved)) != len(resolved):
+        raise ValueError("`targets` must not contain duplicate labels.")
+    return cast(tuple[str, ...], resolved)
+
+
+def _split_optional_seed(
+    value: object,
+    *,
+    count: int,
+    name: str,
+) -> tuple[int | None, ...]:
+    """Split one deterministic master seed into independent child streams."""
+    resolved = _validate_optional_rng_seed(value, name=name)
+    if count == 1 or resolved is None:
+        return (resolved,) * count
+    children = np.random.SeedSequence(resolved).spawn(count)
+    return tuple(int(child.generate_state(1, dtype=np.uint64)[0]) for child in children)
+
+
+def _explicit_seeds_by_target(
+    seeds: ArrayLike | Mapping[str, ArrayLike] | None,
+    *,
+    targets: tuple[str, ...],
+) -> dict[str, ArrayLike | None]:
+    """Resolve optional fixed seed matrices without sharing one across targets."""
+    if seeds is None:
+        return dict.fromkeys(targets)
+    if isinstance(seeds, Mapping):
+        missing = [target for target in targets if target not in seeds]
+        if missing:
+            raise ValueError(
+                "`seeds` is missing target entries: " + ", ".join(missing) + "."
+            )
+        resolved: dict[str, ArrayLike | None] = {
+            target: seeds[target] for target in targets
+        }
+        missing_matrices = [
+            target for target, matrix in resolved.items() if matrix is None
+        ]
+        if missing_matrices:
+            raise TypeError(
+                "`seeds` must provide an explicit matrix for each target; got "
+                f"None for {', '.join(missing_matrices)}."
+            )
+        return resolved
+    if len(targets) != 1:
+        raise ValueError(
+            "Multi-target explicit `seeds` must map each target to its own matrix."
+        )
+    return {targets[0]: seeds}
+
+
+def _type_names(expected_types: tuple[type, ...]) -> str:
+    """Return a readable union of runtime types for validation errors."""
+    return " or ".join(expected_type.__name__ for expected_type in expected_types)
+
+
+def _require_target_mapping_entry(
+    value: Mapping[str, Any],
+    target: str,
+    *,
+    name: str,
+    expected_types: tuple[type, ...],
+) -> Any:
+    """Return and type-check one explicit target override without fallback."""
+    if target not in value:
+        raise ValueError(f"`{name}` is missing an override for target `{target}`.")
+    resolved = value[target]
+    if not isinstance(resolved, expected_types):
+        raise TypeError(
+            f"`{name}[{target!r}]` must be {_type_names(expected_types)}; "
+            f"got {type(resolved).__name__}."
+        )
+    return resolved
+
+
+def _validate_waveform_mapping(
+    value: Mapping[str, Any],
+    *,
+    required_keys: Collection[str],
+    name: str,
+) -> None:
+    """Require waveform-valued entries for every requested physical-qubit key."""
+    missing = [key for key in required_keys if key not in value]
+    if missing:
+        raise ValueError(
+            f"`{name}` is missing waveform overrides for: {', '.join(missing)}."
+        )
+    for key in required_keys:
+        resolved = value[key]
+        if not isinstance(resolved, Waveform):
+            raise TypeError(
+                f"`{name}[{key!r}]` must be Waveform; got {type(resolved).__name__}."
+            )
+
+
+def _validate_multi_target_schedule_overrides(
+    targets: tuple[str, ...],
+    target_specs: Mapping[str, _TargetSpec],
+    *,
+    interleaved_waveform: _InterleavedOverride,
+    zx90: _ZX90Override,
+) -> None:
+    """Reject target-specific schedules that would be reused across multiple targets."""
+    if len(targets) <= 1:
+        return
+    if isinstance(interleaved_waveform, PulseSchedule):
+        raise ValueError(  # noqa: TRY004 - valid for one target, invalid here
+            "Multi-target paired IRB cannot reuse one `interleaved_waveform` "
+            "PulseSchedule across targets; pass a TargetMap keyed by target instead."
+        )
+    two_qubit_targets = tuple(
+        target for target in targets if target_specs[target].is_two_qubit
+    )
+    if len(two_qubit_targets) > 1 and isinstance(zx90, PulseSchedule):
+        raise ValueError(
+            "Multi-target paired IRB with more than one CR target cannot reuse one "
+            "`zx90` PulseSchedule; pass a TargetMap keyed by CR target instead."
+        )
+
+
+def _resolve_interleaved_waveform_override(
+    target: str,
+    target_spec: _TargetSpec,
+    value: _InterleavedOverride,
+) -> _ResolvedInterleavedWaveform:
+    """Resolve one target's interleaved-gate implementation."""
+    expected_types = (
+        (PulseSchedule,) if target_spec.is_two_qubit else (Waveform, PulseSchedule)
+    )
+    if isinstance(value, Mapping):
+        return cast(
+            _ResolvedInterleavedWaveform,
+            _require_target_mapping_entry(
+                value,
+                target,
+                name="interleaved_waveform",
+                expected_types=expected_types,
+            ),
+        )
+    if value is not None and not isinstance(value, expected_types):
+        raise TypeError(
+            "`interleaved_waveform` must be "
+            f"{_type_names(expected_types)} for target `{target}`; "
+            f"got {type(value).__name__}."
+        )
+    return value
+
+
+def _resolve_zx90_override(
+    target: str,
+    target_spec: _TargetSpec,
+    value: _ZX90Override,
+) -> PulseSchedule | None:
+    """Resolve a CR-target ZX90 schedule and discard it for 1Q targets."""
+    if not target_spec.is_two_qubit:
+        return None
+    if isinstance(value, Mapping):
+        return cast(
+            PulseSchedule,
+            _require_target_mapping_entry(
+                value,
+                target,
+                name="zx90",
+                expected_types=(PulseSchedule,),
+            ),
+        )
+    if value is not None and not isinstance(value, PulseSchedule):
+        raise TypeError(
+            f"`zx90` must be PulseSchedule for CR target `{target}`; "
+            f"got {type(value).__name__}."
+        )
+    return value
+
+
+def _resolve_x90_override(
+    target: str,
+    target_spec: _TargetSpec,
+    value: _X90Override,
+) -> _X90Override:
+    """Resolve a 1Q target entry or validate a CR physical-qubit map."""
+    if target_spec.is_two_qubit:
+        if isinstance(value, Mapping):
+            _validate_waveform_mapping(
+                value,
+                required_keys=target_spec.qubits,
+                name="x90",
+            )
+        elif value is not None:
+            raise TypeError(
+                "`x90` must be a physical-qubit waveform mapping for CR target "
+                f"`{target}`; got {type(value).__name__}."
+            )
+        return value
+    if isinstance(value, Mapping):
+        return cast(
+            Waveform,
+            _require_target_mapping_entry(
+                value,
+                target,
+                name="x90",
+                expected_types=(Waveform,),
+            ),
+        )
+    if value is not None and not isinstance(value, Waveform):
+        raise TypeError(
+            f"`x90` must be Waveform for 1Q target `{target}`; "
+            f"got {type(value).__name__}."
+        )
+    return value
+
+
+def _resolve_analysis_options(
+    *,
+    n_bootstrap: object,
+    bootstrap_seed: object,
+    sem_floor: object,
+    error_bar: object,
+    plot: object,
+    save_image: object,
+) -> _AnalysisOptions:
+    """Validate analysis options before numerical work or hardware acquisition."""
+    if error_bar is not None and not isinstance(error_bar, str):
+        raise TypeError("`error_bar` must be a string or None.")
+    if error_bar not in (None, "sem", "std"):
+        raise ValueError("`error_bar` must be 'sem', 'std', or None.")
+    resolved_sem_floor = (
+        None
+        if sem_floor is None
+        else _validate_positive_real(sem_floor, name="sem_floor")
+    )
+    return _AnalysisOptions(
+        n_bootstrap=_validate_nonnegative_integer(
+            n_bootstrap,
+            name="n_bootstrap",
+        ),
+        bootstrap_seed=_validate_optional_rng_seed(
+            bootstrap_seed,
+            name="bootstrap_seed",
+        ),
+        sem_floor=resolved_sem_floor,
+        error_bar=cast(_ErrorBar, error_bar),
+        plot=_validate_boolean(plot, name="plot"),
+        save_image=_validate_boolean(save_image, name="save_image"),
+    )
+
+
+def _default_n_cliffords(maximum: int) -> NDArray[np.int64]:
+    """Return zero followed by powers of two through the fixed maximum."""
+    maximum = _validate_positive_integer(maximum, name="max_n_cliffords")
+    if maximum < 4:
+        raise ValueError("`max_n_cliffords` must be at least 4.")
+    if maximum > np.iinfo(np.int64).max:
+        raise ValueError("`max_n_cliffords` must fit in a signed 64-bit integer.")
+    values = [0]
+    value = 1
+    while value <= maximum:
+        values.append(value)
+        value *= 2
+    return np.asarray(values, dtype=np.int64)
+
+
+def _auto_range_candidate_grid(maximum: int) -> NDArray[np.int64]:
+    """Return power-of-two pilot lengths plus the exact exploration ceiling."""
+    grid = _default_n_cliffords(maximum)
+    if int(grid[-1]) != maximum:
+        grid = np.append(grid, np.int64(maximum))
+    if len(grid) < _MIN_AUTO_RANGE_FIT_POINTS:
+        raise ValueError(
+            "Active auto-range requires `max_n_cliffords` to provide at least "
+            "six pilot lengths; increase it or set `auto_range=False`."
+        )
+    return grid
+
+
+def _validate_range_choice(
+    n_cliffords_range: ArrayLike | None,
+    max_n_cliffords: int | None,
+) -> None:
+    """Reject the two mutually exclusive Clifford-range controls."""
+    if n_cliffords_range is not None and max_n_cliffords is not None:
+        raise ValueError(
+            "Specify only one of `n_cliffords_range` and `max_n_cliffords`."
+        )
+
+
+def _resolve_n_cliffords(
+    n_cliffords_range: ArrayLike | None,
+    *,
+    maximum: int,
+) -> NDArray[np.int64]:
+    """Return a validated fixed Clifford-length grid."""
+    if n_cliffords_range is None:
+        return _default_n_cliffords(maximum)
+    raw = np.asarray(n_cliffords_range)
+    if raw.ndim != 1:
+        raise ValueError("`n_cliffords_range` must be one-dimensional.")
+    if raw.size < 4:
+        raise ValueError("`n_cliffords_range` must contain at least four lengths.")
+    if np.issubdtype(raw.dtype, np.bool_) or not np.issubdtype(raw.dtype, np.integer):
+        raise TypeError("`n_cliffords_range` must contain integers.")
+    resolved = raw.astype(np.int64)
+    if np.any(resolved < 0):
+        raise ValueError("`n_cliffords_range` must contain nonnegative lengths.")
+    if np.any(np.diff(resolved) <= 0):
+        raise ValueError("`n_cliffords_range` must be strictly increasing.")
+    return resolved
+
+
+def _generated_seed_matrix(
+    shape: tuple[int, int],
+    *,
+    sequence_seed: int | None,
+) -> NDArray[np.int64]:
+    """Generate independent uint32 seeds, retrying the negligible collisions."""
+    rng = np.random.default_rng(sequence_seed)
+    size = int(np.prod(shape))
+    while True:
+        seeds = rng.integers(0, 2**32, size=size, dtype=np.uint32).astype(np.int64)
+        if len(np.unique(seeds)) == size:
+            return seeds.reshape(shape)
+
+
+def _resolve_seed_matrix(
+    seeds: ArrayLike | None,
+    *,
+    shape: tuple[int, int],
+    sequence_seed: int | None,
+) -> NDArray[np.int64]:
+    """Return exactly one sequence seed per Clifford-length/trial cell."""
+    if seeds is not None and sequence_seed is not None:
+        raise ValueError("Specify only one of `seeds` and `sequence_seed`.")
+    if seeds is None:
+        return _generated_seed_matrix(shape, sequence_seed=sequence_seed)
+    raw = np.asarray(seeds)
+    if raw.shape != shape:
+        raise ValueError(f"`seeds` must have shape {shape}; got {raw.shape}.")
+    if np.issubdtype(raw.dtype, np.bool_) or not np.issubdtype(raw.dtype, np.integer):
+        raise TypeError("`seeds` must contain integers.")
+    resolved = raw.astype(np.int64)
+    if np.any(resolved < 0) or np.any(resolved >= 2**32):
+        raise ValueError("`seeds` values must be in the uint32 range.")
+    if len(np.unique(resolved)) != resolved.size:
+        raise ValueError("`seeds` must contain distinct values for every cell.")
+    return resolved
+
+
+def _build_pair_plan(
+    n_cliffords: NDArray[np.int64],
+    seeds: NDArray[np.int64],
+    *,
+    acquisition_seed: int | None,
+) -> list[_PairPlan]:
+    """Randomize pairs globally after balancing AB/BA within every length."""
+    rng = np.random.default_rng(acquisition_seed)
+    unordered_plans: list[_PairPlan] = []
+    n_trials = seeds.shape[1]
+    extra_reference_first = np.zeros(len(n_cliffords), dtype=np.bool_)
+    if n_trials % 2 == 1:
+        n_extra_reference = len(n_cliffords) // 2
+        if len(n_cliffords) % 2 == 1:
+            n_extra_reference += int(rng.integers(0, 2))
+        extra_reference_first[:n_extra_reference] = True
+        rng.shuffle(extra_reference_first)
+    for length_index, n_clifford in enumerate(n_cliffords):
+        n_reference_first = n_trials // 2 + int(extra_reference_first[length_index])
+        first_protocols: list[_Protocol] = [
+            *(_PROTOCOL_REFERENCE for _ in range(n_reference_first)),
+            *(_PROTOCOL_INTERLEAVED for _ in range(n_trials - n_reference_first)),
+        ]
+        rng.shuffle(first_protocols)
+        unordered_plans.extend(
+            _PairPlan(
+                length_index=length_index,
+                trial_index=trial_index,
+                n_cliffords=int(n_clifford),
+                seed=int(seeds[length_index, trial_index]),
+                first_protocol=first_protocol,
+            )
+            for trial_index, first_protocol in enumerate(first_protocols)
+        )
+    pair_order = rng.permutation(len(unordered_plans))
+    return [unordered_plans[int(index)] for index in pair_order]
+
+
+def _resolve_interleaved_clifford(
+    exp: Experiment,
+    interleaved_clifford: str | Clifford,
+) -> tuple[Clifford, str]:
+    """Resolve a public Clifford name without changing the legacy service."""
+    if isinstance(interleaved_clifford, str):
+        resolved = exp.benchmarking_service.clifford.get(interleaved_clifford)
+        if resolved is None:
+            raise ValueError(f"Invalid Clifford: {interleaved_clifford}")
+        if not isinstance(resolved, Clifford):
+            raise TypeError(
+                "The benchmarking-service Clifford registry must contain "
+                "Clifford instances."
+            )
+        return resolved, interleaved_clifford
+    if not isinstance(interleaved_clifford, Clifford):
+        raise TypeError("`interleaved_clifford` must be a Clifford or its name.")
+    return interleaved_clifford, interleaved_clifford.name
+
+
+def _validate_clifford_arity(
+    interleaved_clifford: Clifford,
+    *,
+    target_spec: _TargetSpec,
+) -> None:
+    """Require the Clifford and target to act on the same number of qubits."""
+    expected_arity = 2 if target_spec.is_two_qubit else 1
+    operator_arities = {len(operator) for operator in interleaved_clifford.map}
+    if operator_arities != {expected_arity}:
+        target_kind = "two-qubit" if target_spec.is_two_qubit else "one-qubit"
+        raise ValueError(
+            f"`interleaved_clifford` must be a {target_kind} Clifford for this target."
+        )
+
+
+def _resolve_target(exp: Experiment, target: str) -> _TargetSpec:
+    """Validate one target and return its measurement specification."""
+    if not isinstance(target, str):
+        raise TypeError("`target` must be a single target label string.")
+    target_object = exp.experiment_system.get_target(target)
+    is_two_qubit = bool(target_object.is_cr)
+    if not is_two_qubit:
+        qubit = exp.experiment_system.resolve_qubit_label(target)
+        if not isinstance(qubit, str):
+            raise ValueError(f"Could not resolve a qubit label for `{target}`.")
+        exp.pulse.validate_rabi_params([target])
+        return _TargetSpec(is_two_qubit=False, dimension=2, qubits=(qubit,))
+
+    cr_params = getattr(getattr(exp.ctx, "calib_note", None), "cr_params", {})
+    if target not in cr_params:
+        raise ValueError(f"CR parameters for `{target}` are not stored.")
+    qubits = tuple(exp.ctx.cr_pair(target))
+    if (
+        len(qubits) != 2
+        or not all(isinstance(qubit, str) for qubit in qubits)
+        or len(set(qubits)) != 2
+    ):
+        raise ValueError(f"CR target `{target}` must resolve to two distinct qubits.")
+    classifiers = exp.ctx.classifiers
+    missing = [qubit for qubit in qubits if classifiers.get(qubit) is None]
+    if missing:
+        raise ValueError(f"Classifier not found for {', '.join(missing)}.")
+    return _TargetSpec(is_two_qubit=True, dimension=4, qubits=qubits)
+
+
+def _resolve_target_maximum(
+    target_spec: _TargetSpec,
+    max_n_cliffords: int | None,
+) -> int:
+    """Return the target-specific default or a validated explicit maximum."""
+    if max_n_cliffords is not None:
+        return _validate_positive_integer(
+            max_n_cliffords,
+            name="max_n_cliffords",
+        )
+    return (
+        DEFAULT_MAX_N_CLIFFORDS_2Q
+        if target_spec.is_two_qubit
+        else DEFAULT_MAX_N_CLIFFORDS_1Q
+    )
+
+
+def _resolve_target_acquisition(
+    exp: Experiment,
+    target: str,
+    *,
+    interleaved_clifford: str | Clifford,
+    interleaved_waveform: _InterleavedOverride,
+    pairs_per_sweep: object,
+    x90: _X90Override,
+    zx90: _ZX90Override,
+    mitigate_readout: object,
+    n_shots: object,
+    shot_interval: object,
+    time_integration: object,
+    sweep_timeout: object,
+    target_spec: _TargetSpec | None = None,
+) -> _SingleAcquisitionContext:
+    """Resolve one target and return its validated acquisition context."""
+    resolved_target_spec = (
+        _resolve_target(exp, target) if target_spec is None else target_spec
+    )
+    resolved_clifford, clifford_name = _resolve_interleaved_clifford(
+        exp,
+        interleaved_clifford,
+    )
+    _validate_clifford_arity(resolved_clifford, target_spec=resolved_target_spec)
+    context = _SingleAcquisitionContext(
+        target_spec=resolved_target_spec,
+        interleaved_clifford=resolved_clifford,
+        interleaved_clifford_name=clifford_name,
+        interleaved_waveform=_resolve_interleaved_waveform_override(
+            target,
+            resolved_target_spec,
+            interleaved_waveform,
+        ),
+        pairs_per_sweep=_validate_positive_integer(
+            pairs_per_sweep,
+            name="pairs_per_sweep",
+        ),
+        x90=_resolve_x90_override(target, resolved_target_spec, x90),
+        zx90=_resolve_zx90_override(target, resolved_target_spec, zx90),
+        mitigate_readout=_validate_boolean(
+            mitigate_readout,
+            name="mitigate_readout",
+        ),
+        n_shots=_validate_positive_integer(n_shots, name="n_shots"),
+        shot_interval=_validate_positive_real(
+            shot_interval,
+            name="shot_interval",
+        ),
+        time_integration=_validate_boolean(
+            time_integration,
+            name="time_integration",
+        ),
+        sweep_timeout=_validate_positive_real(
+            sweep_timeout,
+            name="sweep_timeout",
+        ),
+    )
+    return context
+
+
+def _resolve_target_acquisitions(
+    exp: Experiment,
+    targets: tuple[str, ...],
+    target_specs: Mapping[str, _TargetSpec],
+    *,
+    interleaved_clifford: str | Clifford,
+    interleaved_waveform: _InterleavedOverride,
+    pairs_per_sweep: object,
+    x90: _X90Override,
+    zx90: _ZX90Override,
+    mitigate_readout: object,
+    n_shots: object,
+    shot_interval: object,
+    time_integration: object,
+    sweep_timeout: object,
+) -> dict[str, _SingleAcquisitionContext]:
+    """Resolve validated acquisition contexts for an ordered target group."""
+    return {
+        target: _resolve_target_acquisition(
+            exp,
+            target,
+            interleaved_clifford=interleaved_clifford,
+            interleaved_waveform=interleaved_waveform,
+            pairs_per_sweep=pairs_per_sweep,
+            x90=x90,
+            zx90=zx90,
+            mitigate_readout=mitigate_readout,
+            n_shots=n_shots,
+            shot_interval=shot_interval,
+            time_integration=time_integration,
+            sweep_timeout=sweep_timeout,
+            target_spec=target_specs[target],
+        )
+        for target in targets
+    }
+
+
+def _rb_schedule_for_protocol(
+    exp: Experiment,
+    target: str,
+    context: _SingleAcquisitionContext,
+    *,
+    n_cliffords: int,
+    seed: int,
+    protocol: _Protocol,
+) -> PulseSchedule:
+    """Build one reference or interleaved RB schedule for a resolved target."""
+    is_interleaved = protocol == _PROTOCOL_INTERLEAVED
+    return exp.rb_sequence(
+        target,
+        n=n_cliffords,
+        x90=context.x90,
+        zx90=context.zx90,
+        interleaved_waveform=(context.interleaved_waveform if is_interleaved else None),
+        interleaved_clifford=(context.interleaved_clifford if is_interleaved else None),
+        seed=seed,
+    )
+
+
+def _pair_chunk_points(
+    chunk: Sequence[_PairPlan],
+) -> list[tuple[_PairPlan, _Protocol]]:
+    """Expand each pair into its two adjacent protocol measurement points."""
+    return [(pair, protocol) for pair in chunk for protocol in pair.protocols]
+
+
+def _raw_target_payload(
+    *,
+    context: _SingleAcquisitionContext,
+    n_cliffords: NDArray[np.int64],
+    seeds: NDArray[np.int64],
+    sequence_seed: int | None,
+    acquisition_seed: int | None,
+    pair_plan: Sequence[_PairPlan],
+    pair_chunks: tuple[dict[str, object], ...],
+    reference_trials: NDArray[np.float64],
+    interleaved_trials: NDArray[np.float64],
+    batching_semantics: str,
+    acquisition_extras: Mapping[str, object] | None = None,
+) -> dict[str, object]:
+    """Build the shared raw-result schema for one target."""
+    planned_order = tuple(
+        {
+            "pair_order_index": pair_order_index,
+            "length_index": pair.length_index,
+            "trial_index": pair.trial_index,
+            "n_cliffords": pair.n_cliffords,
+            "seed": int(seeds[pair.length_index, pair.trial_index]),
+            "first_protocol": pair.first_protocol,
+        }
+        for pair_order_index, pair in enumerate(pair_plan)
+    )
+    acquisition: dict[str, object] = {
+        "n_cliffords": n_cliffords.copy(),
+        "n_trials": seeds.shape[1],
+        "n_shots": context.n_shots,
+        "shot_interval": context.shot_interval,
+        "time_integration": context.time_integration,
+        "seeds": seeds.copy(),
+        "sequence_seed": sequence_seed,
+        "acquisition_seed": acquisition_seed,
+        "planned_order": planned_order,
+        "pair_chunks": pair_chunks,
+        "pairs_per_sweep": context.pairs_per_sweep,
+        "n_sweep_calls": len(pair_chunks),
+        "n_measurement_points": 2 * seeds.size,
+        "timestamp_granularity": "sweep_chunk",
+        "batching_semantics": batching_semantics,
+    }
+    if acquisition_extras is not None:
+        acquisition.update(acquisition_extras)
+
+    return {
+        "reference": {"trials": reference_trials},
+        "interleaved": {"trials": interleaved_trials},
+        "acquisition": acquisition,
+        "metadata": {
+            "schema_version": _RAW_SCHEMA_VERSION,
+            "dimension": context.target_spec.dimension,
+            "is_two_qubit": context.target_spec.is_two_qubit,
+            "qubits": context.target_spec.qubits,
+            "interleaved_clifford": context.interleaved_clifford_name,
+            "mitigate_readout": (
+                context.mitigate_readout if context.target_spec.is_two_qubit else False
+            ),
+        },
+    }
+
+
+# -----------------------------------------------------------------------------
+# Hardware acquisition and raw-result construction
+# -----------------------------------------------------------------------------
+
+
+def _point_kerneled_data(
+    exp: Experiment,
+    target: str,
+    point_result: MeasurementResult,
+) -> NDArray[Any]:
+    """Return integrated data from the final capture of a one-qubit target."""
+    resolve_read_label = getattr(exp.experiment_system, "resolve_read_label", None)
+    readout_target = (
+        str(resolve_read_label(target)) if callable(resolve_read_label) else target
+    )
+    if readout_target in point_result.data:
+        data_target = readout_target
+    elif target in point_result.data:
+        data_target = target
+    else:
+        raise KeyError(
+            f"Neither `{readout_target}` nor `{target}` exists in measurement "
+            f"result targets {list(point_result.data)}."
+        )
+    captures = point_result.data[data_target]
+    if not captures:
+        raise ValueError(f"Measurement result for `{data_target}` has no captures.")
+    capture = captures[-1]
+    capture_data = np.asarray(capture.data)
+    capture_config = getattr(capture, "config", None)
+    if capture_config is not None and not capture_config.time_integration:
+        integration_axis = None if capture_config.shot_averaging else -1
+        return np.asarray(np.sum(capture_data, axis=integration_axis))
+    return capture_data
+
+
+def _extract_survival_probability(
+    exp: Experiment,
+    target: str,
+    point_result: MeasurementResult,
+    *,
+    is_two_qubit: bool,
+    qubits: tuple[str, ...],
+    mitigate_readout: bool,
+) -> float:
+    """Convert one sweep-point result into computational-state survival."""
+    if not is_two_qubit:
+        kerneled_data = _point_kerneled_data(exp, target, point_result)
+        normalized = exp.pulse.rabi_params[target].normalize(kerneled_data)
+        probability = float(np.real(np.mean(np.asarray(normalized)))) / 2.0 + 0.5
+    else:
+        measure_result = MeasurementResultConverter.to_measure_result(
+            point_result,
+            index=-1,
+            classifiers=exp.ctx.classifiers,
+        )
+        probabilities = (
+            measure_result.get_mitigated_probabilities(qubits)
+            if mitigate_readout
+            else measure_result.get_probabilities(qubits)
+        )
+        try:
+            probability = float(probabilities["00"])
+        except KeyError:
+            raise ValueError(
+                "The two-qubit measurement did not produce `P(00)`."
+            ) from None
+    if not np.isfinite(probability):
+        raise ValueError("The measured survival probability must be finite.")
+    return probability
+
+
+def _iso_now() -> str:
+    """Return the current UTC timestamp in ISO 8601 format."""
+    return datetime.now(timezone.utc).isoformat()
+
+
+async def _measure_paired_irb_async(
+    exp: Experiment,
+    target: str,
+    *,
+    context: _SingleAcquisitionContext,
+    n_cliffords: NDArray[np.int64],
+    seeds: NDArray[np.int64],
+    sequence_seed: int | None,
+    acquisition_seed: int | None,
+) -> Result:
+    """Measure randomized pair chunks and retain their honest timing metadata."""
+    pair_plan = _build_pair_plan(
+        n_cliffords,
+        seeds,
+        acquisition_seed=acquisition_seed,
+    )
+    reference_trials = np.full(seeds.shape, np.nan, dtype=np.float64)
+    interleaved_trials = np.full(seeds.shape, np.nan, dtype=np.float64)
+    chunk_records: list[dict[str, object]] = []
+    exp.ctx.reset_awg_and_capunits(qubits=set(context.target_spec.qubits))
+
+    for chunk_start in range(0, len(pair_plan), context.pairs_per_sweep):
+        chunk = pair_plan[chunk_start : chunk_start + context.pairs_per_sweep]
+        points = _pair_chunk_points(chunk)
+
+        def schedule(
+            point_index: int,
+            *,
+            _points: list[tuple[_PairPlan, _Protocol]] = points,
+        ) -> PulseSchedule:
+            pair, protocol = _points[int(point_index)]
+            return _rb_schedule_for_protocol(
+                exp,
+                target,
+                context,
+                n_cliffords=pair.n_cliffords,
+                seed=pair.seed,
+                protocol=protocol,
+            )
+
+        started_at = _iso_now()
+        sweep = await asyncio.wait_for(
+            exp.measurement_service.run_sweep_measurement(
+                schedule,
+                sweep_values=np.arange(len(points), dtype=np.int64),
+                n_shots=context.n_shots,
+                shot_interval=context.shot_interval,
+                shot_averaging=not context.target_spec.is_two_qubit,
+                time_integration=context.time_integration,
+                state_classification=False,
+                final_measurement=True,
+                plot=False,
+                enable_tqdm=False,
+            ),
+            timeout=context.sweep_timeout,
+        )
+        completed_at = _iso_now()
+        if len(sweep.results) != len(points):
+            raise RuntimeError(
+                "Sweep result count does not match the requested paired points: "
+                f"expected {len(points)}, got {len(sweep.results)}."
+            )
+        for point_result, (pair, protocol) in zip(
+            sweep.results,
+            points,
+            strict=True,
+        ):
+            probability = _extract_survival_probability(
+                exp,
+                target,
+                point_result,
+                is_two_qubit=context.target_spec.is_two_qubit,
+                qubits=context.target_spec.qubits,
+                mitigate_readout=context.mitigate_readout,
+            )
+            destination = (
+                reference_trials
+                if protocol == _PROTOCOL_REFERENCE
+                else interleaved_trials
+            )
+            destination[pair.length_index, pair.trial_index] = probability
+        chunk_records.append(
+            {
+                "pair_order_indices": tuple(
+                    range(chunk_start, chunk_start + len(chunk))
+                ),
+                "n_points": len(points),
+                "started_at": started_at,
+                "completed_at": completed_at,
+            }
+        )
+
+    if not np.all(np.isfinite(reference_trials)) or not np.all(
+        np.isfinite(interleaved_trials)
+    ):
+        raise RuntimeError("Paired IRB acquisition produced non-finite trial data.")
+    payload = _raw_target_payload(
+        context=context,
+        n_cliffords=n_cliffords,
+        seeds=seeds,
+        sequence_seed=sequence_seed,
+        acquisition_seed=acquisition_seed,
+        pair_plan=pair_plan,
+        pair_chunks=tuple(chunk_records),
+        reference_trials=reference_trials,
+        interleaved_trials=interleaved_trials,
+        batching_semantics="delegated_to_run_sweep_measurement",
+    )
+    return Result(data={target: payload})
+
+
+def _run_single_target_acquisition(
+    exp: Experiment,
+    target: str,
+    *,
+    context: _SingleAcquisitionContext,
+    n_cliffords: NDArray[np.int64],
+    seeds: NDArray[np.int64],
+    sequence_seed: int | None,
+    acquisition_seed: int | None,
+) -> Result:
+    """Run one resolved single-target acquisition through the async bridge."""
+    n_pair_chunks = math.ceil(seeds.size / context.pairs_per_sweep)
+    bridge_timeout = context.sweep_timeout * n_pair_chunks + 30.0
+    bridge = get_shared_async_bridge(key="experiment")
+    return bridge.run(
+        lambda: _measure_paired_irb_async(
+            exp,
+            target,
+            context=context,
+            n_cliffords=n_cliffords,
+            seeds=seeds,
+            sequence_seed=sequence_seed,
+            acquisition_seed=acquisition_seed,
+        ),
+        timeout=bridge_timeout,
+    )
+
+
+def _validate_parallel_target_specs(
+    target_specs: Mapping[str, _TargetSpec],
+) -> bool:
+    """Validate homogeneous, physically disjoint parallel targets."""
+    target_kinds = {target_spec.is_two_qubit for target_spec in target_specs.values()}
+    if len(target_kinds) != 1:
+        raise ValueError("Parallel paired IRB cannot mix 1Q and 2Q targets.")
+    occupied_qubits: set[str] = set()
+    for target, target_spec in target_specs.items():
+        overlap = occupied_qubits.intersection(target_spec.qubits)
+        if overlap:
+            raise ValueError(
+                "Parallel paired IRB targets must not share physical qubits; "
+                f"`{target}` overlaps on {', '.join(sorted(overlap))}."
+            )
+        occupied_qubits.update(target_spec.qubits)
+    return next(iter(target_kinds))
+
+
+async def _measure_paired_irb_parallel_async(
+    exp: Experiment,
+    targets: tuple[str, ...],
+    *,
+    contexts: Mapping[str, _SingleAcquisitionContext],
+    n_cliffords: NDArray[np.int64],
+    seeds_by_target: Mapping[str, NDArray[np.int64]],
+    sequence_seeds: Mapping[str, int | None],
+    acquisition_seed: int | None,
+) -> Result:
+    """Acquire one shared point stream with independent per-target sequences."""
+    first_context = contexts[targets[0]]
+    pair_plan = _build_pair_plan(
+        n_cliffords,
+        seeds_by_target[targets[0]],
+        acquisition_seed=acquisition_seed,
+    )
+    reference_trials = {
+        target: np.full(seeds_by_target[target].shape, np.nan, dtype=np.float64)
+        for target in targets
+    }
+    interleaved_trials = {
+        target: np.full(seeds_by_target[target].shape, np.nan, dtype=np.float64)
+        for target in targets
+    }
+    chunk_records: list[dict[str, object]] = []
+    reset_qubits = {
+        qubit for context in contexts.values() for qubit in context.target_spec.qubits
+    }
+    exp.ctx.reset_awg_and_capunits(qubits=reset_qubits)
+
+    for chunk_start in range(0, len(pair_plan), first_context.pairs_per_sweep):
+        chunk = pair_plan[chunk_start : chunk_start + first_context.pairs_per_sweep]
+        points = _pair_chunk_points(chunk)
+
+        def schedule(
+            point_index: int,
+            *,
+            _points: list[tuple[_PairPlan, _Protocol]] = points,
+        ) -> PulseSchedule:
+            pair, protocol = _points[int(point_index)]
+            target_schedules = [
+                _rb_schedule_for_protocol(
+                    exp,
+                    target,
+                    contexts[target],
+                    n_cliffords=pair.n_cliffords,
+                    seed=int(
+                        seeds_by_target[target][
+                            pair.length_index,
+                            pair.trial_index,
+                        ]
+                    ),
+                    protocol=protocol,
+                )
+                for target in targets
+            ]
+            maximum_duration = max(
+                target_schedule.duration for target_schedule in target_schedules
+            )
+            with PulseSchedule() as combined:
+                for target_schedule in target_schedules:
+                    combined.call(
+                        target_schedule.padded(
+                            total_duration=maximum_duration,
+                            pad_side="left",
+                            deepcopy=False,
+                        )
+                    )
+            return combined
+
+        started_at = _iso_now()
+        sweep = await asyncio.wait_for(
+            exp.measurement_service.run_sweep_measurement(
+                schedule,
+                sweep_values=np.arange(len(points), dtype=np.int64),
+                n_shots=first_context.n_shots,
+                shot_interval=first_context.shot_interval,
+                shot_averaging=not first_context.target_spec.is_two_qubit,
+                time_integration=first_context.time_integration,
+                state_classification=False,
+                final_measurement=True,
+                plot=False,
+                enable_tqdm=False,
+            ),
+            timeout=first_context.sweep_timeout,
+        )
+        completed_at = _iso_now()
+        if len(sweep.results) != len(points):
+            raise RuntimeError(
+                "Parallel sweep result count does not match the requested paired "
+                f"points: expected {len(points)}, got {len(sweep.results)}."
+            )
+        for point_result, (pair, protocol) in zip(
+            sweep.results,
+            points,
+            strict=True,
+        ):
+            for target in targets:
+                context = contexts[target]
+                probability = _extract_survival_probability(
+                    exp,
+                    target,
+                    point_result,
+                    is_two_qubit=context.target_spec.is_two_qubit,
+                    qubits=context.target_spec.qubits,
+                    mitigate_readout=context.mitigate_readout,
+                )
+                destination = (
+                    reference_trials[target]
+                    if protocol == _PROTOCOL_REFERENCE
+                    else interleaved_trials[target]
+                )
+                destination[pair.length_index, pair.trial_index] = probability
+        chunk_records.append(
+            {
+                "pair_order_indices": tuple(
+                    range(chunk_start, chunk_start + len(chunk))
+                ),
+                "n_points": len(points),
+                "started_at": started_at,
+                "completed_at": completed_at,
+            }
+        )
+
+    result_data: dict[str, object] = {}
+    for target in targets:
+        if not np.all(np.isfinite(reference_trials[target])) or not np.all(
+            np.isfinite(interleaved_trials[target])
+        ):
+            raise RuntimeError(
+                f"Parallel paired IRB produced non-finite data for `{target}`."
+            )
+        target_seeds = seeds_by_target[target]
+        context = contexts[target]
+        result_data[target] = _raw_target_payload(
+            context=context,
+            n_cliffords=n_cliffords,
+            seeds=target_seeds,
+            sequence_seed=sequence_seeds[target],
+            acquisition_seed=acquisition_seed,
+            pair_plan=pair_plan,
+            pair_chunks=tuple(dict(record) for record in chunk_records),
+            reference_trials=reference_trials[target],
+            interleaved_trials=interleaved_trials[target],
+            batching_semantics="parallel_targets_per_measurement_point",
+            acquisition_extras={
+                "in_parallel": True,
+                "parallel_targets": targets,
+                "schedule_alignment": "left_padded_to_group_max_duration",
+            },
+        )
+    return Result(data=result_data)
+
+
+def _run_parallel_acquisition(
+    exp: Experiment,
+    targets: tuple[str, ...],
+    *,
+    contexts: Mapping[str, _SingleAcquisitionContext],
+    n_cliffords: NDArray[np.int64],
+    seeds_by_target: Mapping[str, NDArray[np.int64]],
+    sequence_seeds: Mapping[str, int | None],
+    acquisition_seed: int | None,
+) -> Result:
+    """Run one resolved parallel acquisition through the async bridge."""
+    first_context = contexts[targets[0]]
+    n_pair_chunks = math.ceil(
+        seeds_by_target[targets[0]].size / first_context.pairs_per_sweep
+    )
+    bridge_timeout = first_context.sweep_timeout * n_pair_chunks + 30.0
+    bridge = get_shared_async_bridge(key="experiment")
+    return bridge.run(
+        lambda: _measure_paired_irb_parallel_async(
+            exp,
+            targets,
+            contexts=contexts,
+            n_cliffords=n_cliffords,
+            seeds_by_target=seeds_by_target,
+            sequence_seeds=sequence_seeds,
+            acquisition_seed=acquisition_seed,
+        ),
+        timeout=bridge_timeout,
+    )
+
+
+def measure_paired_irb(
+    exp: Experiment,
+    target: str,
+    *,
+    interleaved_clifford: str | Clifford,
+    interleaved_waveform: Waveform | PulseSchedule | None = None,
+    n_cliffords_range: ArrayLike | None = None,
+    n_trials: int | None = None,
+    seeds: ArrayLike | None = None,
+    sequence_seed: int | None = None,
+    acquisition_seed: int | None = _DEFAULT_ACQUISITION_SEED,
+    pairs_per_sweep: int = _DEFAULT_PAIRS_PER_SWEEP,
+    max_n_cliffords: int | None = None,
+    x90: Waveform | TargetMap[Waveform] | None = None,
+    zx90: PulseSchedule | None = None,
+    mitigate_readout: bool = True,
+    n_shots: int | None = None,
+    shot_interval: float | None = None,
+    time_integration: bool = True,
+    sweep_timeout: float = _DEFAULT_SWEEP_TIMEOUT_SECONDS,
+) -> Result:
+    """
+    Acquire raw reference/interleaved trials in randomized adjacent pairs.
+
+    Parameters
+    ----------
+    exp : Experiment
+        Configured Qubex experiment.
+    target : str
+        One 1Q or CR target label. This low-level primitive is single-target.
+    interleaved_clifford : str | Clifford
+        Clifford inserted after every random Clifford in the interleaved arm.
+    interleaved_waveform : Waveform | PulseSchedule | None, optional
+        Physical implementation of the interleaved gate. A 1Q target accepts a
+        `Waveform` or a target-containing `PulseSchedule`; a 2Q target requires
+        a `PulseSchedule`. Required when the existing RB sequence builder
+        cannot infer it from `interleaved_clifford`.
+    n_cliffords_range : ArrayLike | None, optional
+        Fixed, strictly increasing Clifford lengths. At least four are required.
+        Four or five points produce an analysis warning because the decay fit
+        has little residual freedom. Mutually exclusive with `max_n_cliffords`.
+        When omitted, use zero and powers of two through the target-specific
+        maximum.
+    n_trials : int | None, optional
+        Paired sequence trials per length. Must be at least 2 and defaults to
+        30.
+    seeds : ArrayLike | None, optional
+        Explicit uint32 seed matrix with shape `(n_lengths, n_trials)`. Every
+        cell must contain a distinct seed.
+    sequence_seed : int | None, optional
+        Master seed used to generate the seed matrix. Mutually exclusive with
+        `seeds`. Defaults to `None`, which generates a fresh matrix.
+    acquisition_seed : int | None, optional
+        Seed for global pair order and balanced AB/BA order. Defaults to `None`,
+        which draws a fresh randomized order for each acquisition.
+    pairs_per_sweep : int, optional
+        Number of complete adjacent pairs submitted in each measurement call.
+        The backend controls physical batching within that call. Defaults to 1.
+    max_n_cliffords : int | None, optional
+        Upper bound for power-of-two lengths in the default grid. Mutually
+        exclusive with `n_cliffords_range`. Defaults to the target-specific
+        experiment constant.
+    x90 : Waveform | TargetMap[Waveform] | None, optional
+        Optional pi/2 pulse override used by the RB sequence builder. Use a
+        `Waveform` or one-target mapping for 1Q and a two-qubit mapping for 2Q.
+    zx90 : PulseSchedule | None, optional
+        Optional ZX90 schedule override for a CR target. Ignored for 1Q.
+    mitigate_readout : bool, optional
+        Apply fixed-classifier readout mitigation to 2Q `P(00)`. Ignored for 1Q.
+        Defaults to `True`.
+    n_shots : int | None, optional
+        Shots per sweep point. Defaults to the experiment constant.
+    shot_interval : float | None, optional
+        Shot interval in ns. Defaults to the experiment constant.
+    time_integration : bool, optional
+        Integrate readout data over time. Defaults to `True`.
+    sweep_timeout : float, optional
+        Timeout in seconds for each pair-preserving sweep chunk. Defaults to
+        300 seconds.
+
+    Returns
+    -------
+    Result
+        Raw paired trials, seed matrix, planned acquisition order, and chunk
+        timestamps. Call `analyze_paired_irb` to fit without remeasurement.
+
+    Raises
+    ------
+    TypeError
+        Raised when an argument has an incompatible type.
+    ValueError
+        Raised when the target, Clifford, length grid, seeds, or measurement
+        options are invalid.
+    TimeoutError
+        Raised when a pair-preserving sweep chunk exceeds `sweep_timeout`.
+    RuntimeError
+        Raised when the measurement backend returns incomplete or invalid data.
+
+    Notes
+    -----
+    This function performs hardware acquisition and resets the AWG and capture
+    units for the resolved qubits once before the first sweep chunk.
+
+    The backend may batch or schedule-pack points according to its capabilities.
+    Qubex therefore records honest chunk timestamps, not unavailable per-point
+    hardware timestamps. Increasing `pairs_per_sweep` reduces service-call
+    overhead while preserving adjacent reference/interleaved points inside
+    every pair.
+
+    The default `pairs_per_sweep=1` is deliberately conservative until both 1Q
+    and 2Q hardware paths have been benchmarked. Larger values reduce service
+    calls but may lengthen the time separating pairs within a sweep chunk.
+
+    The returned target payload contains `reference["trials"]` and
+    `interleaved["trials"]` matrices with shape `(n_lengths, n_trials)`, plus
+    `acquisition` and schema-versioned `metadata` mappings needed for later
+    analysis.
+    """
+    context = _resolve_target_acquisition(
+        exp,
+        target,
+        interleaved_clifford=interleaved_clifford,
+        interleaved_waveform=interleaved_waveform,
+        pairs_per_sweep=pairs_per_sweep,
+        x90=x90,
+        zx90=zx90,
+        mitigate_readout=mitigate_readout,
+        n_shots=DEFAULT_SHOTS if n_shots is None else n_shots,
+        shot_interval=DEFAULT_INTERVAL if shot_interval is None else shot_interval,
+        time_integration=time_integration,
+        sweep_timeout=sweep_timeout,
+    )
+    resolved_trials = _resolve_paired_n_trials(n_trials)
+    _validate_range_choice(n_cliffords_range, max_n_cliffords)
+    resolved_maximum = _resolve_target_maximum(
+        context.target_spec,
+        max_n_cliffords,
+    )
+    n_cliffords = _resolve_n_cliffords(
+        n_cliffords_range,
+        maximum=resolved_maximum,
+    )
+    resolved_sequence_seed = _validate_optional_rng_seed(
+        sequence_seed,
+        name="sequence_seed",
+    )
+    seed_matrix = _resolve_seed_matrix(
+        seeds,
+        shape=(len(n_cliffords), resolved_trials),
+        sequence_seed=resolved_sequence_seed,
+    )
+    resolved_acquisition_seed = _validate_optional_rng_seed(
+        acquisition_seed,
+        name="acquisition_seed",
+    )
+    return _run_single_target_acquisition(
+        exp,
+        target,
+        context=context,
+        n_cliffords=n_cliffords,
+        seeds=seed_matrix,
+        sequence_seed=resolved_sequence_seed,
+        acquisition_seed=resolved_acquisition_seed,
+    )
+
+
+def _trial_moments(trials: NDArray[np.float64]) -> _TrialMoments:
+    """Calculate mean, sample SD, and SEM for each Clifford length."""
+    mean = np.mean(trials, axis=1)
+    std = np.std(trials, axis=1, ddof=1)
+    # NumPy's two-pass variance can leave round-off residue for a row whose
+    # values are exactly identical. Preserve the statistical zero explicitly.
+    constant_rows = np.all(trials == trials[:, :1], axis=1)
+    std = np.where(constant_rows, 0.0, std)
+    sem = std / math.sqrt(trials.shape[1])
+    return _TrialMoments(mean=mean, std=std, sem=sem)
+
+
+def _resolve_sem_floor(
+    reference_sem: NDArray[np.float64],
+    interleaved_sem: NDArray[np.float64],
+    requested_floor: float | None,
+) -> float:
+    """Resolve one common empirical or user-specified SEM floor for both arms."""
+    if requested_floor is not None:
+        return requested_floor
+    combined = np.concatenate((reference_sem, interleaved_sem))
+    positive = combined[combined > 0.0]
+    if len(positive) == 0:
+        # With no empirical scatter, equal finite weights are preferable to
+        # machine-epsilon weights. The absolute scale affects covariance only;
+        # the weighted point estimate is unchanged when every weight is equal.
+        return _ALL_ZERO_SEM_FLOOR
+    empirical_floor = float(_EMPIRICAL_SEM_FLOOR_FRACTION * np.median(positive))
+    return empirical_floor if empirical_floor > 0.0 else _ALL_ZERO_SEM_FLOOR
+
+
+def _regularize_trial_moments(
+    moments: _TrialMoments,
+    *,
+    sem_floor: float,
+) -> _TrialStatistics:
+    """Apply a resolved SEM floor to one arm's raw trial moments."""
+    sem_used = np.maximum(moments.sem, sem_floor)
+    return _TrialStatistics(
+        mean=moments.mean,
+        std=moments.std,
+        sem=moments.sem,
+        sem_used=sem_used,
+        sem_floor_count=int(np.count_nonzero(moments.sem < sem_floor)),
+    )
+
+
+def _paired_trial_statistics(
+    reference_trials: NDArray[np.float64],
+    interleaved_trials: NDArray[np.float64],
+    *,
+    sem_floor: float | None,
+) -> _PairedStatistics:
+    """Calculate paired statistics using a common resolved SEM floor."""
+    reference_moments = _trial_moments(reference_trials)
+    interleaved_moments = _trial_moments(interleaved_trials)
+    resolved_floor = _resolve_sem_floor(
+        reference_moments.sem,
+        interleaved_moments.sem,
+        sem_floor,
+    )
+    combined_sem = np.concatenate((reference_moments.sem, interleaved_moments.sem))
+    # An automatic floor is estimated from the positive SEM values themselves.
+    # A fixed floor supplies no empirical covariance scale when it replaces all
+    # observed SEM values, even if those values are nonzero.
+    fit_covariance_scale_empirical = bool(
+        np.any(combined_sem > 0.0)
+        if sem_floor is None
+        else np.any(combined_sem >= resolved_floor)
+    )
+    return _PairedStatistics(
+        reference=_regularize_trial_moments(
+            reference_moments,
+            sem_floor=resolved_floor,
+        ),
+        interleaved=_regularize_trial_moments(
+            interleaved_moments,
+            sem_floor=resolved_floor,
+        ),
+        sem_floor=resolved_floor,
+        fit_covariance_scale_empirical=fit_covariance_scale_empirical,
+    )
+
+
+def _initial_fit_parameters(mean: NDArray[np.float64]) -> tuple[float, float, float]:
+    """Return an interior starting point for bounded RB fitting."""
+    epsilon = 1e-6
+    offset = float(np.clip(np.min(mean), epsilon, 1.0 - epsilon))
+    amplitude = float(np.clip(mean[0] - offset, epsilon, 1.0 - epsilon))
+    return amplitude, 0.98, offset
+
+
+def _fit_rb_decay(
+    n_cliffords: NDArray[np.int64],
+    mean: NDArray[np.float64],
+    sem_used: NDArray[np.float64],
+) -> _DecayFitResult:
+    """Fit `A * p**m + C` with absolute SEM weights and no plotting."""
+    if not (
+        np.all(np.isfinite(mean))
+        and np.all(np.isfinite(sem_used))
+        and np.all(sem_used > 0)
+    ):
+        raise ValueError(
+            "RB fit inputs must be finite and SEM weights must be positive."
+        )
+    with warnings.catch_warnings(record=True) as fit_warnings:
+        warnings.simplefilter("always", OptimizeWarning)
+        parameters, covariance = curve_fit(
+            _rb_decay,
+            n_cliffords.astype(np.float64),
+            mean,
+            p0=_initial_fit_parameters(mean),
+            sigma=sem_used,
+            absolute_sigma=True,
+            bounds=((0.0, 0.0, 0.0), (1.0, 1.0, 1.0)),
+            maxfev=20_000,
+        )
+    parameters = np.asarray(parameters, dtype=np.float64)
+    raw_covariance = np.asarray(covariance, dtype=np.float64)
+    if not np.all(np.isfinite(parameters)):
+        raise RuntimeError("RB fit returned non-finite parameters.")
+    covariance_valid = bool(
+        raw_covariance.shape == (3, 3)
+        and np.all(np.isfinite(raw_covariance))
+        and np.all(np.diag(raw_covariance) >= 0)
+        and not any(
+            isinstance(warning.message, OptimizeWarning) for warning in fit_warnings
+        )
+    )
+    covariance = raw_covariance if covariance_valid else None
+    standard_errors = np.sqrt(np.diag(raw_covariance)) if covariance_valid else None
+    predicted = _rb_decay(n_cliffords.astype(np.float64), *parameters)
+    residuals = mean - predicted
+    weighted_residuals = residuals / sem_used
+    chi_square = float(np.sum(weighted_residuals**2))
+    degrees_of_freedom = len(n_cliffords) - len(parameters)
+    reduced_chi_square = (
+        chi_square / degrees_of_freedom if degrees_of_freedom > 0 else None
+    )
+    centered_sum_squares = float(np.sum((mean - np.mean(mean)) ** 2))
+    r_squared = (
+        1.0 - float(np.sum(residuals**2)) / centered_sum_squares
+        if centered_sum_squares > 0
+        else None
+    )
+    names = ("A", "p", "C")
+    at_bound = tuple(
+        name
+        for name, value in zip(names, parameters, strict=True)
+        if np.isclose(value, 0.0, atol=1e-6, rtol=0.0)
+        or np.isclose(value, 1.0, atol=1e-6, rtol=0.0)
+    )
+    return _DecayFitResult(
+        amplitude=float(parameters[0]),
+        decay_parameter=float(parameters[1]),
+        offset=float(parameters[2]),
+        covariance=covariance,
+        standard_errors=standard_errors,
+        predicted=predicted,
+        residuals=residuals,
+        weighted_residuals=weighted_residuals,
+        chi_square=chi_square,
+        reduced_chi_square=reduced_chi_square,
+        r_squared=r_squared,
+        parameters_at_bound=at_bound,
+    )
+
+
+def _fit_pilot_decay(
+    n_cliffords: NDArray[np.int64],
+    mean: NDArray[np.float64],
+    *,
+    dimension: int,
+) -> _PilotDecayFitResult:
+    """Fit a coarse pilot decay with the asymptote fixed to `1 / dimension`."""
+    if dimension not in (2, 4):
+        raise ValueError("Pilot RB dimension must be 2 or 4.")
+    if n_cliffords.ndim != 1 or mean.shape != n_cliffords.shape:
+        raise ValueError("Pilot RB lengths and means must be matching 1D arrays.")
+    if not np.all(np.isfinite(mean)):
+        raise ValueError("Pilot RB means must be finite.")
+
+    offset = 1.0 / dimension
+    maximum_amplitude = 1.0 - offset
+    epsilon = 1e-6
+    initial_amplitude = float(
+        np.clip(mean[0] - offset, epsilon, maximum_amplitude - epsilon)
+    )
+
+    def fixed_offset_decay(
+        lengths: NDArray[np.float64],
+        amplitude: float,
+        decay_parameter: float,
+    ) -> NDArray[np.float64]:
+        return _rb_decay(lengths, amplitude, decay_parameter, offset)
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", OptimizeWarning)
+        parameters, _ = curve_fit(
+            fixed_offset_decay,
+            n_cliffords.astype(np.float64),
+            mean,
+            p0=(initial_amplitude, 0.98),
+            bounds=((0.0, 0.0), (maximum_amplitude, 1.0)),
+            maxfev=20_000,
+        )
+    parameters = np.asarray(parameters, dtype=np.float64)
+    if not np.all(np.isfinite(parameters)):
+        raise RuntimeError("Pilot RB fit returned non-finite parameters.")
+    predicted = fixed_offset_decay(
+        n_cliffords.astype(np.float64),
+        float(parameters[0]),
+        float(parameters[1]),
+    )
+    residuals = mean - predicted
+    centered_sum_squares = float(np.sum((mean - np.mean(mean)) ** 2))
+    r_squared = (
+        1.0 - float(np.sum(residuals**2)) / centered_sum_squares
+        if centered_sum_squares > np.finfo(np.float64).eps
+        else None
+    )
+    at_bound = tuple(
+        name
+        for name, value, upper in zip(
+            ("A", "p"),
+            parameters,
+            (maximum_amplitude, 1.0),
+            strict=True,
+        )
+        if np.isclose(value, 0.0, atol=_PILOT_BOUND_ATOL, rtol=0.0)
+        or np.isclose(value, upper, atol=_PILOT_BOUND_ATOL, rtol=0.0)
+    )
+    return _PilotDecayFitResult(
+        amplitude=float(parameters[0]),
+        decay_parameter=float(parameters[1]),
+        offset=offset,
+        predicted=predicted,
+        residuals=residuals,
+        r_squared=r_squared,
+        parameters_at_bound=at_bound,
+    )
+
+
+def _observed_decay_significance(
+    mean: NDArray[np.float64],
+    sem: NDArray[np.float64],
+) -> float:
+    """Return endpoint decay divided by its independent-SEM uncertainty."""
+    if mean.ndim != 1 or sem.shape != mean.shape or len(mean) < 2:
+        raise ValueError("Pilot means and SEM values must be matching 1D arrays.")
+    if not (np.all(np.isfinite(mean)) and np.all(np.isfinite(sem))):
+        raise ValueError("Pilot means and SEM values must be finite.")
+    uncertainty = float(math.hypot(sem[0], sem[-1]))
+    observed_decay = float(mean[0] - mean[-1])
+    if uncertainty > 0.0:
+        return observed_decay / uncertainty
+    if observed_decay > 0.0:
+        return math.inf
+    if observed_decay < 0.0:
+        return -math.inf
+    return 0.0
+
+
+def _pilot_fit_payload(fit: _PilotDecayFitResult) -> dict[str, object]:
+    """Convert one fixed-offset pilot fit into an auditable payload."""
+    return {
+        "model": "A * p**m + 1/d",
+        "A": fit.amplitude,
+        "p": fit.decay_parameter,
+        "C": fit.offset,
+        "predicted": fit.predicted,
+        "residuals": fit.residuals,
+        "r_squared": fit.r_squared,
+        "parameters_at_bound": fit.parameters_at_bound,
+        "amplitude_lower_bound_hit": fit.amplitude_lower_bound_hit,
+        "amplitude_upper_bound_hit": fit.amplitude_upper_bound_hit,
+        "weighting": "unweighted",
+    }
+
+
+def _pilot_model_payload(
+    *,
+    dimension: int,
+    unmitigated_two_qubit_readout: bool,
+) -> dict[str, object]:
+    """Describe the pilot-only fixed-offset approximation and its caveat."""
+    caveat = (
+        "Asymmetric assignment errors can shift the observed unmitigated 2Q "
+        "asymptote away from 1/d."
+        if unmitigated_two_qubit_readout
+        else None
+    )
+    return {
+        "model": "A * p**m + 1/d",
+        "fixed_offset": 1.0 / dimension,
+        "purpose": "range_selection_only",
+        "used_for_main_fit": False,
+        "unmitigated_2q_readout_caveat": caveat,
+    }
+
+
+def _fit_payload(fit: _DecayFitResult) -> dict[str, object]:
+    """Convert a private fit value into a stable result payload."""
+    standard_errors = fit.standard_errors
+    return {
+        "model": "A * p**m + C",
+        "A": fit.amplitude,
+        "p": fit.decay_parameter,
+        "C": fit.offset,
+        "covariance": fit.covariance,
+        "standard_errors": standard_errors,
+        "A_err": float(standard_errors[0]) if standard_errors is not None else None,
+        "p_err": float(standard_errors[1]) if standard_errors is not None else None,
+        "C_err": float(standard_errors[2]) if standard_errors is not None else None,
+        "predicted": fit.predicted,
+        "residuals": fit.residuals,
+        "weighted_residuals": fit.weighted_residuals,
+        "chi_square": fit.chi_square,
+        "reduced_chi_square": fit.reduced_chi_square,
+        "r_squared": fit.r_squared,
+        "parameters_at_bound": fit.parameters_at_bound,
+        "covariance_valid": fit.covariance_valid,
+        "absolute_sigma": True,
+    }
+
+
+def _curve_payload(
+    trials: NDArray[np.float64],
+    statistics: _TrialStatistics,
+    fit: _DecayFitResult,
+) -> dict[str, object]:
+    """Build one reference or interleaved analysis payload."""
+    return {
+        "trials": trials,
+        "mean": statistics.mean,
+        "std": statistics.std,
+        "sem": statistics.sem,
+        "sem_used": statistics.sem_used,
+        "fit": _fit_payload(fit),
+    }
+
+
+def _gate_fidelity(
+    p_reference: float,
+    p_interleaved: float,
+    *,
+    dimension: int,
+) -> float:
+    """Calculate standard IRB gate fidelity without physical-range clipping."""
+    if not np.isfinite(p_reference) or not np.isfinite(p_interleaved):
+        raise ValueError("Decay parameters must be finite.")
+    if p_reference == 0.0:
+        raise ValueError("Reference decay parameter is zero.")
+    factor = (dimension - 1.0) / dimension
+    return float(1.0 - factor * (1.0 - p_interleaved / p_reference))
+
+
+def _stratified_paired_resample_indices(
+    first_protocols: NDArray[np.str_],
+    *,
+    rng: np.random.Generator,
+) -> NDArray[np.int64]:
+    """Sample paired trial indices within each length and AB/BA stratum."""
+    if first_protocols.ndim != 2:
+        raise ValueError("Bootstrap protocol strata must be two-dimensional.")
+    indices = np.empty(first_protocols.shape, dtype=np.int64)
+    for length_index, protocol_row in enumerate(first_protocols):
+        for protocol in (_PROTOCOL_REFERENCE, _PROTOCOL_INTERLEAVED):
+            stratum_indices = np.flatnonzero(protocol_row == protocol)
+            if len(stratum_indices) == 0:
+                raise ValueError(
+                    "Each Clifford length must contain both AB/BA bootstrap strata."
+                )
+            indices[length_index, stratum_indices] = rng.choice(
+                stratum_indices,
+                size=len(stratum_indices),
+                replace=True,
+            )
+    return indices
+
+
+def _bootstrap_stratum_counts(
+    first_protocols: NDArray[np.str_],
+) -> tuple[dict[str, int], ...]:
+    """Return the retained reference-first and interleaved-first counts."""
+    return tuple(
+        {
+            "reference_first": int(
+                np.count_nonzero(protocol_row == _PROTOCOL_REFERENCE)
+            ),
+            "interleaved_first": int(
+                np.count_nonzero(protocol_row == _PROTOCOL_INTERLEAVED)
+            ),
+        }
+        for protocol_row in first_protocols
+    )
+
+
+def _bootstrap_analysis(
+    n_cliffords: NDArray[np.int64],
+    reference_trials: NDArray[np.float64],
+    interleaved_trials: NDArray[np.float64],
+    first_protocols: NDArray[np.str_],
+    *,
+    dimension: int,
+    n_bootstrap: int,
+    bootstrap_seed: int | None,
+    sem_floor: float | None,
+) -> _BootstrapResult:
+    """Repeat the paired statistics, fit, and fidelity chain within AB/BA strata."""
+    stratum_counts = _bootstrap_stratum_counts(first_protocols)
+    resampling_valid = all(
+        counts["reference_first"] >= _MIN_BOOTSTRAP_SAMPLES_PER_STRATUM
+        and counts["interleaved_first"] >= _MIN_BOOTSTRAP_SAMPLES_PER_STRATUM
+        for counts in stratum_counts
+    )
+    if n_bootstrap == 0 or not resampling_valid:
+        empty = np.asarray([], dtype=np.float64)
+        return _BootstrapResult(
+            seed=bootstrap_seed,
+            n_requested=n_bootstrap,
+            fidelities=empty,
+            p_reference=empty.copy(),
+            p_interleaved=empty.copy(),
+            p_correlation=None,
+            stratum_counts=stratum_counts,
+            reference_any_bound_count=0,
+            interleaved_any_bound_count=0,
+            reference_p_bound_count=0,
+            interleaved_p_bound_count=0,
+        )
+
+    rng = np.random.default_rng(bootstrap_seed)
+    fidelities: list[float] = []
+    p_reference_samples: list[float] = []
+    p_interleaved_samples: list[float] = []
+    reference_any_bound_count = 0
+    interleaved_any_bound_count = 0
+    reference_p_bound_count = 0
+    interleaved_p_bound_count = 0
+    for _ in range(n_bootstrap):
+        indices = _stratified_paired_resample_indices(
+            first_protocols,
+            rng=rng,
+        )
+        row_indices = np.arange(len(n_cliffords))[:, None]
+        reference_sample = reference_trials[row_indices, indices]
+        interleaved_sample = interleaved_trials[row_indices, indices]
+        try:
+            statistics = _paired_trial_statistics(
+                reference_sample,
+                interleaved_sample,
+                sem_floor=sem_floor,
+            )
+            reference_fit = _fit_rb_decay(
+                n_cliffords,
+                statistics.reference.mean,
+                statistics.reference.sem_used,
+            )
+            interleaved_fit = _fit_rb_decay(
+                n_cliffords,
+                statistics.interleaved.mean,
+                statistics.interleaved.sem_used,
+            )
+            fidelity = _gate_fidelity(
+                reference_fit.decay_parameter,
+                interleaved_fit.decay_parameter,
+                dimension=dimension,
+            )
+        except (
+            FloatingPointError,
+            RuntimeError,
+            ValueError,
+            np.linalg.LinAlgError,
+        ):
+            continue
+        if not np.isfinite(fidelity):
+            continue
+        fidelities.append(fidelity)
+        p_reference_samples.append(reference_fit.decay_parameter)
+        p_interleaved_samples.append(interleaved_fit.decay_parameter)
+        reference_any_bound_count += int(bool(reference_fit.parameters_at_bound))
+        interleaved_any_bound_count += int(bool(interleaved_fit.parameters_at_bound))
+        reference_p_bound_count += int("p" in reference_fit.parameters_at_bound)
+        interleaved_p_bound_count += int("p" in interleaved_fit.parameters_at_bound)
+
+    fidelity_array = np.asarray(fidelities, dtype=np.float64)
+    p_reference_array = np.asarray(p_reference_samples, dtype=np.float64)
+    p_interleaved_array = np.asarray(p_interleaved_samples, dtype=np.float64)
+    n_success = len(fidelity_array)
+    correlation: float | None = None
+    if (
+        n_success >= 2
+        and np.std(p_reference_array) > 0
+        and np.std(p_interleaved_array) > 0
+    ):
+        candidate = float(np.corrcoef(p_reference_array, p_interleaved_array)[0, 1])
+        if np.isfinite(candidate):
+            correlation = candidate
+    return _BootstrapResult(
+        seed=bootstrap_seed,
+        n_requested=n_bootstrap,
+        fidelities=fidelity_array,
+        p_reference=p_reference_array,
+        p_interleaved=p_interleaved_array,
+        p_correlation=correlation,
+        stratum_counts=stratum_counts,
+        reference_any_bound_count=reference_any_bound_count,
+        interleaved_any_bound_count=interleaved_any_bound_count,
+        reference_p_bound_count=reference_p_bound_count,
+        interleaved_p_bound_count=interleaved_p_bound_count,
+    )
+
+
+def _mapping(value: object, *, name: str) -> Mapping[str, object]:
+    """Narrow a result payload node to a string-keyed mapping."""
+    if not isinstance(value, Mapping):
+        raise TypeError(f"`{name}` must be a mapping.")
+    return cast(Mapping[str, object], value)
+
+
+def _validated_dimension(metadata: Mapping[str, object]) -> int:
+    """Return a valid dimension consistent with optional target-kind metadata."""
+    try:
+        dimension = _validate_positive_integer(
+            metadata["dimension"],
+            name="metadata.dimension",
+        )
+    except (KeyError, TypeError, ValueError):
+        raise ValueError(
+            "Raw paired IRB metadata must contain a valid dimension."
+        ) from None
+    if dimension not in (2, 4):
+        raise ValueError("Paired IRB dimension must be 2 or 4.")
+    if "is_two_qubit" not in metadata:
+        return dimension
+    try:
+        is_two_qubit = _validate_boolean(
+            metadata["is_two_qubit"],
+            name="metadata.is_two_qubit",
+        )
+    except TypeError:
+        raise ValueError(
+            "Raw paired IRB metadata must contain a valid is_two_qubit flag."
+        ) from None
+    expected_dimension = 4 if is_two_qubit else 2
+    if dimension != expected_dimension:
+        raise ValueError(
+            "`metadata.dimension` is inconsistent with `metadata.is_two_qubit`."
+        )
+    return dimension
+
+
+def _validated_trial_matrices(
+    reference: Mapping[str, object],
+    interleaved: Mapping[str, object],
+) -> tuple[NDArray[np.float64], NDArray[np.float64], tuple[int, int]]:
+    """Return finite, shape-compatible paired trial matrices."""
+    reference_trials = np.asarray(reference.get("trials"), dtype=np.float64)
+    interleaved_trials = np.asarray(interleaved.get("trials"), dtype=np.float64)
+    if reference_trials.ndim != 2 or interleaved_trials.ndim != 2:
+        raise ValueError("Reference and interleaved trials must be two-dimensional.")
+    if reference_trials.shape != interleaved_trials.shape:
+        raise ValueError("Reference and interleaved trials must have the same shape.")
+    if reference_trials.shape[1] < 2:
+        raise ValueError("Paired IRB analysis requires at least two trials.")
+    if not np.all(np.isfinite(reference_trials)) or not np.all(
+        np.isfinite(interleaved_trials)
+    ):
+        raise ValueError("Raw paired trials must be finite.")
+    shape = (reference_trials.shape[0], reference_trials.shape[1])
+    return reference_trials, interleaved_trials, shape
+
+
+def _validated_first_protocols(
+    acquisition: Mapping[str, object],
+    *,
+    shape: tuple[int, int],
+) -> NDArray[np.str_]:
+    """Reconstruct and validate per-cell AB/BA strata from the acquisition plan."""
+    raw_plan = acquisition.get("planned_order")
+    if isinstance(raw_plan, (str, bytes)) or not isinstance(raw_plan, Sequence):
+        raise TypeError("Acquisition `planned_order` must be a sequence.")
+    if len(raw_plan) != int(np.prod(shape)):
+        raise ValueError(
+            "Acquisition `planned_order` must contain one entry per trial cell."
+        )
+    first_protocols = np.full(shape, "", dtype="<U11")
+    for pair_order_index, raw_pair in enumerate(raw_plan):
+        pair = _mapping(
+            raw_pair,
+            name=f"acquisition.planned_order[{pair_order_index}]",
+        )
+        length_index = _validate_nonnegative_integer(
+            pair.get("length_index"),
+            name=f"planned_order[{pair_order_index}].length_index",
+        )
+        trial_index = _validate_nonnegative_integer(
+            pair.get("trial_index"),
+            name=f"planned_order[{pair_order_index}].trial_index",
+        )
+        if length_index >= shape[0] or trial_index >= shape[1]:
+            raise ValueError("Acquisition `planned_order` contains an invalid cell.")
+        if first_protocols[length_index, trial_index]:
+            raise ValueError("Acquisition `planned_order` contains a duplicate cell.")
+        first_protocol = pair.get("first_protocol")
+        if not isinstance(first_protocol, str) or first_protocol not in (
+            _PROTOCOL_REFERENCE,
+            _PROTOCOL_INTERLEAVED,
+        ):
+            raise ValueError(
+                "Each acquisition-plan entry must have a valid `first_protocol`."
+            )
+        first_protocols[length_index, trial_index] = cast(str, first_protocol)
+    for row in first_protocols:
+        n_reference_first = int(np.count_nonzero(row == _PROTOCOL_REFERENCE))
+        n_interleaved_first = int(np.count_nonzero(row == _PROTOCOL_INTERLEAVED))
+        if abs(n_reference_first - n_interleaved_first) > 1:
+            raise ValueError(
+                "Acquisition `planned_order` must balance AB/BA within each length."
+            )
+    return first_protocols
+
+
+def _extract_raw_payload(
+    raw_result: Result | Mapping[str, object],
+) -> tuple[str, Mapping[str, object]]:
+    """Return the sole target and its raw acquisition payload."""
+    data: Mapping[str, object]
+    if isinstance(raw_result, Result):
+        data = raw_result.data
+    elif isinstance(raw_result, Mapping):
+        data = raw_result
+    else:
+        raise TypeError("`raw_result` must be a Result or mapping.")
+    if len(data) != 1:
+        raise ValueError("Paired IRB analysis requires exactly one target entry.")
+    target = next(iter(data))
+    if not isinstance(target, str):
+        raise TypeError("The paired IRB target key must be a string.")
+    return target, _mapping(data[target], name=f"raw_result[{target!r}]")
+
+
+def _validated_raw_data(
+    target_payload: Mapping[str, object],
+) -> _RawIRBData:
+    """Read and validate paired matrices plus acquisition metadata."""
+    reference = _mapping(target_payload.get("reference"), name="reference")
+    interleaved = _mapping(target_payload.get("interleaved"), name="interleaved")
+    acquisition = _mapping(target_payload.get("acquisition"), name="acquisition")
+    metadata = _mapping(target_payload.get("metadata"), name="metadata")
+    schema_version = metadata.get("schema_version")
+    if (
+        isinstance(schema_version, (bool, np.bool_))
+        or not isinstance(schema_version, (int, np.integer))
+        or int(schema_version) != _RAW_SCHEMA_VERSION
+    ):
+        raise ValueError(
+            "Unsupported paired IRB schema_version "
+            f"{schema_version!r}; expected {_RAW_SCHEMA_VERSION}."
+        )
+    dimension = _validated_dimension(metadata)
+    reference_trials, interleaved_trials, trial_shape = _validated_trial_matrices(
+        reference,
+        interleaved,
+    )
+    raw_n_cliffords = acquisition.get("n_cliffords")
+    if raw_n_cliffords is None:
+        raise ValueError("Acquisition metadata must contain `n_cliffords`.")
+    n_cliffords = _resolve_n_cliffords(
+        cast(ArrayLike, raw_n_cliffords),
+        maximum=DEFAULT_MAX_N_CLIFFORDS_1Q,
+    )
+    if len(n_cliffords) != reference_trials.shape[0]:
+        raise ValueError(
+            "The number of Clifford lengths must match the trial-matrix rows."
+        )
+    raw_seeds = acquisition.get("seeds")
+    if raw_seeds is None:
+        raise ValueError("Acquisition metadata must contain `seeds`.")
+    _resolve_seed_matrix(
+        cast(ArrayLike, raw_seeds),
+        shape=trial_shape,
+        sequence_seed=None,
+    )
+    raw_n_trials = acquisition.get("n_trials")
+    if raw_n_trials is not None:
+        resolved_n_trials = _validate_positive_integer(
+            raw_n_trials,
+            name="acquisition.n_trials",
+        )
+        if resolved_n_trials != reference_trials.shape[1]:
+            raise ValueError(
+                "Acquisition `n_trials` must match the trial-matrix columns."
+            )
+    first_protocols = _validated_first_protocols(
+        acquisition,
+        shape=trial_shape,
+    )
+    return _RawIRBData(
+        n_cliffords=n_cliffords,
+        reference_trials=reference_trials,
+        interleaved_trials=interleaved_trials,
+        first_protocols=first_protocols,
+        dimension=dimension,
+        acquisition=acquisition,
+        metadata=metadata,
+    )
+
+
+def _bootstrap_warning_messages(bootstrap: _BootstrapResult) -> list[str]:
+    """Return bootstrap design, optimizer, and bound-hit diagnostics."""
+    messages: list[str] = []
+    if bootstrap.n_requested > 0:
+        if not bootstrap.resampling_valid:
+            messages.append(
+                "Primary paired-bootstrap uncertainty is unavailable because at "
+                "least two samples per AB/BA stratum are required at every "
+                "Clifford length. Bootstrap fitting was skipped."
+            )
+        elif bootstrap.n_success < 2:
+            messages.append(
+                "Fewer than two paired bootstrap replicates produced valid fits; "
+                "uncertainty intervals are unavailable."
+            )
+        elif not bootstrap.optimizer_valid:
+            messages.append(
+                f"Fewer than {_MIN_BOOTSTRAP_SUCCESS_RATE:.0%} of paired bootstrap "
+                "replicates produced valid fits; "
+                "bootstrap spread summaries are diagnostic only and primary "
+                "uncertainty is unavailable."
+            )
+    for protocol, any_fraction, p_fraction in (
+        (
+            _PROTOCOL_REFERENCE,
+            bootstrap.reference_any_bound_fraction,
+            bootstrap.reference_p_bound_fraction,
+        ),
+        (
+            _PROTOCOL_INTERLEAVED,
+            bootstrap.interleaved_any_bound_fraction,
+            bootstrap.interleaved_p_bound_fraction,
+        ),
+    ):
+        if (
+            any_fraction is not None
+            and p_fraction is not None
+            and (
+                any_fraction > _MAX_BOOTSTRAP_ANY_BOUND_FRACTION
+                or p_fraction > _MAX_BOOTSTRAP_P_BOUND_FRACTION
+            )
+        ):
+            messages.append(
+                f"The {protocol} bootstrap fit has excessive parameter-bound "
+                f"hits (any={any_fraction:.1%}, p={p_fraction:.1%}); bootstrap "
+                "fit quality is unreliable."
+            )
+    return messages
+
+
+def _curve_fit_warning_messages(
+    reference_fit: _DecayFitResult,
+    interleaved_fit: _DecayFitResult,
+) -> list[str]:
+    """Return bound, covariance, and goodness-of-fit warnings for both arms."""
+    messages: list[str] = []
+    for protocol, fit in (
+        (_PROTOCOL_REFERENCE, reference_fit),
+        (_PROTOCOL_INTERLEAVED, interleaved_fit),
+    ):
+        if fit.parameters_at_bound:
+            messages.append(
+                f"The {protocol} fit has parameters at a bound: "
+                f"{', '.join(fit.parameters_at_bound)}."
+            )
+        if not fit.covariance_valid:
+            messages.append(f"The {protocol} fit covariance is unavailable.")
+        if fit.reduced_chi_square is not None and fit.reduced_chi_square > 5.0:
+            messages.append(
+                f"The {protocol} reduced chi-square is {fit.reduced_chi_square:.3g}."
+            )
+    return messages
+
+
+def _analysis_warnings(
+    *,
+    n_trials: int,
+    n_clifford_points: int,
+    reference_statistics: _TrialStatistics,
+    interleaved_statistics: _TrialStatistics,
+    fit_covariance_scale_empirical: bool,
+    reference_fit: _DecayFitResult,
+    interleaved_fit: _DecayFitResult,
+    gate_fidelity: float,
+    bootstrap: _BootstrapResult,
+) -> list[str]:
+    """Collect and emit fit and bootstrap diagnostics requiring attention."""
+    messages: list[str] = []
+    if n_trials < _MIN_RECOMMENDED_TRIALS:
+        messages.append(
+            f"n_trials={n_trials} is below the recommended minimum of "
+            f"{_MIN_RECOMMENDED_TRIALS}."
+        )
+    if n_clifford_points < _MIN_RECOMMENDED_CLIFFORD_POINTS:
+        messages.append(
+            f"Only {n_clifford_points} Clifford-length points were provided; "
+            f"at least {_MIN_RECOMMENDED_CLIFFORD_POINTS} are recommended for "
+            "the three-parameter decay fit."
+        )
+    floor_count = (
+        reference_statistics.sem_floor_count + interleaved_statistics.sem_floor_count
+    )
+    if floor_count:
+        messages.append(f"The SEM floor was applied at {floor_count} points.")
+    if not fit_covariance_scale_empirical:
+        messages.append(
+            "No empirical SEM values contribute to the effective fit weights; "
+            "the fit-covariance scale is non-empirical and covariance-derived "
+            "fidelity uncertainty is unavailable."
+        )
+    messages.extend(_curve_fit_warning_messages(reference_fit, interleaved_fit))
+    if not 0.0 <= gate_fidelity <= 1.0:
+        messages.append(
+            "The finite-sample gate-fidelity estimate lies outside [0, 1] and "
+            "was intentionally not clipped."
+        )
+    messages.extend(_bootstrap_warning_messages(bootstrap))
+    for message in messages:
+        warnings.warn(message, RuntimeWarning, stacklevel=4)
+    return messages
+
+
+def _fit_covariance_fidelity_error(
+    reference_fit: _DecayFitResult,
+    interleaved_fit: _DecayFitResult,
+    *,
+    dimension: int,
+) -> float | None:
+    """Propagate independent fit covariance as a diagnostic only."""
+    reference_errors = reference_fit.standard_errors
+    interleaved_errors = interleaved_fit.standard_errors
+    if reference_errors is None or interleaved_errors is None:
+        return None
+    p_reference = reference_fit.decay_parameter
+    p_interleaved = interleaved_fit.decay_parameter
+    factor = (dimension - 1.0) / dimension
+    p_reference_error = float(reference_errors[1])
+    p_interleaved_error = float(interleaved_errors[1])
+    variance = factor**2 * (
+        (p_interleaved_error / p_reference) ** 2
+        + (p_reference_error * p_interleaved / p_reference**2) ** 2
+    )
+    if not np.isfinite(variance) or variance < 0:
+        return None
+    return float(math.sqrt(variance))
+
+
+def _make_figure(
+    target: str,
+    n_cliffords: NDArray[np.int64],
+    reference_statistics: _TrialStatistics,
+    interleaved_statistics: _TrialStatistics,
+    reference_fit: _DecayFitResult,
+    interleaved_fit: _DecayFitResult,
+    *,
+    gate_fidelity: float,
+    gate_fidelity_error: float | None,
+    gate_fidelity_ci95: tuple[float, float] | None,
+    error_bar: _ErrorBar,
+    interleaved_clifford_name: str | None,
+) -> go.Figure:
+    """Build a paired IRB figure in the established Qubex IRB style."""
+    figure = viz.make_figure()
+    dense_x = np.linspace(float(n_cliffords[0]), float(n_cliffords[-1]), 1_000)
+    for name, color, statistics, fit in (
+        ("Reference", viz.COLORS[0], reference_statistics, reference_fit),
+        ("Interleaved", viz.COLORS[1], interleaved_statistics, interleaved_fit),
+    ):
+        if error_bar == "sem":
+            error_values = statistics.sem
+        elif error_bar == "std":
+            error_values = statistics.std
+        else:
+            error_values = None
+        dense_y = _rb_decay(
+            dense_x,
+            fit.amplitude,
+            fit.decay_parameter,
+            fit.offset,
+        )
+        figure.add_trace(
+            go.Scatter(
+                x=dense_x,
+                y=dense_y,
+                mode="lines",
+                name=name,
+                line={"color": color},
+            )
+        )
+        figure.add_trace(
+            go.Scatter(
+                x=n_cliffords,
+                y=statistics.mean,
+                mode="markers",
+                error_y={"type": "data", "array": error_values}
+                if error_values is not None
+                else None,
+                marker={"color": color},
+                showlegend=False,
+            )
+        )
+    uncertainty_text = (
+        "unavailable"
+        if gate_fidelity_error is None
+        else f"{100.0 * gate_fidelity_error:.4f} pp"
+    )
+    ci_text = (
+        "unavailable"
+        if gate_fidelity_ci95 is None
+        else (
+            f"[{100.0 * gate_fidelity_ci95[0]:.4f}, "
+            f"{100.0 * gate_fidelity_ci95[1]:.4f}] %"
+        )
+    )
+    figure.add_annotation(
+        xref="paper",
+        yref="paper",
+        x=0.95,
+        y=0.95,
+        text=(
+            f"F = {100.0 * gate_fidelity:.4f} %<br>"
+            f"bootstrap σ = {uncertainty_text}<br>"
+            f"95% CI = {ci_text}"
+        ),
+        showarrow=False,
+        align="right",
+    )
+    gate_name = f" of {interleaved_clifford_name}" if interleaved_clifford_name else ""
+    figure.update_layout(
+        title=f"Paired interleaved randomized benchmarking{gate_name} : {target}",
+        xaxis_title="Number of Cliffords",
+        xaxis_type="linear",
+        yaxis_title="Normalized signal",
+        yaxis_type="linear",
+    )
+    return figure
+
+
+def _analyze_paired_irb(
+    raw_result: Result | Mapping[str, object],
+    *,
+    options: _AnalysisOptions,
+) -> Result:
+    """Run paired IRB analysis with options validated by a public entry point."""
+    target, target_payload = _extract_raw_payload(raw_result)
+    raw_data = _validated_raw_data(target_payload)
+    dimension = raw_data.dimension
+
+    statistics = _paired_trial_statistics(
+        raw_data.reference_trials,
+        raw_data.interleaved_trials,
+        sem_floor=options.sem_floor,
+    )
+    reference_statistics = statistics.reference
+    interleaved_statistics = statistics.interleaved
+    reference_fit = _fit_rb_decay(
+        raw_data.n_cliffords,
+        reference_statistics.mean,
+        reference_statistics.sem_used,
+    )
+    interleaved_fit = _fit_rb_decay(
+        raw_data.n_cliffords,
+        interleaved_statistics.mean,
+        interleaved_statistics.sem_used,
+    )
+    gate_fidelity = _gate_fidelity(
+        reference_fit.decay_parameter,
+        interleaved_fit.decay_parameter,
+        dimension=dimension,
+    )
+    bootstrap = _bootstrap_analysis(
+        raw_data.n_cliffords,
+        raw_data.reference_trials,
+        raw_data.interleaved_trials,
+        raw_data.first_protocols,
+        dimension=dimension,
+        n_bootstrap=options.n_bootstrap,
+        bootstrap_seed=options.bootstrap_seed,
+        sem_floor=options.sem_floor,
+    )
+    if bootstrap.valid:
+        gate_fidelity_error = bootstrap.fidelity_std
+        gate_fidelity_ci68 = bootstrap.fidelity_ci68
+        gate_fidelity_ci95 = bootstrap.fidelity_ci95
+        uncertainty_method = "paired_bootstrap"
+    else:
+        gate_fidelity_error = None
+        gate_fidelity_ci68 = None
+        gate_fidelity_ci95 = None
+        if bootstrap.n_requested > 0 and not bootstrap.resampling_valid:
+            uncertainty_method = "paired_bootstrap_resampling_invalid"
+        elif bootstrap.n_success >= 2:
+            uncertainty_method = "paired_bootstrap_unreliable"
+        else:
+            uncertainty_method = "unavailable"
+    warning_messages = _analysis_warnings(
+        n_trials=raw_data.reference_trials.shape[1],
+        n_clifford_points=len(raw_data.n_cliffords),
+        reference_statistics=reference_statistics,
+        interleaved_statistics=interleaved_statistics,
+        fit_covariance_scale_empirical=(statistics.fit_covariance_scale_empirical),
+        reference_fit=reference_fit,
+        interleaved_fit=interleaved_fit,
+        gate_fidelity=gate_fidelity,
+        bootstrap=bootstrap,
+    )
+    reference_payload = _curve_payload(
+        raw_data.reference_trials,
+        reference_statistics,
+        reference_fit,
+    )
+    interleaved_payload = _curve_payload(
+        raw_data.interleaved_trials,
+        interleaved_statistics,
+        interleaved_fit,
+    )
+    fit_covariance_error = (
+        _fit_covariance_fidelity_error(
+            reference_fit,
+            interleaved_fit,
+            dimension=dimension,
+        )
+        if statistics.fit_covariance_scale_empirical
+        else None
+    )
+    parameter_bound_quality_valid = not (
+        reference_fit.parameters_at_bound or interleaved_fit.parameters_at_bound
+    )
+    analyzed_payload: dict[str, object] = {
+        "gate_fidelity": gate_fidelity,
+        "gate_error": 1.0 - gate_fidelity,
+        "gate_fidelity_err": gate_fidelity_error,
+        "gate_fidelity_ci68": gate_fidelity_ci68,
+        "gate_fidelity_ci95": gate_fidelity_ci95,
+        "reference": reference_payload,
+        "interleaved": interleaved_payload,
+        "acquisition": dict(raw_data.acquisition),
+        "metadata": dict(raw_data.metadata),
+        "uncertainty_method": uncertainty_method,
+        "bootstrap": bootstrap.to_payload(),
+        "diagnostics": {
+            "warnings": tuple(warning_messages),
+            "parameter_bound_quality_valid": parameter_bound_quality_valid,
+            "reference_p_at_bound": "p" in reference_fit.parameters_at_bound,
+            "interleaved_p_at_bound": "p" in interleaved_fit.parameters_at_bound,
+            "bootstrap_parameter_bound_quality_valid": (
+                bootstrap.parameter_bound_quality_valid
+            ),
+            "bootstrap_resampling_valid": bootstrap.resampling_valid,
+            "bootstrap_optimizer_valid": bootstrap.optimizer_valid,
+            "bootstrap_parameters_at_bound": {
+                "reference": {
+                    "any_count": bootstrap.reference_any_bound_count,
+                    "any_fraction": bootstrap.reference_any_bound_fraction,
+                    "p_count": bootstrap.reference_p_bound_count,
+                    "p_fraction": bootstrap.reference_p_bound_fraction,
+                },
+                "interleaved": {
+                    "any_count": bootstrap.interleaved_any_bound_count,
+                    "any_fraction": bootstrap.interleaved_any_bound_fraction,
+                    "p_count": bootstrap.interleaved_p_bound_count,
+                    "p_fraction": bootstrap.interleaved_p_bound_fraction,
+                },
+            },
+            "sem_floor": statistics.sem_floor,
+            "sem_floor_mode": ("automatic" if options.sem_floor is None else "fixed"),
+            "sem_floor_applied": {
+                "reference": reference_statistics.sem_floor_count,
+                "interleaved": interleaved_statistics.sem_floor_count,
+            },
+            "parameters_at_bound": {
+                "reference": reference_fit.parameters_at_bound,
+                "interleaved": interleaved_fit.parameters_at_bound,
+            },
+            "reduced_chi_square": {
+                "reference": reference_fit.reduced_chi_square,
+                "interleaved": interleaved_fit.reduced_chi_square,
+            },
+            "r_squared": {
+                "reference": reference_fit.r_squared,
+                "interleaved": interleaved_fit.r_squared,
+            },
+            "gate_fidelity_err_fit_covariance": fit_covariance_error,
+            "fit_covariance_scale_empirical": (
+                statistics.fit_covariance_scale_empirical
+            ),
+            "uncertainty_scope": "paired statistical bootstrap only",
+            "irb_model_uncertainty_included": False,
+            "readout_calibration_uncertainty_included": False,
+        },
+    }
+    figure: go.Figure | None = None
+    if options.plot or options.save_image:
+        raw_interleaved_name = raw_data.metadata.get("interleaved_clifford")
+        figure = _make_figure(
+            target,
+            raw_data.n_cliffords,
+            reference_statistics,
+            interleaved_statistics,
+            reference_fit,
+            interleaved_fit,
+            gate_fidelity=gate_fidelity,
+            gate_fidelity_error=gate_fidelity_error,
+            gate_fidelity_ci95=gate_fidelity_ci95,
+            error_bar=options.error_bar,
+            interleaved_clifford_name=(
+                raw_interleaved_name if isinstance(raw_interleaved_name, str) else None
+            ),
+        )
+        if options.save_image:
+            viz.save_figure(
+                figure,
+                name=f"paired_interleaved_randomized_benchmarking_{target}",
+            )
+        if options.plot:
+            figure.show()
+    return Result(
+        data={target: analyzed_payload},
+        figure=figure,
+        figures={target: figure} if figure is not None else None,
+    )
+
+
+def analyze_paired_irb(
+    raw_result: Result | Mapping[str, object],
+    *,
+    n_bootstrap: int = _DEFAULT_BOOTSTRAP_SAMPLES,
+    bootstrap_seed: int | None = _DEFAULT_BOOTSTRAP_SEED,
+    sem_floor: float | None = None,
+    error_bar: Literal["sem", "std"] | None = "sem",
+    plot: bool = False,
+    save_image: bool = False,
+) -> Result:
+    """
+    Analyze saved paired IRB trials without repeating hardware measurement.
+
+    Parameters
+    ----------
+    raw_result : Result | Mapping[str, object]
+        Measurement-only result returned by `measure_paired_irb`.
+    n_bootstrap : int, optional
+        Number of paired bootstrap replicates. Defaults to 2000. Zero disables
+        bootstrap uncertainty while retaining the weighted point estimate. At
+        least two samples in every AB/BA stratum, two successful replicates,
+        and an 80% success rate are required to report primary uncertainty.
+    bootstrap_seed : int | None, optional
+        Reproducible bootstrap RNG seed. Defaults to 0.
+    sem_floor : float | None, optional
+        Common positive SEM floor for both weighted fits. With the default
+        `None`, it is 25% of the median positive SEM across both arms. If every
+        SEM is zero, a probability-scale fallback of 0.001 is used. Pass a
+        positive value to override this automatic floor. If that fixed value
+        replaces every empirical SEM, covariance-derived fidelity uncertainty
+        is unavailable.
+    error_bar : {"sem", "std"} | None, optional
+        Error bars used in the optional figure. Use `None` to disable them.
+        Defaults to `"sem"`.
+    plot : bool, optional
+        Display the analysis figure. Defaults to `False`.
+    save_image : bool, optional
+        Save the analysis figure through Qubex visualization. Defaults to
+        `False`.
+
+    Returns
+    -------
+    Result
+        Full-data weighted fits, unclipped gate fidelity, paired-bootstrap
+        uncertainty and intervals, raw trials, and diagnostics.
+
+    Raises
+    ------
+    TypeError
+        Raised when `raw_result` or an option has an incompatible type.
+    ValueError
+        Raised when the raw result schema or an analysis option is invalid.
+    RuntimeError
+        Raised when either full-data decay fit does not converge.
+
+    Notes
+    -----
+    Raw input must use paired IRB schema version 1, including one
+    `acquisition.planned_order` entry per trial cell. When
+    `metadata.is_two_qubit` is present, it must agree with `metadata.dimension`.
+    Setting `save_image=True` writes the generated figure through Qubex
+    visualization.
+
+    Bootstrap resampling is independent at each length and stratified by the
+    actual reference-first/interleaved-first counts in `acquisition.planned_order`.
+    It uses the same sampled trial indices for the reference and interleaved
+    matrices. Each stratum must contain at least two samples; bootstrap fitting
+    is skipped entirely when that condition is not met. Data with two or three
+    total trials still produce a point estimate, but cannot produce primary
+    stratified-bootstrap uncertainty. Readout calibration and IRB model/systematic
+    uncertainty are treated as fixed and are not included in the reported
+    statistical interval.
+
+    The returned target payload keeps the raw trials and adds `mean`, `std`,
+    `sem`, and `fit` under each arm. Primary uncertainty fields are derived from
+    the paired bootstrap only when every stratum has at least two samples and
+    at least 80% of replicates succeed. When fitting is attempted, bootstrap
+    spread summaries remain available as diagnostics if optimizer validity
+    fails. Resampling validity, execution status, optimizer reliability, and
+    bootstrap parameter-bound quality are reported separately; bound-hit
+    samples remain in the distribution. Fit covariance propagation is
+    diagnostic only.
+
+    `bootstrap["parameter_bound_quality_valid"]` uses a 5% decay-parameter
+    bound-hit limit and a 10% any-parameter bound-hit limit among successful
+    replicates. It is independent of `bootstrap["optimizer_valid"]`; exceeding
+    a bound-hit limit emits a warning but does not suppress primary uncertainty.
+    Full-data `diagnostics["parameter_bound_quality_valid"]` is `False` when
+    either fit has any parameter at a bound, while the point fidelity remains
+    available.
+
+    With automatic SEM regularization, `diagnostics["sem_floor"]` is the
+    full-data floor and `diagnostics["sem_floor_mode"]` is `"automatic"`.
+    Each bootstrap replicate recomputes its floor from its resampled trials.
+    When every trial SEM is zero, or a fixed floor replaces every empirical
+    SEM, covariance-derived fidelity uncertainty is unavailable and
+    `diagnostics["fit_covariance_scale_empirical"]` is `False`. Full-data and
+    bootstrap parameter-bound quality flags are also retained in `diagnostics`
+    without suppressing the point fidelity.
+    """
+    options = _resolve_analysis_options(
+        n_bootstrap=n_bootstrap,
+        bootstrap_seed=bootstrap_seed,
+        sem_floor=sem_floor,
+        error_bar=error_bar,
+        plot=plot,
+        save_image=save_image,
+    )
+    return _analyze_paired_irb(raw_result, options=options)
+
+
+# -----------------------------------------------------------------------------
+# Auto-range pilot and adaptive main-grid selection
+# -----------------------------------------------------------------------------
+
+
+def _combine_pilot_results(
+    target: str,
+    stage_results: Sequence[Result],
+    *,
+    sequence_seed: int | None,
+    acquisition_seed: int | None,
+    stage_acquisition_seeds: Sequence[int | None],
+) -> dict[str, object]:
+    """Combine adaptive pilot stages into one schema-compatible raw payload."""
+    if not stage_results:
+        raise ValueError("At least one pilot stage result is required.")
+    payloads = [
+        _mapping(stage.data[target], name=f"pilot_result[{target!r}]")
+        for stage in stage_results
+    ]
+    acquisitions = [
+        _mapping(payload["acquisition"], name="pilot acquisition")
+        for payload in payloads
+    ]
+    reference_trials = np.concatenate(
+        [
+            np.asarray(
+                _mapping(payload["reference"], name="pilot reference")["trials"],
+                dtype=np.float64,
+            )
+            for payload in payloads
+        ],
+        axis=0,
+    )
+    interleaved_trials = np.concatenate(
+        [
+            np.asarray(
+                _mapping(payload["interleaved"], name="pilot interleaved")["trials"],
+                dtype=np.float64,
+            )
+            for payload in payloads
+        ],
+        axis=0,
+    )
+    n_cliffords = np.concatenate(
+        [
+            np.asarray(acquisition["n_cliffords"], dtype=np.int64)
+            for acquisition in acquisitions
+        ]
+    )
+    seeds = np.concatenate(
+        [
+            np.asarray(acquisition["seeds"], dtype=np.int64)
+            for acquisition in acquisitions
+        ],
+        axis=0,
+    )
+    planned_order: list[dict[str, object]] = []
+    pair_chunks: list[dict[str, object]] = []
+    length_offset = 0
+    pair_offset = 0
+    for payload, acquisition in zip(payloads, acquisitions, strict=True):
+        stage_rows = np.asarray(
+            _mapping(payload["reference"], name="pilot reference")["trials"]
+        ).shape[0]
+        stage_plan = cast(Sequence[object], acquisition["planned_order"])
+        for raw_pair in stage_plan:
+            pair = dict(_mapping(raw_pair, name="pilot planned-order entry"))
+            pair["pair_order_index"] = len(planned_order)
+            pair["length_index"] = int(cast(int, pair["length_index"])) + length_offset
+            planned_order.append(pair)
+        for raw_chunk in cast(Sequence[object], acquisition["pair_chunks"]):
+            chunk = dict(_mapping(raw_chunk, name="pilot pair chunk"))
+            chunk["pair_order_indices"] = tuple(
+                int(cast(int, index)) + pair_offset
+                for index in cast(Sequence[object], chunk["pair_order_indices"])
+            )
+            pair_chunks.append(chunk)
+        length_offset += int(stage_rows)
+        pair_offset += len(stage_plan)
+
+    first_acquisition = dict(acquisitions[0])
+    first_acquisition.update(
+        {
+            "n_cliffords": n_cliffords,
+            "n_trials": reference_trials.shape[1],
+            "seeds": seeds,
+            "sequence_seed": sequence_seed,
+            "acquisition_seed": acquisition_seed,
+            "stage_acquisition_seeds": tuple(stage_acquisition_seeds),
+            "planned_order": tuple(planned_order),
+            "pair_chunks": tuple(pair_chunks),
+            "n_sweep_calls": sum(
+                int(cast(int, acquisition["n_sweep_calls"]))
+                for acquisition in acquisitions
+            ),
+            "n_measurement_points": sum(
+                int(cast(int, acquisition["n_measurement_points"]))
+                for acquisition in acquisitions
+            ),
+            "adaptive_stage_count": len(stage_results),
+        }
+    )
+    metadata = dict(_mapping(payloads[0]["metadata"], name="pilot metadata"))
+    metadata["pilot"] = True
+    return {
+        "reference": {"trials": reference_trials},
+        "interleaved": {"trials": interleaved_trials},
+        "acquisition": first_acquisition,
+        "metadata": metadata,
+    }
+
+
+def _assess_pilot_arm(
+    n_cliffords: NDArray[np.int64],
+    moments: _TrialMoments,
+    *,
+    dimension: int,
+) -> _PilotArmAssessment:
+    """Fit and validate one pilot arm, including observed endpoint decay."""
+    significance = _observed_decay_significance(moments.mean, moments.sem)
+    try:
+        fit = _fit_pilot_decay(
+            n_cliffords,
+            moments.mean,
+            dimension=dimension,
+        )
+    except (RuntimeError, ValueError, np.linalg.LinAlgError):
+        fit = None
+
+    invalid_reasons: list[str] = []
+    if fit is None:
+        invalid_reasons.append("fit_failed")
+    else:
+        if not 0.0 < fit.decay_parameter < 1.0:
+            invalid_reasons.append("invalid_decay_parameter")
+        if "p" in fit.parameters_at_bound:
+            invalid_reasons.append("decay_parameter_at_bound")
+        if fit.amplitude < _MIN_PILOT_AMPLITUDE:
+            invalid_reasons.append("pathological_amplitude")
+        if fit.r_squared is None or fit.r_squared < _MIN_PILOT_R_SQUARED:
+            invalid_reasons.append("poor_decay_shape")
+    if significance < _MIN_PILOT_DECAY_SIGNIFICANCE:
+        invalid_reasons.append("insufficient_observed_decay")
+    return _PilotArmAssessment(
+        fit=fit,
+        decay_significance=significance,
+        invalid_reasons=tuple(invalid_reasons),
+    )
+
+
+def _pilot_arm_quality_payload(
+    assessment: _PilotArmAssessment,
+) -> dict[str, object]:
+    """Return one concise pilot-specific fit-quality record."""
+    fit = assessment.fit
+    return {
+        "p": fit.decay_parameter if fit is not None else None,
+        "A": fit.amplitude if fit is not None else None,
+        "C": fit.offset if fit is not None else None,
+        "r_squared": fit.r_squared if fit is not None else None,
+        "parameters_at_bound": fit.parameters_at_bound if fit is not None else (),
+        "amplitude_lower_bound_hit": (
+            fit.amplitude_lower_bound_hit if fit is not None else False
+        ),
+        "amplitude_upper_bound_hit": (
+            fit.amplitude_upper_bound_hit if fit is not None else False
+        ),
+        "minimum_amplitude": _MIN_PILOT_AMPLITUDE,
+        "minimum_r_squared": _MIN_PILOT_R_SQUARED,
+        "decay_significance": assessment.decay_significance,
+        "minimum_decay_significance": _MIN_PILOT_DECAY_SIGNIFICANCE,
+        "valid": assessment.valid,
+        "invalid_reasons": assessment.invalid_reasons,
+    }
+
+
+def _pilot_assessment_payload(
+    assessment: _PilotDecayAssessment,
+) -> dict[str, object]:
+    """Return target-level pilot quality diagnostics for both arms."""
+    return {
+        "reference": _pilot_arm_quality_payload(assessment.reference),
+        "interleaved": _pilot_arm_quality_payload(assessment.interleaved),
+    }
+
+
+def _assess_pilot_decay(
+    pilot_payload: Mapping[str, object],
+) -> _PilotDecayAssessment:
+    """Assess fixed-offset paired pilot fits independently of main analysis."""
+    acquisition = _mapping(pilot_payload["acquisition"], name="pilot acquisition")
+    n_cliffords = np.asarray(acquisition["n_cliffords"], dtype=np.int64)
+    if len(n_cliffords) < _MIN_AUTO_RANGE_FIT_POINTS:
+        raise ValueError("Pilot assessment requires at least six Clifford lengths.")
+    reference_trials = np.asarray(
+        _mapping(pilot_payload["reference"], name="pilot reference")["trials"],
+        dtype=np.float64,
+    )
+    interleaved_trials = np.asarray(
+        _mapping(pilot_payload["interleaved"], name="pilot interleaved")["trials"],
+        dtype=np.float64,
+    )
+    dimension = _validated_dimension(
+        _mapping(pilot_payload["metadata"], name="pilot metadata")
+    )
+    return _PilotDecayAssessment(
+        reference=_assess_pilot_arm(
+            n_cliffords,
+            _trial_moments(reference_trials),
+            dimension=dimension,
+        ),
+        interleaved=_assess_pilot_arm(
+            n_cliffords,
+            _trial_moments(interleaved_trials),
+            dimension=dimension,
+        ),
+    )
+
+
+def _remaining_contrast_fraction(
+    fits: tuple[_PilotDecayFitResult, _PilotDecayFitResult],
+    *,
+    n_cliffords: int,
+) -> float:
+    """Return the slower arm's fitted contrast fraction at one length."""
+    return max(
+        fits[0].decay_parameter ** n_cliffords,
+        fits[1].decay_parameter ** n_cliffords,
+    )
+
+
+def _contrast_target_grid(
+    decay_parameter: float,
+    remaining_fractions: Collection[float],
+    *,
+    maximum: int,
+) -> tuple[NDArray[np.int64], bool]:
+    """Map target contrast fractions to bounded integer Clifford lengths."""
+    if not np.isfinite(decay_parameter) or not 0.0 < decay_parameter < 1.0:
+        raise ValueError("The pilot decay parameter must be finite and in (0, 1).")
+    log_decay = math.log(decay_parameter)
+    if not np.isfinite(log_decay) or abs(log_decay) < _MIN_ABSOLUTE_LOG_DECAY:
+        raise ValueError("The pilot decay parameter is too close to 1.")
+
+    candidates: set[int] = set()
+    maximum_anchor_added = False
+    for remaining_fraction in remaining_fractions:
+        estimated_length = math.log(remaining_fraction) / log_decay
+        if not np.isfinite(estimated_length):
+            raise ValueError("A contrast target produced a non-finite length.")
+        if estimated_length > maximum:
+            maximum_anchor_added = True
+            continue
+        rounded_length = round(estimated_length)
+        if 0 < rounded_length <= maximum:
+            candidates.add(rounded_length)
+    if maximum_anchor_added:
+        candidates.add(maximum)
+    return np.asarray(sorted(candidates), dtype=np.int64), maximum_anchor_added
+
+
+def _merge_near_duplicate_grid(
+    grid: NDArray[np.int64],
+) -> tuple[NDArray[np.int64], bool]:
+    """Merge only closely spaced points outside the sensitive early region."""
+    merged: list[int] = []
+    merging_applied = False
+    maximum = int(grid[-1])
+    preserved = {0, 1, maximum}
+    for raw_value in grid:
+        value = int(raw_value)
+        if not merged:
+            merged.append(value)
+            continue
+        previous = merged[-1]
+        relative_separation = (value - previous) / max(previous, 1)
+        can_merge = (
+            previous >= _MIN_RELATIVE_MERGE_LENGTH
+            and previous not in preserved
+            and value not in preserved
+            and relative_separation <= _NEAR_DUPLICATE_RELATIVE_SEPARATION
+        )
+        if can_merge:
+            merged[-1] = round((previous + value) / 2.0)
+            merging_applied = True
+        else:
+            merged.append(value)
+    return np.asarray(sorted(set(merged)), dtype=np.int64), merging_applied
+
+
+def _thin_grid_in_log_space(
+    grid: NDArray[np.int64],
+    *,
+    maximum_points: int,
+) -> tuple[NDArray[np.int64], bool]:
+    """Thin a large union while preserving broad `log(1 + m)` coverage."""
+    if len(grid) <= maximum_points:
+        return grid, False
+    values = tuple(int(value) for value in grid)
+    coordinates = {value: math.log1p(value) for value in values}
+    selected = {values[0], values[-1]}
+    if 1 in coordinates:
+        selected.add(1)
+    while len(selected) < maximum_points:
+        remaining = [value for value in values if value not in selected]
+        next_value = max(
+            remaining,
+            key=lambda value: (
+                min(
+                    abs(coordinates[value] - coordinates[current])
+                    for current in selected
+                ),
+                -value,
+            ),
+        )
+        selected.add(next_value)
+    return np.asarray(sorted(selected), dtype=np.int64), True
+
+
+def _thin_grid_preserving_points(
+    grid: NDArray[np.int64],
+    *,
+    mandatory_points: Collection[int],
+    maximum_points: int,
+) -> tuple[NDArray[np.int64], bool]:
+    """Thin a grid in log space without removing required target coverage."""
+    if len(grid) <= maximum_points:
+        return grid, False
+    values = tuple(int(value) for value in grid)
+    coordinates = {value: math.log1p(value) for value in values}
+    selected = {int(value) for value in mandatory_points}
+    if not selected.issubset(coordinates):
+        raise ValueError("Mandatory parallel-grid points must belong to the union.")
+    if len(selected) > maximum_points:
+        raise ValueError("The parallel-grid cap cannot hold all mandatory points.")
+    while len(selected) < maximum_points:
+        remaining = [value for value in values if value not in selected]
+        next_value = max(
+            remaining,
+            key=lambda value: (
+                min(
+                    abs(coordinates[value] - coordinates[current])
+                    for current in selected
+                ),
+                -value,
+            ),
+        )
+        selected.add(next_value)
+    return np.asarray(sorted(selected), dtype=np.int64), True
+
+
+def _parallel_shared_main_grid(
+    selections: Mapping[str, _MainGridSelection],
+    *,
+    maximum: int,
+) -> tuple[
+    NDArray[np.int64],
+    dict[str, NDArray[np.int64]],
+    int,
+    bool,
+]:
+    """Build a shared grid while retaining broad coverage for every target."""
+    retained_by_target: dict[str, NDArray[np.int64]] = {}
+    for target, selection in selections.items():
+        target_grid = selection.selected_grid
+        retained_count = min(
+            _MIN_PARALLEL_RETAINED_POINTS_PER_TARGET,
+            len(target_grid),
+        )
+        retained_by_target[target] = _thin_grid_in_log_space(
+            target_grid,
+            maximum_points=retained_count,
+        )[0]
+
+    candidates = np.asarray(
+        sorted(
+            {
+                int(length)
+                for selection in selections.values()
+                for length in selection.selected_grid
+                if 0 <= int(length) <= maximum
+            }
+        ),
+        dtype=np.int64,
+    )
+    mandatory = {
+        int(length)
+        for retained_grid in retained_by_target.values()
+        for length in retained_grid
+    }
+    maximum_points = max(
+        _MAX_MAIN_GRID_POINTS,
+        4 + 4 * len(selections),
+        len(mandatory),
+    )
+    shared_grid, thinning_applied = _thin_grid_preserving_points(
+        candidates,
+        mandatory_points=mandatory,
+        maximum_points=maximum_points,
+    )
+    return shared_grid, retained_by_target, maximum_points, thinning_applied
+
+
+def _fill_short_main_grid(
+    grid: NDArray[np.int64],
+    *,
+    maximum: int,
+) -> tuple[NDArray[np.int64], NDArray[np.int64]]:
+    """
+    Add well-separated integer lengths when contrast targets round together.
+
+    This is only used after a valid pilot fit. For very fast decay, several
+    contrast targets can round to the same early Clifford length.
+    """
+    if len(grid) >= _MIN_MAIN_GRID_POINTS or maximum < 5:
+        return grid, np.asarray([], dtype=np.int64)
+
+    selected = {int(value) for value in grid}
+    upper = min(maximum, max(_MIN_MAIN_GRID_POINTS - 1, int(grid[-1])))
+    added: list[int] = []
+    if upper not in selected:
+        selected.add(upper)
+        added.append(upper)
+    while len(selected) < _MIN_MAIN_GRID_POINTS:
+        ordered = sorted(selected)
+        candidates = {
+            min(
+                right - 1,
+                max(
+                    left + 1,
+                    round(math.expm1((math.log1p(left) + math.log1p(right)) / 2.0)),
+                ),
+            )
+            for left, right in pairwise(ordered)
+            if right - left > 1
+        }
+        if not candidates:
+            break
+        next_value = max(
+            candidates,
+            key=lambda value: (
+                min(
+                    abs(math.log1p(value) - math.log1p(current)) for current in selected
+                ),
+                -value,
+            ),
+        )
+        selected.add(next_value)
+        added.append(next_value)
+    return (
+        np.asarray(sorted(selected), dtype=np.int64),
+        np.asarray(sorted(added), dtype=np.int64),
+    )
+
+
+def _postprocess_main_grid(
+    candidates: Collection[int],
+    *,
+    maximum: int,
+) -> tuple[NDArray[np.int64], bool, bool]:
+    """Anchor, bound, merge, sort, and thin one main-grid candidate union."""
+    bounded = {
+        int(value)
+        for value in candidates
+        if isinstance(value, (int, np.integer)) and 0 <= int(value) <= maximum
+    }
+    bounded.add(0)
+    if maximum >= 1:
+        bounded.add(1)
+    merged, merging_applied = _merge_near_duplicate_grid(
+        np.asarray(sorted(bounded), dtype=np.int64)
+    )
+    thinned, thinning_applied = _thin_grid_in_log_space(
+        merged,
+        maximum_points=_MAX_MAIN_GRID_POINTS,
+    )
+    return thinned, merging_applied, thinning_applied
+
+
+def _fallback_main_grid(
+    fallback_grid: NDArray[np.int64],
+    *,
+    reason: str,
+) -> _MainGridSelection:
+    """Return an exploration-grid fallback with an auditable reason."""
+    return _MainGridSelection(
+        reference_grid=np.asarray([], dtype=np.int64),
+        interleaved_grid=np.asarray([], dtype=np.int64),
+        selected_grid=fallback_grid.copy(),
+        additional_fractions_used=(),
+        supplemental_integer_grid=np.asarray([], dtype=np.int64),
+        near_duplicate_merging_applied=False,
+        thinning_applied=False,
+        maximum_anchor_added=False,
+        fallback_used=True,
+        fallback_reason=reason,
+    )
+
+
+def _select_decay_adapted_main_grid(
+    fits: tuple[_PilotDecayFitResult, _PilotDecayFitResult] | None,
+    *,
+    remaining_fractions: tuple[float, ...],
+    maximum: int,
+    fallback_grid: NDArray[np.int64],
+) -> _MainGridSelection:
+    """Select a bounded main grid from both fitted decay scales."""
+    if fits is None:
+        return _fallback_main_grid(fallback_grid, reason="pilot_fit_unusable")
+    try:
+        reference_grid, reference_capped = _contrast_target_grid(
+            fits[0].decay_parameter,
+            remaining_fractions,
+            maximum=maximum,
+        )
+        interleaved_grid, interleaved_capped = _contrast_target_grid(
+            fits[1].decay_parameter,
+            remaining_fractions,
+            maximum=maximum,
+        )
+    except ValueError as error:
+        return _fallback_main_grid(
+            fallback_grid,
+            reason=f"invalid_pilot_decay: {error}",
+        )
+
+    reference_candidates = {int(value) for value in reference_grid}
+    interleaved_candidates = {int(value) for value in interleaved_grid}
+    selected_grid, merging_applied, thinning_applied = _postprocess_main_grid(
+        reference_candidates | interleaved_candidates,
+        maximum=maximum,
+    )
+    additional_fractions_used: list[float] = []
+    for fraction in _ADDITIONAL_MAIN_REMAINING_FRACTIONS:
+        if len(selected_grid) >= _MIN_MAIN_GRID_POINTS:
+            break
+        if fraction in remaining_fractions:
+            continue
+        additional_fractions_used.append(fraction)
+        try:
+            extra_reference, extra_reference_capped = _contrast_target_grid(
+                fits[0].decay_parameter,
+                (fraction,),
+                maximum=maximum,
+            )
+            extra_interleaved, extra_interleaved_capped = _contrast_target_grid(
+                fits[1].decay_parameter,
+                (fraction,),
+                maximum=maximum,
+            )
+        except ValueError as error:
+            return _fallback_main_grid(
+                fallback_grid,
+                reason=f"invalid_pilot_decay: {error}",
+            )
+        reference_candidates.update(int(value) for value in extra_reference)
+        interleaved_candidates.update(int(value) for value in extra_interleaved)
+        reference_capped = reference_capped or extra_reference_capped
+        interleaved_capped = interleaved_capped or extra_interleaved_capped
+        selected_grid, merged_now, thinned_now = _postprocess_main_grid(
+            reference_candidates | interleaved_candidates,
+            maximum=maximum,
+        )
+        merging_applied = merging_applied or merged_now
+        thinning_applied = thinning_applied or thinned_now
+
+    selected_grid, supplemental_integer_grid = _fill_short_main_grid(
+        selected_grid,
+        maximum=maximum,
+    )
+    if len(selected_grid) < _MIN_MAIN_GRID_POINTS:
+        return _fallback_main_grid(
+            fallback_grid,
+            reason="insufficient_unique_adaptive_points",
+        )
+    return _MainGridSelection(
+        reference_grid=np.asarray(sorted(reference_candidates), dtype=np.int64),
+        interleaved_grid=np.asarray(sorted(interleaved_candidates), dtype=np.int64),
+        selected_grid=selected_grid,
+        additional_fractions_used=tuple(additional_fractions_used),
+        supplemental_integer_grid=supplemental_integer_grid,
+        near_duplicate_merging_applied=merging_applied,
+        thinning_applied=thinning_applied,
+        maximum_anchor_added=reference_capped or interleaved_capped,
+        fallback_used=False,
+        fallback_reason=None,
+    )
+
+
+def _run_single_target_auto_range(
+    exp: Experiment,
+    target: str,
+    *,
+    context: _SingleAcquisitionContext,
+    candidate_grid: NDArray[np.int64],
+    maximum: int,
+    pilot_n_trials: int,
+    remaining_fraction_threshold: float,
+    main_remaining_fractions: tuple[float, ...],
+    pilot_sequence_seed: int | None,
+    pilot_acquisition_seed: int | None,
+) -> _AutoRangeOutcome:
+    """Select a fresh-main grid from incrementally extended paired pilot data."""
+    pilot_seeds = _generated_seed_matrix(
+        (len(candidate_grid), pilot_n_trials),
+        sequence_seed=pilot_sequence_seed,
+    )
+    stage_seed_values = _split_optional_seed(
+        pilot_acquisition_seed,
+        count=len(candidate_grid),
+        name="pilot_acquisition_seed",
+    )
+    stage_results: list[Result] = []
+    used_stage_seeds: list[int | None] = []
+    stage_diagnostics: list[dict[str, object]] = []
+    measured_count = 0
+    pilot_payload: dict[str, object] | None = None
+    pilot_assessment: _PilotDecayAssessment | None = None
+    pilot_fits: tuple[_PilotDecayFitResult, _PilotDecayFitResult] | None = None
+    stop_reason = "max_n_cliffords_reached"
+    stop_detail = "fit_unusable"
+    while measured_count < len(candidate_grid):
+        next_count = (
+            min(_MIN_AUTO_RANGE_FIT_POINTS, len(candidate_grid))
+            if measured_count == 0
+            else measured_count + 1
+        )
+        stage_slice = slice(measured_count, next_count)
+        stage_seed = stage_seed_values[len(stage_results)]
+        stage_results.append(
+            _run_single_target_acquisition(
+                exp,
+                target,
+                context=context,
+                n_cliffords=candidate_grid[stage_slice],
+                seeds=pilot_seeds[stage_slice],
+                sequence_seed=pilot_sequence_seed,
+                acquisition_seed=stage_seed,
+            )
+        )
+        used_stage_seeds.append(stage_seed)
+        measured_count = next_count
+        pilot_payload = _combine_pilot_results(
+            target,
+            stage_results,
+            sequence_seed=pilot_sequence_seed,
+            acquisition_seed=pilot_acquisition_seed,
+            stage_acquisition_seeds=used_stage_seeds,
+        )
+        current_maximum = int(candidate_grid[measured_count - 1])
+        remaining_fraction: float | None = None
+        fit_quality: dict[str, object] | None = None
+        if measured_count >= _MIN_AUTO_RANGE_FIT_POINTS:
+            pilot_assessment = _assess_pilot_decay(pilot_payload)
+            fit_quality = _pilot_assessment_payload(pilot_assessment)
+            pilot_fits = pilot_assessment.valid_fits
+        if pilot_fits is None:
+            stop_detail = (
+                pilot_assessment.blocking_reason
+                if pilot_assessment is not None
+                else "fit_unusable"
+            ) or "fit_unusable"
+        else:
+            remaining_fraction = _remaining_contrast_fraction(
+                pilot_fits,
+                n_cliffords=current_maximum,
+            )
+            if remaining_fraction <= remaining_fraction_threshold:
+                stop_reason = "decay_threshold_reached"
+                stop_detail = "criteria_satisfied"
+            else:
+                stop_detail = "remaining_fraction_above_threshold"
+        stage_diagnostics.append(
+            {
+                "max_n_cliffords": current_maximum,
+                "remaining_fraction": remaining_fraction,
+                "decision": stop_detail,
+                "fit_quality": fit_quality,
+            }
+        )
+        if stop_reason == "decay_threshold_reached":
+            break
+
+    if pilot_payload is None:
+        raise RuntimeError("Paired-IRB pilot acquisition produced no data.")
+    if stop_reason == "max_n_cliffords_reached":
+        warnings.warn(
+            f"Paired-IRB auto-range reached the maximum Clifford length "
+            f"{int(candidate_grid[-1])} before satisfying the decay criterion "
+            f"({stop_detail}).",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+    pilot_grid = candidate_grid[:measured_count].copy()
+    main_grid_selection = _select_decay_adapted_main_grid(
+        pilot_fits,
+        remaining_fractions=main_remaining_fractions,
+        maximum=maximum,
+        fallback_grid=candidate_grid,
+    )
+    if main_grid_selection.fallback_used:
+        warnings.warn(
+            "Paired-IRB main-grid selection is falling back to the pilot "
+            f"candidate grid: {main_grid_selection.fallback_reason}.",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+    reference_fit, interleaved_fit = (
+        (
+            pilot_assessment.reference.fit,
+            pilot_assessment.interleaved.fit,
+        )
+        if pilot_assessment is not None
+        else (None, None)
+    )
+    return _AutoRangeOutcome(
+        selected_main_grid=main_grid_selection.selected_grid,
+        metadata={
+            "mode": "decay_adaptive",
+            "enabled": True,
+            "pilot_grid": pilot_grid.copy(),
+            "candidate_pilot_grid": candidate_grid.copy(),
+            "pilot_n_trials": pilot_n_trials,
+            "pilot_remaining_fraction": remaining_fraction_threshold,
+            "pilot_model": _pilot_model_payload(
+                dimension=context.target_spec.dimension,
+                unmitigated_two_qubit_readout=(
+                    context.target_spec.is_two_qubit and not context.mitigate_readout
+                ),
+            ),
+            "pilot_p_reference": (
+                reference_fit.decay_parameter if reference_fit is not None else None
+            ),
+            "pilot_p_interleaved": (
+                interleaved_fit.decay_parameter if interleaved_fit is not None else None
+            ),
+            "main_remaining_fractions": main_remaining_fractions,
+            "additional_remaining_fractions_used": (
+                main_grid_selection.additional_fractions_used
+            ),
+            "supplemental_integer_grid": (
+                main_grid_selection.supplemental_integer_grid
+            ),
+            "candidate_reference_grid": main_grid_selection.reference_grid,
+            "candidate_interleaved_grid": main_grid_selection.interleaved_grid,
+            "selected_main_grid": main_grid_selection.selected_grid,
+            "max_n_cliffords": maximum,
+            "fallback_used": main_grid_selection.fallback_used,
+            "fallback_reason": main_grid_selection.fallback_reason,
+            "maximum_anchor_added": main_grid_selection.maximum_anchor_added,
+            "near_duplicate_merging_applied": (
+                main_grid_selection.near_duplicate_merging_applied
+            ),
+            "thinning_applied": main_grid_selection.thinning_applied,
+            "pilot_stop_reason": stop_reason,
+            "pilot_stop_detail": stop_detail,
+            "pilot_fit_quality": (
+                _pilot_assessment_payload(pilot_assessment)
+                if pilot_assessment is not None
+                else None
+            ),
+            "pilot_stage_diagnostics": tuple(stage_diagnostics),
+            "pilot_sequence_seed": pilot_sequence_seed,
+            "main_sequence_seed": None,
+            "pilot_acquisition_seed": pilot_acquisition_seed,
+            "main_acquisition_seed": None,
+            "pilot_reference_fit": (
+                _pilot_fit_payload(reference_fit) if reference_fit is not None else None
+            ),
+            "pilot_interleaved_fit": (
+                _pilot_fit_payload(interleaved_fit)
+                if interleaved_fit is not None
+                else None
+            ),
+            "pilot_raw_result": pilot_payload,
+        },
+    )
+
+
+def _run_parallel_auto_range(
+    exp: Experiment,
+    targets: tuple[str, ...],
+    *,
+    contexts: Mapping[str, _SingleAcquisitionContext],
+    candidate_grid: NDArray[np.int64],
+    maximum: int,
+    pilot_n_trials: int,
+    remaining_fraction_threshold: float,
+    main_remaining_fractions: tuple[float, ...],
+    pilot_sequence_seeds: Mapping[str, int | None],
+    pilot_acquisition_seed: int | None,
+) -> _ParallelAutoRangeOutcome:
+    """Select one shared range from incrementally extended parallel pilots."""
+    pilot_seeds_by_target = {
+        target: _generated_seed_matrix(
+            (len(candidate_grid), pilot_n_trials),
+            sequence_seed=pilot_sequence_seeds[target],
+        )
+        for target in targets
+    }
+    stage_seed_values = _split_optional_seed(
+        pilot_acquisition_seed,
+        count=len(candidate_grid),
+        name="pilot_acquisition_seed",
+    )
+    stage_results: list[Result] = []
+    used_stage_seeds: list[int | None] = []
+    measured_count = 0
+    pilot_payloads: dict[str, dict[str, object]] = {}
+    pilot_assessments: dict[str, _PilotDecayAssessment] = {}
+    pilot_fits: dict[
+        str,
+        tuple[_PilotDecayFitResult, _PilotDecayFitResult] | None,
+    ] = {}
+    stage_diagnostics_by_target: dict[str, list[dict[str, object]]] = {
+        target: [] for target in targets
+    }
+    stop_details = dict.fromkeys(targets, "fit_unusable")
+    stop_reason = "max_n_cliffords_reached"
+    while measured_count < len(candidate_grid):
+        next_count = (
+            min(_MIN_AUTO_RANGE_FIT_POINTS, len(candidate_grid))
+            if measured_count == 0
+            else measured_count + 1
+        )
+        stage_slice = slice(measured_count, next_count)
+        stage_seed = stage_seed_values[len(stage_results)]
+        stage_results.append(
+            _run_parallel_acquisition(
+                exp,
+                targets,
+                contexts=contexts,
+                n_cliffords=candidate_grid[stage_slice],
+                seeds_by_target={
+                    target: values[stage_slice]
+                    for target, values in pilot_seeds_by_target.items()
+                },
+                sequence_seeds=pilot_sequence_seeds,
+                acquisition_seed=stage_seed,
+            )
+        )
+        used_stage_seeds.append(stage_seed)
+        measured_count = next_count
+        pilot_payloads = {
+            target: _combine_pilot_results(
+                target,
+                stage_results,
+                sequence_seed=pilot_sequence_seeds[target],
+                acquisition_seed=pilot_acquisition_seed,
+                stage_acquisition_seeds=used_stage_seeds,
+            )
+            for target in targets
+        }
+        if measured_count >= _MIN_AUTO_RANGE_FIT_POINTS:
+            pilot_assessments = {
+                target: _assess_pilot_decay(payload)
+                for target, payload in pilot_payloads.items()
+            }
+            pilot_fits = {
+                target: assessment.valid_fits
+                for target, assessment in pilot_assessments.items()
+            }
+        current_maximum = int(candidate_grid[measured_count - 1])
+        all_targets_satisfied = True
+        for target in targets:
+            assessment = pilot_assessments.get(target)
+            fits = pilot_fits.get(target)
+            remaining_fraction: float | None = None
+            if fits is None:
+                detail = (
+                    assessment.blocking_reason
+                    if assessment is not None
+                    else "fit_unusable"
+                ) or "fit_unusable"
+            else:
+                remaining_fraction = _remaining_contrast_fraction(
+                    fits,
+                    n_cliffords=current_maximum,
+                )
+                detail = (
+                    "criteria_satisfied"
+                    if remaining_fraction <= remaining_fraction_threshold
+                    else "remaining_fraction_above_threshold"
+                )
+            stop_details[target] = detail
+            all_targets_satisfied &= detail == "criteria_satisfied"
+            stage_diagnostics_by_target[target].append(
+                {
+                    "max_n_cliffords": current_maximum,
+                    "remaining_fraction": remaining_fraction,
+                    "decision": detail,
+                    "fit_quality": (
+                        _pilot_assessment_payload(assessment)
+                        if assessment is not None
+                        else None
+                    ),
+                }
+            )
+        if all_targets_satisfied:
+            stop_reason = "decay_threshold_reached"
+            break
+
+    if stop_reason == "max_n_cliffords_reached":
+        warnings.warn(
+            f"Parallel paired-IRB auto-range reached the maximum Clifford length "
+            f"{int(candidate_grid[-1])} before every target satisfied the decay "
+            f"criterion ({stop_details}).",
+            RuntimeWarning,
+            stacklevel=3,
+        )
+    pilot_grid = candidate_grid[:measured_count].copy()
+    selections = {
+        target: _select_decay_adapted_main_grid(
+            pilot_fits.get(target),
+            remaining_fractions=main_remaining_fractions,
+            maximum=maximum,
+            fallback_grid=candidate_grid,
+        )
+        for target in targets
+    }
+    for target, selection in selections.items():
+        if selection.fallback_used:
+            warnings.warn(
+                "Parallel paired-IRB main-grid selection is falling back to the "
+                f"pilot candidate grid for `{target}`: "
+                f"{selection.fallback_reason}.",
+                RuntimeWarning,
+                stacklevel=3,
+            )
+    (
+        shared_main_grid,
+        retained_by_target,
+        parallel_max_points,
+        group_thinning_applied,
+    ) = _parallel_shared_main_grid(
+        selections,
+        maximum=maximum,
+    )
+    metadata_by_target: dict[str, dict[str, object]] = {}
+    for target in targets:
+        assessment = pilot_assessments.get(target)
+        reference_fit, interleaved_fit = (
+            (assessment.reference.fit, assessment.interleaved.fit)
+            if assessment is not None
+            else (None, None)
+        )
+        selection = selections[target]
+        metadata_by_target[target] = {
+            "mode": "decay_adaptive",
+            "enabled": True,
+            "pilot_grid": pilot_grid.copy(),
+            "candidate_pilot_grid": candidate_grid.copy(),
+            "pilot_n_trials": pilot_n_trials,
+            "pilot_remaining_fraction": remaining_fraction_threshold,
+            "pilot_model": _pilot_model_payload(
+                dimension=contexts[target].target_spec.dimension,
+                unmitigated_two_qubit_readout=(
+                    contexts[target].target_spec.is_two_qubit
+                    and not contexts[target].mitigate_readout
+                ),
+            ),
+            "pilot_p_reference": (
+                reference_fit.decay_parameter if reference_fit is not None else None
+            ),
+            "pilot_p_interleaved": (
+                interleaved_fit.decay_parameter if interleaved_fit is not None else None
+            ),
+            "main_remaining_fractions": main_remaining_fractions,
+            "additional_remaining_fractions_used": (
+                selection.additional_fractions_used
+            ),
+            "supplemental_integer_grid": selection.supplemental_integer_grid.copy(),
+            "candidate_reference_grid": selection.reference_grid.copy(),
+            "candidate_interleaved_grid": selection.interleaved_grid.copy(),
+            "target_candidate_main_grid": selection.selected_grid.copy(),
+            "target_retained_main_grid": retained_by_target[target].copy(),
+            "target_retained_point_count": len(retained_by_target[target]),
+            "selected_main_grid": shared_main_grid.copy(),
+            "parallel_max_points": parallel_max_points,
+            "parallel_retained_point_goal": (_MIN_PARALLEL_RETAINED_POINTS_PER_TARGET),
+            "max_n_cliffords": maximum,
+            "fallback_used": selection.fallback_used,
+            "fallback_reason": selection.fallback_reason,
+            "maximum_anchor_added": selection.maximum_anchor_added,
+            "near_duplicate_merging_applied": (
+                selection.near_duplicate_merging_applied
+            ),
+            "thinning_applied": (selection.thinning_applied or group_thinning_applied),
+            "pilot_stop_reason": stop_reason,
+            "pilot_stop_detail": stop_details[target],
+            "pilot_fit_quality": (
+                _pilot_assessment_payload(assessment)
+                if assessment is not None
+                else None
+            ),
+            "pilot_stage_diagnostics": tuple(stage_diagnostics_by_target[target]),
+            "parallel_shared_grid": True,
+            "pilot_sequence_seed": pilot_sequence_seeds[target],
+            "main_sequence_seed": None,
+            "pilot_acquisition_seed": pilot_acquisition_seed,
+            "main_acquisition_seed": None,
+            "pilot_reference_fit": (
+                _pilot_fit_payload(reference_fit) if reference_fit is not None else None
+            ),
+            "pilot_interleaved_fit": (
+                _pilot_fit_payload(interleaved_fit)
+                if interleaved_fit is not None
+                else None
+            ),
+            "pilot_raw_result": pilot_payloads[target],
+        }
+    return _ParallelAutoRangeOutcome(
+        selected_main_grid=shared_main_grid,
+        metadata_by_target=metadata_by_target,
+    )
+
+
+# -----------------------------------------------------------------------------
+# High-level workflow orchestration and reporting
+# -----------------------------------------------------------------------------
+
+
+def _fixed_range_metadata(
+    n_cliffords: NDArray[np.int64],
+    *,
+    stop_reason: Literal["explicit_range", "auto_range_disabled"],
+) -> dict[str, object]:
+    """Return high-level range metadata when no pilot was required."""
+    return {
+        "mode": ("explicit" if stop_reason == "explicit_range" else "power_of_two"),
+        "enabled": False,
+        "pilot_grid": np.asarray([], dtype=np.int64),
+        "candidate_pilot_grid": np.asarray([], dtype=np.int64),
+        "pilot_n_trials": None,
+        "pilot_remaining_fraction": None,
+        "pilot_model": None,
+        "pilot_p_reference": None,
+        "pilot_p_interleaved": None,
+        "main_remaining_fractions": None,
+        "additional_remaining_fractions_used": (),
+        "supplemental_integer_grid": np.asarray([], dtype=np.int64),
+        "candidate_reference_grid": np.asarray([], dtype=np.int64),
+        "candidate_interleaved_grid": np.asarray([], dtype=np.int64),
+        "selected_main_grid": n_cliffords.copy(),
+        "max_n_cliffords": int(n_cliffords[-1]),
+        "fallback_used": False,
+        "fallback_reason": None,
+        "maximum_anchor_added": False,
+        "near_duplicate_merging_applied": False,
+        "thinning_applied": False,
+        "pilot_stop_reason": stop_reason,
+        "pilot_stop_detail": None,
+        "pilot_fit_quality": None,
+        "pilot_stage_diagnostics": (),
+        "pilot_reference_fit": None,
+        "pilot_interleaved_fit": None,
+        "pilot_raw_result": None,
+    }
+
+
+def _validate_serial_explicit_seed_matrices(
+    targets: tuple[str, ...],
+    *,
+    contexts: Mapping[str, _SingleAcquisitionContext],
+    seeds_by_target: Mapping[str, ArrayLike | None],
+    n_cliffords_range: ArrayLike | None,
+    n_trials: int,
+    max_n_cliffords: int | None,
+) -> None:
+    """Validate every serial seed matrix before the first hardware call."""
+    for target in targets:
+        explicit_seed_matrix = seeds_by_target[target]
+        if explicit_seed_matrix is None:
+            continue
+        target_spec = contexts[target].target_spec
+        resolved_maximum = _resolve_target_maximum(
+            target_spec,
+            max_n_cliffords,
+        )
+        n_cliffords = _resolve_n_cliffords(
+            n_cliffords_range,
+            maximum=resolved_maximum,
+        )
+        _resolve_seed_matrix(
+            explicit_seed_matrix,
+            shape=(len(n_cliffords), n_trials),
+            sequence_seed=None,
+        )
+
+
+def _log_paired_irb_summary(target: str, payload: Mapping[str, object]) -> None:
+    """Log one concise statistical and acquisition summary for a target."""
+    reference_fit = _mapping(
+        _mapping(payload["reference"], name="reference")["fit"],
+        name="reference.fit",
+    )
+    interleaved_fit = _mapping(
+        _mapping(payload["interleaved"], name="interleaved")["fit"],
+        name="interleaved.fit",
+    )
+    bootstrap = _mapping(payload["bootstrap"], name="bootstrap")
+    grid_selection = _mapping(payload["grid_selection"], name="grid_selection")
+    diagnostics = _mapping(payload["diagnostics"], name="diagnostics")
+    gate_fidelity = float(cast(float, payload["gate_fidelity"]))
+    gate_fidelity_error = cast(float | None, payload["gate_fidelity_err"])
+    gate_fidelity_ci95 = cast(
+        tuple[float, float] | None,
+        payload["gate_fidelity_ci95"],
+    )
+    bootstrap_requested = int(cast(int, bootstrap["n_requested"]))
+    bootstrap_correlation = cast(float | None, bootstrap["p_correlation"])
+    bootstrap_parameter_bound_quality = cast(
+        bool | None,
+        bootstrap["parameter_bound_quality_valid"],
+    )
+    resampling_status = (
+        "valid" if cast(bool, bootstrap["resampling_valid"]) else "invalid"
+    )
+    optimizer_status = (
+        "disabled"
+        if bootstrap_requested == 0
+        else "not_run"
+        if cast(bool, bootstrap["execution_skipped"])
+        else "valid"
+        if cast(bool, bootstrap["optimizer_valid"])
+        else "invalid"
+    )
+    correlation_status = (
+        "unavailable"
+        if bootstrap_correlation is None
+        else f"{bootstrap_correlation:.3f}"
+    )
+    parameter_bound_quality_status = (
+        "unavailable"
+        if bootstrap_parameter_bound_quality is None
+        else "valid"
+        if bootstrap_parameter_bound_quality
+        else "invalid"
+    )
+    logger.info("Paired IRB: %s", target)
+    logger.info("p_ref = %.6f", float(cast(float, reference_fit["p"])))
+    logger.info("p_irb = %.6f", float(cast(float, interleaved_fit["p"])))
+    if gate_fidelity_error is None:
+        logger.info("Gate fidelity = %.4f %%", 100.0 * gate_fidelity)
+        logger.info("Statistical uncertainty unavailable")
+    else:
+        logger.info(
+            "Gate fidelity = %.4f ± %.4f %%",
+            100.0 * gate_fidelity,
+            100.0 * gate_fidelity_error,
+        )
+    if gate_fidelity_ci95 is not None:
+        logger.info(
+            "95%% bootstrap CI = [%.4f, %.4f] %%",
+            100.0 * gate_fidelity_ci95[0],
+            100.0 * gate_fidelity_ci95[1],
+        )
+    logger.info(
+        "Bootstrap: requested = %s, attempted = %s, success = %s, "
+        "resampling = %s, optimizer = %s, p_ref/p_irb corr = %s, "
+        "parameter-bound quality = %s",
+        bootstrap_requested,
+        bootstrap["n_attempted"],
+        bootstrap["n_success"],
+        resampling_status,
+        optimizer_status,
+        correlation_status,
+        parameter_bound_quality_status,
+    )
+    logger.info(
+        "Grid selection: mode = %s, selected main grid = %s, pilot stop = %s (%s)",
+        grid_selection["mode"],
+        np.asarray(grid_selection["selected_main_grid"]).tolist(),
+        grid_selection["pilot_stop_reason"],
+        grid_selection.get("pilot_stop_detail"),
+    )
+    warning_messages = cast(Sequence[object], diagnostics["warnings"])
+    if warning_messages:
+        logger.warning(
+            "Paired IRB diagnostics for %s: %s",
+            target,
+            "; ".join(str(message) for message in warning_messages),
+        )
+    if grid_selection["fallback_used"]:
+        logger.warning(
+            "Paired IRB used the pilot-candidate main-grid fallback for %s: %s.",
+            target,
+            grid_selection["fallback_reason"],
+        )
+    if grid_selection["pilot_stop_reason"] == "max_n_cliffords_reached":
+        logger.warning("Paired IRB auto-range maximum reached for %s.", target)
+
+
+def _analyze_workflow_target(
+    raw_result: Result,
+    target: str,
+    *,
+    grid_selection: Mapping[str, object],
+    options: _AnalysisOptions,
+) -> tuple[dict[str, object], go.Figure | None]:
+    """Analyze one target and attach workflow-level grid metadata."""
+    analyzed = _analyze_paired_irb(
+        Result(data={target: raw_result.data[target]}),
+        options=options,
+    )
+    payload = cast(dict[str, object], analyzed.data[target])
+    payload["grid_selection"] = grid_selection
+    _log_paired_irb_summary(target, payload)
+    return payload, analyzed.figure
+
+
+def _run_parallel_workflow(
+    exp: Experiment,
+    targets: tuple[str, ...],
+    *,
+    interleaved_clifford: str | Clifford,
+    interleaved_waveform: _InterleavedOverride,
+    n_cliffords_range: ArrayLike | None,
+    use_auto_range: bool,
+    pilot_n_trials: int,
+    remaining_fraction_threshold: float,
+    main_remaining_fractions: tuple[float, ...],
+    n_trials: int,
+    seeds: ArrayLike | Mapping[str, ArrayLike] | None,
+    sequence_seed: int | None,
+    acquisition_seed: int | None,
+    pairs_per_sweep: int,
+    max_n_cliffords: int | None,
+    x90: _X90Override,
+    zx90: _ZX90Override,
+    mitigate_readout: bool,
+    n_shots: int | None,
+    shot_interval: float | None,
+    time_integration: bool,
+    sweep_timeout: float,
+    analysis_options: _AnalysisOptions,
+) -> Result:
+    """Run fixed-range or adaptive paired IRB with shared parallel points."""
+    target_specs = {target: _resolve_target(exp, target) for target in targets}
+    _validate_parallel_target_specs(target_specs)
+    _validate_multi_target_schedule_overrides(
+        targets,
+        target_specs,
+        interleaved_waveform=interleaved_waveform,
+        zx90=zx90,
+    )
+    contexts = _resolve_target_acquisitions(
+        exp,
+        targets,
+        target_specs,
+        interleaved_clifford=interleaved_clifford,
+        interleaved_waveform=interleaved_waveform,
+        pairs_per_sweep=pairs_per_sweep,
+        x90=x90,
+        zx90=zx90,
+        mitigate_readout=mitigate_readout,
+        n_shots=DEFAULT_SHOTS if n_shots is None else n_shots,
+        shot_interval=DEFAULT_INTERVAL if shot_interval is None else shot_interval,
+        time_integration=time_integration,
+        sweep_timeout=sweep_timeout,
+    )
+    resolved_maximum = _resolve_target_maximum(
+        contexts[targets[0]].target_spec,
+        max_n_cliffords,
+    )
+
+    if use_auto_range:
+        sequence_streams = _split_optional_seed(
+            sequence_seed,
+            count=2 * len(targets),
+            name="sequence_seed",
+        )
+        pilot_sequence_seeds = {
+            target: sequence_streams[2 * index] for index, target in enumerate(targets)
+        }
+        main_sequence_seeds = {
+            target: sequence_streams[2 * index + 1]
+            for index, target in enumerate(targets)
+        }
+        acquisition_streams = _split_optional_seed(
+            acquisition_seed,
+            count=2,
+            name="acquisition_seed",
+        )
+        auto_outcome = _run_parallel_auto_range(
+            exp,
+            targets,
+            contexts=contexts,
+            candidate_grid=_auto_range_candidate_grid(resolved_maximum),
+            maximum=resolved_maximum,
+            pilot_n_trials=pilot_n_trials,
+            remaining_fraction_threshold=remaining_fraction_threshold,
+            main_remaining_fractions=main_remaining_fractions,
+            pilot_sequence_seeds=pilot_sequence_seeds,
+            pilot_acquisition_seed=acquisition_streams[0],
+        )
+        selected_n_cliffords = auto_outcome.selected_main_grid
+        range_metadata = auto_outcome.metadata_by_target
+        main_acquisition_seed = acquisition_streams[1]
+        for target in targets:
+            range_metadata[target]["main_sequence_seed"] = main_sequence_seeds[target]
+            range_metadata[target]["main_acquisition_seed"] = main_acquisition_seed
+    else:
+        selected_n_cliffords = _resolve_n_cliffords(
+            n_cliffords_range,
+            maximum=resolved_maximum,
+        )
+        main_sequence_values = _split_optional_seed(
+            sequence_seed,
+            count=len(targets),
+            name="sequence_seed",
+        )
+        main_sequence_seeds = dict(zip(targets, main_sequence_values, strict=True))
+        main_acquisition_seed = _validate_optional_rng_seed(
+            acquisition_seed,
+            name="acquisition_seed",
+        )
+        stop_reason = (
+            "explicit_range" if n_cliffords_range is not None else "auto_range_disabled"
+        )
+        range_metadata = {
+            target: _fixed_range_metadata(
+                selected_n_cliffords,
+                stop_reason=stop_reason,
+            )
+            for target in targets
+        }
+
+    explicit_seeds = _explicit_seeds_by_target(seeds, targets=targets)
+    main_seeds_by_target = {
+        target: _resolve_seed_matrix(
+            explicit_seeds[target],
+            shape=(len(selected_n_cliffords), n_trials),
+            sequence_seed=main_sequence_seeds[target],
+        )
+        for target in targets
+    }
+    raw_result = _run_parallel_acquisition(
+        exp,
+        targets,
+        contexts=contexts,
+        n_cliffords=selected_n_cliffords,
+        seeds_by_target=main_seeds_by_target,
+        sequence_seeds=main_sequence_seeds,
+        acquisition_seed=main_acquisition_seed,
+    )
+    data: dict[str, object] = {}
+    figures: dict[str, go.Figure] = {}
+    for target in targets:
+        target_payload, figure = _analyze_workflow_target(
+            raw_result,
+            target,
+            grid_selection=range_metadata[target],
+            options=analysis_options,
+        )
+        data[target] = target_payload
+        if figure is not None:
+            figures[target] = figure
+    primary_figure = figures.get(targets[0]) if len(targets) == 1 else None
+    return Result(data=data, figure=primary_figure, figures=figures or None)
+
+
+def _run_serial_workflow(
+    exp: Experiment,
+    targets: tuple[str, ...],
+    *,
+    interleaved_clifford: str | Clifford,
+    interleaved_waveform: _InterleavedOverride,
+    n_cliffords_range: ArrayLike | None,
+    use_auto_range: bool,
+    pilot_n_trials: int,
+    remaining_fraction_threshold: float,
+    main_remaining_fractions: tuple[float, ...],
+    n_trials: int,
+    seeds: ArrayLike | Mapping[str, ArrayLike] | None,
+    sequence_seed: int | None,
+    acquisition_seed: int | None,
+    pairs_per_sweep: int,
+    max_n_cliffords: int | None,
+    x90: _X90Override,
+    zx90: _ZX90Override,
+    mitigate_readout: bool,
+    n_shots: int | None,
+    shot_interval: float | None,
+    time_integration: bool,
+    sweep_timeout: float,
+    analysis_options: _AnalysisOptions,
+) -> Result:
+    """Run fixed-range or adaptive paired IRB independently by target."""
+    target_specs = {target: _resolve_target(exp, target) for target in targets}
+    _validate_multi_target_schedule_overrides(
+        targets,
+        target_specs,
+        interleaved_waveform=interleaved_waveform,
+        zx90=zx90,
+    )
+    contexts = _resolve_target_acquisitions(
+        exp,
+        targets,
+        target_specs,
+        interleaved_clifford=interleaved_clifford,
+        interleaved_waveform=interleaved_waveform,
+        pairs_per_sweep=pairs_per_sweep,
+        x90=x90,
+        zx90=zx90,
+        mitigate_readout=mitigate_readout,
+        n_shots=DEFAULT_SHOTS if n_shots is None else n_shots,
+        shot_interval=DEFAULT_INTERVAL if shot_interval is None else shot_interval,
+        time_integration=time_integration,
+        sweep_timeout=sweep_timeout,
+    )
+    seeds_by_target = _explicit_seeds_by_target(seeds, targets=targets)
+    streams_per_target = 2 if use_auto_range else 1
+    sequence_streams = _split_optional_seed(
+        sequence_seed,
+        count=len(targets) * streams_per_target,
+        name="sequence_seed",
+    )
+    acquisition_streams = _split_optional_seed(
+        acquisition_seed,
+        count=len(targets) * streams_per_target,
+        name="acquisition_seed",
+    )
+    if seeds is not None:
+        _validate_serial_explicit_seed_matrices(
+            targets,
+            contexts=contexts,
+            seeds_by_target=seeds_by_target,
+            n_cliffords_range=n_cliffords_range,
+            n_trials=n_trials,
+            max_n_cliffords=max_n_cliffords,
+        )
+
+    data: dict[str, object] = {}
+    figures: dict[str, go.Figure] = {}
+    for target_index, target in enumerate(targets):
+        context = contexts[target]
+        stream_start = target_index * streams_per_target
+        if use_auto_range:
+            pilot_sequence_seed = sequence_streams[stream_start]
+            main_sequence_seed = sequence_streams[stream_start + 1]
+            pilot_acquisition_seed = acquisition_streams[stream_start]
+            main_acquisition_seed = acquisition_streams[stream_start + 1]
+            resolved_maximum = _resolve_target_maximum(
+                context.target_spec,
+                max_n_cliffords,
+            )
+            auto_range_outcome = _run_single_target_auto_range(
+                exp,
+                target,
+                context=context,
+                candidate_grid=_auto_range_candidate_grid(resolved_maximum),
+                maximum=resolved_maximum,
+                pilot_n_trials=pilot_n_trials,
+                remaining_fraction_threshold=remaining_fraction_threshold,
+                main_remaining_fractions=main_remaining_fractions,
+                pilot_sequence_seed=pilot_sequence_seed,
+                pilot_acquisition_seed=pilot_acquisition_seed,
+            )
+            selected_n_cliffords = auto_range_outcome.selected_main_grid
+            range_metadata = auto_range_outcome.metadata
+            range_metadata["main_sequence_seed"] = main_sequence_seed
+            range_metadata["main_acquisition_seed"] = main_acquisition_seed
+        else:
+            main_sequence_seed = sequence_streams[stream_start]
+            main_acquisition_seed = acquisition_streams[stream_start]
+            resolved_maximum = _resolve_target_maximum(
+                context.target_spec,
+                max_n_cliffords,
+            )
+            selected_n_cliffords = _resolve_n_cliffords(
+                n_cliffords_range,
+                maximum=resolved_maximum,
+            )
+            range_metadata = _fixed_range_metadata(
+                selected_n_cliffords,
+                stop_reason=(
+                    "explicit_range"
+                    if n_cliffords_range is not None
+                    else "auto_range_disabled"
+                ),
+            )
+
+        main_seeds = _resolve_seed_matrix(
+            seeds_by_target[target],
+            shape=(len(selected_n_cliffords), n_trials),
+            sequence_seed=main_sequence_seed,
+        )
+        raw_result = _run_single_target_acquisition(
+            exp,
+            target,
+            context=context,
+            n_cliffords=selected_n_cliffords,
+            seeds=main_seeds,
+            sequence_seed=main_sequence_seed,
+            acquisition_seed=main_acquisition_seed,
+        )
+        target_payload, figure = _analyze_workflow_target(
+            raw_result,
+            target,
+            grid_selection=range_metadata,
+            options=analysis_options,
+        )
+        data[target] = target_payload
+        if figure is not None:
+            figures[target] = figure
+
+    primary_figure = figures.get(targets[0]) if len(targets) == 1 else None
+    return Result(data=data, figure=primary_figure, figures=figures or None)
+
+
+def paired_interleaved_randomized_benchmarking(
+    exp: Experiment,
+    targets: Sequence[str] | str,
+    *,
+    interleaved_clifford: str | Clifford,
+    interleaved_waveform: (
+        Waveform | PulseSchedule | TargetMap[Waveform | PulseSchedule] | None
+    ) = None,
+    n_cliffords_range: ArrayLike | None = None,
+    auto_range: bool = True,
+    pilot_n_trials: int = 6,
+    auto_range_remaining_fraction: float = 0.2,
+    main_remaining_fractions: Collection[float] = _DEFAULT_MAIN_REMAINING_FRACTIONS,
+    n_trials: int | None = None,
+    seeds: ArrayLike | Mapping[str, ArrayLike] | None = None,
+    sequence_seed: int | None = None,
+    acquisition_seed: int | None = _DEFAULT_ACQUISITION_SEED,
+    bootstrap_seed: int | None = _DEFAULT_BOOTSTRAP_SEED,
+    n_bootstrap: int = _DEFAULT_BOOTSTRAP_SAMPLES,
+    pairs_per_sweep: int = _DEFAULT_PAIRS_PER_SWEEP,
+    max_n_cliffords: int | None = None,
+    x90: Waveform | TargetMap[Waveform] | None = None,
+    zx90: PulseSchedule | TargetMap[PulseSchedule] | None = None,
+    mitigate_readout: bool = True,
+    in_parallel: bool = False,
+    n_shots: int | None = None,
+    shot_interval: float | None = None,
+    time_integration: bool = True,
+    sweep_timeout: float = _DEFAULT_SWEEP_TIMEOUT_SECONDS,
+    sem_floor: float | None = None,
+    error_bar: Literal["sem", "std"] | None = "sem",
+    plot: bool | None = None,
+    save_image: bool | None = None,
+) -> Result:
+    """
+    Measure and analyze paired IRB for one or more targets.
+
+    This high-level workflow adds serial or parallel multi-target orchestration
+    and optional pilot-based range selection around the single-target paired
+    acquisition and analysis primitives.
+
+    Parameters
+    ----------
+    exp : Experiment
+        Configured Qubex experiment.
+    targets : Sequence[str] | str
+        One target label or a nonempty ordered sequence of distinct 1Q or CR
+        target labels. Sequence order determines RNG-stream assignment, serial
+        execution, and result order. Sets and frozensets are rejected.
+    interleaved_clifford : str | Clifford
+        Clifford inserted in the interleaved arm.
+    interleaved_waveform : Waveform | PulseSchedule | TargetMap | None, optional
+        Optional physical implementation of the interleaved gate. A 1Q target
+        accepts a `Waveform` or a target-containing `PulseSchedule`; a 2Q
+        target requires a `PulseSchedule`. A target map is resolved strictly by
+        target, and every requested target must be present. A single
+        `PulseSchedule` is rejected for multi-target calls because schedules are
+        target-specific. Required when the RB sequence builder cannot infer the
+        implementation from `interleaved_clifford`.
+    n_cliffords_range : ArrayLike | None, optional
+        Explicit, strictly increasing Clifford-length grid shared by both arms.
+        At least four lengths are required. When supplied, it takes precedence
+        over `auto_range` and is mutually exclusive with `max_n_cliffords`.
+    auto_range : bool, optional
+        When `True` and no explicit range is supplied, use a paired pilot to
+        select a fresh main-measurement grid. The pilot uses an unweighted
+        two-parameter decay fit with `C=1/d`, an R-squared threshold of 0.5,
+        and the observed-decay safeguard. When `False`, measure the complete
+        power-of-two grid not exceeding `max_n_cliffords`. Defaults to `True`.
+    pilot_n_trials : int, optional
+        Paired trials per pilot length. When auto-range is active, this must be
+        at least 4 and pilot stopping is not evaluated until at least six
+        Clifford lengths are available. Ignored when no pilot is run. Defaults
+        to 6.
+    auto_range_remaining_fraction : float, optional
+        Auto-range stopping threshold strictly between 0 and 1. The pilot stops
+        when `max(p_ref**m, p_irb**m)` is no greater than this value at its
+        current maximum length, both fits are valid, and both arms have endpoint
+        decay significance of at least 3. Ignored when no pilot is run. Defaults
+        to 0.2.
+    main_remaining_fractions : Collection[float], optional
+        Ordered, strictly decreasing contrast fractions used to place the main
+        Clifford lengths for both fitted decay parameters while auto-range is
+        active. Sets and frozensets are rejected. Ignored when no pilot is run.
+        Defaults to `(0.90, 0.70, 0.50, 0.30, 0.15)`.
+    n_trials : int | None, optional
+        Paired trials per main-measurement length. Must be at least 2 and
+        defaults to 30. Two or three trials permit the point estimate but not
+        primary AB/BA-stratified bootstrap uncertainty.
+    seeds : ArrayLike | Mapping[str, ArrayLike] | None, optional
+        Explicit uint32 main seed matrix with shape `(n_lengths, n_trials)`. A
+        multi-target call requires one matrix per target. Explicit matrices are
+        not allowed with active auto-range because the selected length count is
+        initially unknown.
+    sequence_seed : int | None, optional
+        Master seed for deterministic target-specific seed matrices. Auto-range
+        splits it into independent pilot and main streams. Mutually exclusive
+        with `seeds`. `None` generates fresh matrices.
+    acquisition_seed : int | None, optional
+        Master seed for global pair order and balanced AB/BA order. Auto-range
+        splits it into independent pilot and main streams. `None` draws fresh
+        randomized orders.
+    bootstrap_seed : int | None, optional
+        Paired-bootstrap RNG seed. Defaults to 0.
+    n_bootstrap : int, optional
+        Bootstrap replicate count. Defaults to 2000. At least two successful
+        replicates, an 80% success rate, and two samples in every AB/BA stratum
+        are required to report primary uncertainty.
+    pairs_per_sweep : int, optional
+        Complete adjacent pairs submitted per measurement call. The backend
+        controls physical batching within the call. Defaults to 1.
+    max_n_cliffords : int | None, optional
+        Exact final pilot candidate for auto-range, or an upper bound for the
+        fixed power-of-two grid when auto-range is disabled. Mutually exclusive
+        with an explicit range. Active auto-range requires this ceiling to
+        produce at least six pilot lengths (the smallest accepted value is 9).
+        Defaults to the target-specific experiment constant.
+    x90 : Waveform | TargetMap[Waveform] | None, optional
+        Optional pi/2 pulse override. A 1Q target map is resolved by target. For
+        a CR target, the physical-qubit map is passed intact to the RB sequence
+        builder.
+    zx90 : PulseSchedule | TargetMap[PulseSchedule] | None, optional
+        Optional ZX90 schedule override. A target map is resolved strictly by CR
+        target, and every requested CR target must be present. A single schedule
+        is accepted for one CR target but rejected when more than one CR target
+        is requested. The value is ignored for 1Q sequence construction.
+    mitigate_readout : bool, optional
+        Apply fixed readout mitigation for 2Q survival. Ignored for 1Q. Defaults
+        to `True`. With `False`, asymmetric assignment errors can shift the
+        observed pilot asymptote away from its fixed approximation `C=0.25`.
+    in_parallel : bool, optional
+        Execute every target in each shared measurement point. Parallel groups
+        must contain only 1Q targets or only disjoint 2Q targets. Their AB/BA
+        order is shared and shorter schedules are left-padded. Shared-grid
+        thinning retains up to six representative points from every target's
+        proposed grid. Defaults to `False` for serial target execution.
+    n_shots : int | None, optional
+        Shots per sweep point. Defaults to the experiment constant.
+    shot_interval : float | None, optional
+        Shot interval in ns. Defaults to the experiment constant.
+    time_integration : bool, optional
+        Integrate readout data over time. Defaults to `True`.
+    sweep_timeout : float, optional
+        Timeout in seconds for each sweep chunk. Defaults to 300 seconds.
+    sem_floor : float | None, optional
+        Common positive SEM floor for both weighted main fits. It does not
+        affect the unweighted pilot fit. With the default `None`, use 25% of the
+        paired median positive SEM, or 0.001 if every SEM is zero. Pass a
+        positive value to override the automatic floor. If it replaces every
+        empirical SEM, covariance-derived fidelity uncertainty is unavailable.
+    error_bar : {"sem", "std"} | None, optional
+        Optional figure error bars. Use `None` to disable them. Defaults to
+        `"sem"`.
+    plot : bool | None, optional
+        Display each result figure. `None` preserves the legacy-facing default
+        of `True`; explicit `False` disables display.
+    save_image : bool | None, optional
+        Save each result figure through Qubex visualization. `None` preserves
+        the legacy-facing default of `True`; explicit `False` disables saving.
+
+    Returns
+    -------
+    Result
+        Target-keyed paired raw data, fits, fidelities, uncertainty, range
+        metadata, and diagnostics. `figures` contains target-keyed figures when
+        plotting or saving is enabled.
+
+    Raises
+    ------
+    TypeError
+        Raised when an argument has an incompatible type.
+    ValueError
+        Raised when a measurement or analysis option is invalid.
+    TimeoutError
+        Raised when a measurement sweep chunk times out.
+    RuntimeError
+        Raised when measurement data are invalid or full-data fitting fails.
+
+    Notes
+    -----
+    Auto-range measures an incremental paired pilot at zero, powers of two, and
+    the exact non-power-of-two exploration ceiling when needed. It maps the
+    requested remaining-contrast fractions through both fitted decay parameters,
+    then performs a fresh main acquisition on the resulting grid.
+    Pilot trials are retained under `grid_selection["pilot_raw_result"]` but
+    never enter the main fit or bootstrap. Serial targets choose grids
+    independently; parallel targets use the processed union of all target
+    grids.
+
+    The pilot-only fixed-offset model assumes asymptotic survival `1/d`. For
+    unmitigated 2Q readout, asymmetric assignment errors can make the observed
+    asymptote differ from 0.25. This approximation selects the main grid only;
+    the final main fit keeps `C` free.
+
+    This function performs hardware acquisition and resets the AWG and capture
+    units for each serial acquisition or parallel acquisition stage. A target
+    failure is raised immediately; use the legacy benchmark-suite wrappers when
+    best-effort continuation across targets is required. Use `measure_paired_irb`
+    and `analyze_paired_irb` separately for side-effect-free reanalysis.
+
+    The default `pairs_per_sweep=1` is conservative pending 1Q and 2Q hardware
+    benchmarks. Increase it to reduce measurement-service calls when longer
+    sweep chunks are acceptable.
+    """
+    resolved_targets = _normalize_targets(targets)
+    _validate_range_choice(n_cliffords_range, max_n_cliffords)
+    resolved_auto_range = _validate_boolean(auto_range, name="auto_range")
+    resolved_in_parallel = _validate_boolean(in_parallel, name="in_parallel")
+    resolved_n_trials = _resolve_paired_n_trials(n_trials)
+    use_auto_range = n_cliffords_range is None and resolved_auto_range
+    if use_auto_range:
+        resolved_pilot_trials = _validate_positive_integer(
+            pilot_n_trials,
+            name="pilot_n_trials",
+        )
+        if resolved_pilot_trials < 4:
+            raise ValueError("`pilot_n_trials` must be at least 4.")
+        resolved_remaining_fraction = _validate_open_unit_interval(
+            auto_range_remaining_fraction,
+            name="auto_range_remaining_fraction",
+        )
+        resolved_main_remaining_fractions = _resolve_main_remaining_fractions(
+            main_remaining_fractions
+        )
+    else:
+        # Pilot-only options are intentionally ignored when no pilot is run.
+        resolved_pilot_trials = 6
+        resolved_remaining_fraction = 0.2
+        resolved_main_remaining_fractions = _DEFAULT_MAIN_REMAINING_FRACTIONS
+    if use_auto_range and seeds is not None:
+        raise ValueError("`auto_range=True` cannot be combined with explicit `seeds`.")
+    resolved_plot = True if plot is None else _validate_boolean(plot, name="plot")
+    resolved_save_image = (
+        True if save_image is None else _validate_boolean(save_image, name="save_image")
+    )
+    analysis_options = _resolve_analysis_options(
+        n_bootstrap=n_bootstrap,
+        bootstrap_seed=bootstrap_seed,
+        sem_floor=sem_floor,
+        error_bar=error_bar,
+        plot=resolved_plot,
+        save_image=resolved_save_image,
+    )
+    if seeds is not None and sequence_seed is not None:
+        raise ValueError("Specify only one of `seeds` and `sequence_seed`.")
+    if resolved_in_parallel:
+        return _run_parallel_workflow(
+            exp,
+            resolved_targets,
+            interleaved_clifford=interleaved_clifford,
+            interleaved_waveform=interleaved_waveform,
+            n_cliffords_range=n_cliffords_range,
+            use_auto_range=use_auto_range,
+            pilot_n_trials=resolved_pilot_trials,
+            remaining_fraction_threshold=resolved_remaining_fraction,
+            main_remaining_fractions=resolved_main_remaining_fractions,
+            n_trials=resolved_n_trials,
+            seeds=seeds,
+            sequence_seed=sequence_seed,
+            acquisition_seed=acquisition_seed,
+            pairs_per_sweep=pairs_per_sweep,
+            max_n_cliffords=max_n_cliffords,
+            x90=x90,
+            zx90=zx90,
+            mitigate_readout=mitigate_readout,
+            n_shots=n_shots,
+            shot_interval=shot_interval,
+            time_integration=time_integration,
+            sweep_timeout=sweep_timeout,
+            analysis_options=analysis_options,
+        )
+    return _run_serial_workflow(
+        exp,
+        resolved_targets,
+        interleaved_clifford=interleaved_clifford,
+        interleaved_waveform=interleaved_waveform,
+        n_cliffords_range=n_cliffords_range,
+        use_auto_range=use_auto_range,
+        pilot_n_trials=resolved_pilot_trials,
+        remaining_fraction_threshold=resolved_remaining_fraction,
+        main_remaining_fractions=resolved_main_remaining_fractions,
+        n_trials=resolved_n_trials,
+        seeds=seeds,
+        sequence_seed=sequence_seed,
+        acquisition_seed=acquisition_seed,
+        pairs_per_sweep=pairs_per_sweep,
+        max_n_cliffords=max_n_cliffords,
+        x90=x90,
+        zx90=zx90,
+        mitigate_readout=mitigate_readout,
+        n_shots=n_shots,
+        shot_interval=shot_interval,
+        time_integration=time_integration,
+        sweep_timeout=sweep_timeout,
+        analysis_options=analysis_options,
+    )
+
+
+__all__ = [
+    "analyze_paired_irb",
+    "measure_paired_irb",
+    "paired_interleaved_randomized_benchmarking",
+]

--- a/tests/contrib/paired_interleaved_randomized_benchmarking/test_analysis.py
+++ b/tests/contrib/paired_interleaved_randomized_benchmarking/test_analysis.py
@@ -1,0 +1,1440 @@
+"""Tests for paired interleaved randomized-benchmarking analysis."""
+
+from __future__ import annotations
+
+import importlib
+import warnings
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from qubex.contrib import analyze_paired_irb
+from qubex.experiment.models import Result
+
+
+def _raw_result(
+    reference_trials: np.ndarray,
+    interleaved_trials: np.ndarray,
+    *,
+    n_cliffords: np.ndarray,
+    dimension: int = 2,
+    schema_version: int = 1,
+    first_protocols: np.ndarray | None = None,
+) -> Result:
+    """Build a minimal measurement-only result for analysis tests."""
+    n_trials = reference_trials.shape[1]
+    if first_protocols is None:
+        first_protocols = np.empty((len(n_cliffords), n_trials), dtype="<U11")
+        for length_index in range(len(n_cliffords)):
+            n_reference_first = n_trials // 2 + int(
+                n_trials % 2 == 1 and length_index % 2 == 0
+            )
+            first_protocols[length_index, :n_reference_first] = "reference"
+            first_protocols[length_index, n_reference_first:] = "interleaved"
+    planned_order = tuple(
+        {
+            "length_index": length_index,
+            "trial_index": trial_index,
+            "first_protocol": str(first_protocols[length_index, trial_index]),
+        }
+        for length_index in range(len(n_cliffords))
+        for trial_index in range(n_trials)
+    )
+    return Result(
+        data={
+            "Q0": {
+                "reference": {"trials": reference_trials},
+                "interleaved": {"trials": interleaved_trials},
+                "acquisition": {
+                    "n_cliffords": n_cliffords,
+                    "n_trials": n_trials,
+                    "n_shots": 1_000,
+                    "seeds": np.arange(
+                        len(n_cliffords) * n_trials,
+                        dtype=np.int64,
+                    ).reshape(len(n_cliffords), n_trials),
+                    "planned_order": planned_order,
+                },
+                "metadata": {
+                    "schema_version": schema_version,
+                    "dimension": dimension,
+                    "interleaved_clifford": "X90",
+                },
+            }
+        }
+    )
+
+
+def test_identical_paired_trials_produce_unit_fidelity_and_zero_uncertainty() -> None:
+    """Identical paired data should yield unit fidelity in every bootstrap fit."""
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    mean = 0.46 * 0.97**n_cliffords + 0.5
+    offsets = np.linspace(-0.006, 0.006, 20)
+    trials = mean[:, None] + offsets[None, :]
+    raw = _raw_result(trials, trials.copy(), n_cliffords=n_cliffords)
+
+    result = analyze_paired_irb(raw, n_bootstrap=40, bootstrap_seed=123)
+
+    target = result["Q0"]
+    assert target["gate_fidelity"] == pytest.approx(1.0, abs=1e-12)
+    assert target["gate_fidelity_err"] == pytest.approx(0.0, abs=1e-12)
+    assert target["gate_fidelity_ci68"] == pytest.approx((1.0, 1.0), abs=1e-12)
+    assert target["gate_fidelity_ci95"] == pytest.approx((1.0, 1.0), abs=1e-12)
+    assert target["bootstrap"]["n_success"] == 40
+    assert target["bootstrap"]["valid"] is True
+    assert target["bootstrap"]["parameter_bound_quality_valid"] is True
+    assert target["bootstrap"]["resampling_method"] == "ab_ba_stratified_paired"
+    assert target["bootstrap"]["stratum_counts"] == (
+        {"reference_first": 10, "interleaved_first": 10},
+    ) * len(n_cliffords)
+
+
+def test_weighted_fit_recovers_known_synthetic_gate_fidelity() -> None:
+    """Weighted full-data fits should recover a known synthetic IRB fidelity."""
+    rng = np.random.default_rng(7)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16, 32, 64], dtype=np.int64)
+    n_trials = 30
+    p_reference = 0.985
+    p_interleaved = 0.955
+    paired_noise = rng.normal(0.0, 0.002, size=(len(n_cliffords), n_trials))
+    reference = 0.47 * p_reference ** n_cliffords[:, None] + 0.49 + paired_noise
+    interleaved = 0.46 * p_interleaved ** n_cliffords[:, None] + 0.50 + paired_noise
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+    expected = 1.0 - 0.5 * (1.0 - p_interleaved / p_reference)
+
+    result = analyze_paired_irb(raw, n_bootstrap=30, bootstrap_seed=9)
+
+    target = result["Q0"]
+    assert target["gate_fidelity"] == pytest.approx(expected, abs=2e-3)
+    assert target["reference"]["std"].shape == n_cliffords.shape
+    assert target["reference"]["sem"].shape == n_cliffords.shape
+    np.testing.assert_allclose(
+        target["reference"]["std"],
+        np.std(reference, axis=1, ddof=1),
+    )
+    np.testing.assert_allclose(
+        target["reference"]["sem"],
+        np.std(reference, axis=1, ddof=1) / np.sqrt(n_trials),
+    )
+    assert target["reference"]["fit"]["absolute_sigma"] is True
+
+
+def _evaluate_noisy_grid_design(
+    grid: np.ndarray,
+    *,
+    n_trials: int,
+    p_reference: float,
+    p_interleaved: float,
+    n_repeats: int,
+    data_seed: int,
+    bootstrap_seed: int,
+) -> dict[str, float]:
+    """Return deterministic Monte Carlo precision and cost metrics for one grid."""
+    expected_fidelity = 1.0 - 0.5 * (1.0 - p_interleaved / p_reference)
+    p_reference_estimates = []
+    p_interleaved_estimates = []
+    fidelity_estimates = []
+    bootstrap_sigmas = []
+    coverage = []
+    for repeat in range(n_repeats):
+        rng = np.random.default_rng(data_seed + repeat)
+        shape = (len(grid), n_trials)
+        paired_noise = rng.normal(0.0, 0.004, size=shape)
+        reference_noise = rng.normal(0.0, 0.002, size=shape)
+        interleaved_noise = rng.normal(0.0, 0.002, size=shape)
+        reference = (
+            0.48 * p_reference ** grid[:, None] + 0.50 + paired_noise + reference_noise
+        )
+        interleaved = (
+            0.48 * p_interleaved ** grid[:, None]
+            + 0.50
+            + paired_noise
+            + interleaved_noise
+        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", RuntimeWarning)
+            result = analyze_paired_irb(
+                _raw_result(reference, interleaved, n_cliffords=grid),
+                n_bootstrap=30,
+                bootstrap_seed=bootstrap_seed + repeat,
+            )["Q0"]
+        p_reference_estimates.append(result["reference"]["fit"]["p"])
+        p_interleaved_estimates.append(result["interleaved"]["fit"]["p"])
+        fidelity_estimates.append(result["gate_fidelity"])
+        if result["gate_fidelity_err"] is not None:
+            bootstrap_sigmas.append(result["gate_fidelity_err"])
+        ci95 = result["gate_fidelity_ci95"]
+        if ci95 is not None:
+            coverage.append(float(ci95[0] <= expected_fidelity <= ci95[1]))
+    return {
+        "p_reference_bias": float(np.mean(p_reference_estimates) - p_reference),
+        "p_interleaved_bias": float(np.mean(p_interleaved_estimates) - p_interleaved),
+        "fidelity_bias": float(np.mean(fidelity_estimates) - expected_fidelity),
+        "fidelity_sd": float(np.std(fidelity_estimates, ddof=1)),
+        "bootstrap_sigma": float(np.mean(bootstrap_sigmas)),
+        "ci95_coverage": float(np.mean(coverage)),
+        "n_lengths": float(len(grid)),
+        "measurement_pairs": float(len(grid) * n_trials),
+        "sequence_cost": float(2 * n_trials * np.sum(grid)),
+    }
+
+
+def test_decay_adapted_grid_improves_high_fidelity_precision_at_equal_budget() -> None:
+    """Adaptive long-length placement should improve noisy high-fidelity fits."""
+    fixed_grid = np.asarray(
+        [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048],
+        dtype=np.int64,
+    )
+    adaptive_grid = np.asarray(
+        [0, 1, 105, 211, 356, 703, 1203, 1386, 1896, 2048],
+        dtype=np.int64,
+    )
+    design_options = {
+        "p_reference": 0.9995,
+        "p_interleaved": 0.9990,
+        "n_repeats": 16,
+        "data_seed": 10_000,
+        "bootstrap_seed": 20_000,
+    }
+    fixed = _evaluate_noisy_grid_design(
+        fixed_grid,
+        n_trials=24,
+        **design_options,
+    )
+    adaptive = _evaluate_noisy_grid_design(
+        adaptive_grid,
+        n_trials=31,
+        **design_options,
+    )
+    assert abs(adaptive["p_reference_bias"]) < 5e-6
+    assert abs(adaptive["p_interleaved_bias"]) < 5e-6
+    assert abs(adaptive["fidelity_bias"]) < 3e-6
+    assert adaptive["fidelity_sd"] < 0.8 * fixed["fidelity_sd"]
+    assert adaptive["bootstrap_sigma"] < fixed["bootstrap_sigma"]
+    assert adaptive["ci95_coverage"] >= fixed["ci95_coverage"]
+    assert adaptive["ci95_coverage"] >= 0.8
+    assert abs(adaptive["measurement_pairs"] - fixed["measurement_pairs"]) <= 2
+    assert adaptive["n_lengths"] < fixed["n_lengths"]
+    assert adaptive["sequence_cost"] > fixed["sequence_cost"]
+
+
+def test_parallel_shared_grid_preserves_noisy_multi_scale_precision() -> None:
+    """Shared-grid retention should not degrade noisy fits across decay scales."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    decay_pairs = {
+        "slow": (0.9995, 0.9990),
+        "medium": (0.9950, 0.9900),
+        "fast": (0.9800, 0.9500),
+    }
+    fallback = module._default_n_cliffords(2_048)  # noqa: SLF001
+    selections = {
+        target: module._select_decay_adapted_main_grid(  # noqa: SLF001
+            (
+                SimpleNamespace(decay_parameter=p_reference),
+                SimpleNamespace(decay_parameter=p_interleaved),
+            ),
+            remaining_fractions=(0.90, 0.70, 0.50, 0.30, 0.15),
+            maximum=2_048,
+            fallback_grid=fallback,
+        )
+        for target, (p_reference, p_interleaved) in decay_pairs.items()
+    }
+    shared_grid, retained, _, _ = module._parallel_shared_main_grid(  # noqa: SLF001
+        selections,
+        maximum=2_048,
+    )
+
+    for index, (target, (p_reference, p_interleaved)) in enumerate(decay_pairs.items()):
+        common = {
+            "n_trials": 24,
+            "p_reference": p_reference,
+            "p_interleaved": p_interleaved,
+            "n_repeats": 8,
+            "data_seed": 30_000 + 1_000 * index,
+            "bootstrap_seed": 40_000 + 1_000 * index,
+        }
+        independent = _evaluate_noisy_grid_design(
+            selections[target].selected_grid,
+            **common,
+        )
+        shared = _evaluate_noisy_grid_design(shared_grid, **common)
+
+        assert len(retained[target]) == 6
+        assert abs(shared["p_reference_bias"]) < 2e-4
+        assert abs(shared["p_interleaved_bias"]) < 2e-4
+        assert abs(shared["fidelity_bias"]) < 2e-4
+        assert shared["fidelity_sd"] <= 1.5 * independent["fidelity_sd"]
+        assert shared["bootstrap_sigma"] <= 1.5 * independent["bootstrap_sigma"]
+
+
+def test_default_contrast_set_balances_precision_coverage_and_sequence_cost() -> None:
+    """Default set A should be a balanced choice among the requested designs."""
+    grids = {
+        "A": np.asarray(
+            [0, 1, 10, 21, 35, 70, 120, 138, 189, 240, 378],
+            dtype=np.int64,
+        ),
+        "B": np.asarray(
+            [0, 1, 10, 21, 29, 51, 57, 79, 102, 120, 160, 240, 321],
+            dtype=np.int64,
+        ),
+        "C": np.asarray(
+            [0, 1, 22, 45, 51, 91, 102, 160, 183, 229, 321, 459],
+            dtype=np.int64,
+        ),
+    }
+    trials = {"A": 28, "B": 24, "C": 26}
+    metrics = {
+        name: _evaluate_noisy_grid_design(
+            grid,
+            n_trials=trials[name],
+            p_reference=0.995,
+            p_interleaved=0.990,
+            n_repeats=20,
+            data_seed=30_000,
+            bootstrap_seed=40_000,
+        )
+        for name, grid in grids.items()
+    }
+
+    assert max(abs(item["fidelity_bias"]) for item in metrics.values()) < 2e-6
+    assert min(item["ci95_coverage"] for item in metrics.values()) >= 0.9
+    assert metrics["A"]["fidelity_sd"] < metrics["B"]["fidelity_sd"]
+    assert metrics["A"]["bootstrap_sigma"] < metrics["B"]["bootstrap_sigma"]
+    assert metrics["C"]["fidelity_sd"] < metrics["A"]["fidelity_sd"]
+    assert metrics["B"]["sequence_cost"] < metrics["A"]["sequence_cost"]
+    assert metrics["A"]["sequence_cost"] < metrics["C"]["sequence_cost"]
+    assert (
+        max(item["measurement_pairs"] for item in metrics.values())
+        - min(item["measurement_pairs"] for item in metrics.values())
+        <= 4
+    )
+
+
+def test_two_qubit_analysis_uses_dimension_four_for_fidelity() -> None:
+    """The 2Q result should use d=4 in its point fit and paired bootstrap."""
+    rng = np.random.default_rng(71)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16, 32, 64], dtype=np.int64)
+    p_reference = 0.985
+    p_interleaved = 0.955
+    paired_noise = rng.normal(0.0, 0.002, size=(len(n_cliffords), 30))
+    reference = 0.47 * p_reference ** n_cliffords[:, None] + 0.49 + paired_noise
+    interleaved = 0.46 * p_interleaved ** n_cliffords[:, None] + 0.50 + paired_noise
+    raw = _raw_result(
+        reference,
+        interleaved,
+        n_cliffords=n_cliffords,
+        dimension=4,
+    )
+    expected = 1.0 - 0.75 * (1.0 - p_interleaved / p_reference)
+
+    result = analyze_paired_irb(raw, n_bootstrap=20, bootstrap_seed=19)
+
+    target = result["Q0"]
+    assert target["gate_fidelity"] == pytest.approx(expected, abs=2e-3)
+    assert target["metadata"]["dimension"] == 4
+    assert target["bootstrap"]["n_success"] == 20
+    assert target["bootstrap"]["valid"] is True
+    assert target["gate_fidelity_ci95"] is not None
+
+
+def test_bootstrap_is_reproducible_for_a_fixed_seed() -> None:
+    """Reanalysis should reproduce the complete bootstrap distribution."""
+    rng = np.random.default_rng(2)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    reference = 0.48 * 0.98 ** n_cliffords[:, None] + 0.49
+    reference = reference + rng.normal(0.0, 0.003, size=(6, 20))
+    interleaved = reference - 0.02 * (1.0 - 0.96 ** n_cliffords[:, None])
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    first = analyze_paired_irb(raw, n_bootstrap=25, bootstrap_seed=44)
+    second = analyze_paired_irb(raw, n_bootstrap=25, bootstrap_seed=44)
+
+    np.testing.assert_array_equal(
+        first["Q0"]["bootstrap"]["fidelities"],
+        second["Q0"]["bootstrap"]["fidelities"],
+    )
+    np.testing.assert_array_equal(
+        first["Q0"]["bootstrap"]["p_reference"],
+        second["Q0"]["bootstrap"]["p_reference"],
+    )
+
+
+def test_stratified_resampling_preserves_odd_ab_ba_counts_and_pairing() -> None:
+    """Each resample should retain actual odd stratum counts and paired indices."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    first_protocols = np.asarray(
+        [
+            ["reference", "reference", "interleaved", "reference", "interleaved"],
+            ["interleaved", "reference", "interleaved", "reference", "interleaved"],
+        ]
+    )
+    reference = np.arange(10, dtype=np.float64).reshape(2, 5)
+    interleaved = reference + 100.0
+    rng = np.random.default_rng(17)
+
+    for _ in range(30):
+        indices = module._stratified_paired_resample_indices(  # noqa: SLF001
+            first_protocols,
+            rng=rng,
+        )
+        row_indices = np.arange(2)[:, None]
+
+        np.testing.assert_array_equal(
+            first_protocols[row_indices, indices],
+            first_protocols,
+        )
+        np.testing.assert_array_equal(
+            interleaved[row_indices, indices] - reference[row_indices, indices],
+            np.full((2, 5), 100.0),
+        )
+
+
+def test_bootstrap_reports_actual_odd_ab_ba_counts_from_acquisition() -> None:
+    """Bootstrap metadata should report each length's observed odd stratum counts."""
+    rng = np.random.default_rng(64)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    reference_mean = 0.48 * 0.98**n_cliffords + 0.49
+    interleaved_mean = 0.47 * 0.95**n_cliffords + 0.50
+    noise = rng.normal(0.0, 0.002, size=(6, 5))
+    reference = reference_mean[:, None] + noise
+    interleaved = interleaved_mean[:, None] + noise
+    first_protocols = np.asarray(
+        [
+            ["reference", "reference", "reference", "interleaved", "interleaved"],
+            ["reference", "reference", "interleaved", "interleaved", "interleaved"],
+        ]
+        * 3
+    )
+    raw = _raw_result(
+        reference,
+        interleaved,
+        n_cliffords=n_cliffords,
+        first_protocols=first_protocols,
+    )
+
+    with pytest.warns(RuntimeWarning, match="n_trials"):
+        result = analyze_paired_irb(raw, n_bootstrap=5, bootstrap_seed=4)
+
+    assert (
+        result["Q0"]["bootstrap"]["stratum_counts"]
+        == (
+            {"reference_first": 3, "interleaved_first": 2},
+            {"reference_first": 2, "interleaved_first": 3},
+        )
+        * 3
+    )
+
+
+@pytest.mark.parametrize("n_trials", [2, 3])
+def test_small_ab_ba_strata_do_not_report_primary_uncertainty(
+    n_trials: int,
+) -> None:
+    """Two or three trials should retain the point fit but invalidate resampling."""
+    rng = np.random.default_rng(200 + n_trials)
+    n_cliffords = np.asarray([0, 1, 2, 4, 8, 16, 32, 64], dtype=np.int64)
+    shape = (len(n_cliffords), n_trials)
+    paired_noise = rng.normal(0.0, 0.003, size=shape)
+    reference = (
+        0.48 * 0.98 ** n_cliffords[:, None]
+        + 0.50
+        + paired_noise
+        + rng.normal(0.0, 0.001, size=shape)
+    )
+    interleaved = (
+        0.48 * 0.95 ** n_cliffords[:, None]
+        + 0.50
+        + paired_noise
+        + rng.normal(0.0, 0.001, size=shape)
+    )
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    with pytest.warns(RuntimeWarning) as warning_records:
+        result = analyze_paired_irb(raw, n_bootstrap=20, bootstrap_seed=17)
+
+    target = result["Q0"]
+    bootstrap = target["bootstrap"]
+    assert np.isfinite(target["gate_fidelity"])
+    assert bootstrap["optimizer_valid"] is False
+    assert bootstrap["resampling_valid"] is False
+    assert bootstrap["execution_skipped"] is True
+    assert bootstrap["n_attempted"] == 0
+    assert bootstrap["n_success"] == 0
+    assert bootstrap["valid"] is False
+    assert target["diagnostics"]["bootstrap_optimizer_valid"] is False
+    assert target["diagnostics"]["bootstrap_resampling_valid"] is False
+    assert bootstrap["invalid_reasons"] == ("insufficient_samples_per_stratum",)
+    assert target["gate_fidelity_err"] is None
+    assert target["gate_fidelity_ci68"] is None
+    assert target["gate_fidelity_ci95"] is None
+    assert target["uncertainty_method"] == "paired_bootstrap_resampling_invalid"
+    assert any(
+        "two samples per AB/BA stratum" in str(record.message)
+        for record in warning_records
+    )
+
+
+def test_invalid_bootstrap_resampling_skips_optimizer(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A degenerate AB/BA design must not run meaningless bootstrap fits."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    n_cliffords = np.asarray([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    offsets = np.asarray([-0.002, 0.002])
+    reference = 0.48 * 0.98 ** n_cliffords[:, None] + 0.49 + offsets
+    interleaved = 0.47 * 0.95 ** n_cliffords[:, None] + 0.50 + offsets
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+    original_fit = module._fit_rb_decay  # noqa: SLF001
+    call_count = 0
+
+    def count_fits(*args: Any, **kwargs: Any) -> Any:
+        """Count the two required full-data fits and any unexpected fit."""
+        nonlocal call_count
+        call_count += 1
+        return original_fit(*args, **kwargs)
+
+    monkeypatch.setattr(module, "_fit_rb_decay", count_fits)
+
+    with pytest.warns(RuntimeWarning) as warning_records:
+        result = analyze_paired_irb(raw, n_bootstrap=3, bootstrap_seed=17)
+
+    bootstrap = result["Q0"]["bootstrap"]
+    assert call_count == 2
+    assert bootstrap["execution_skipped"] is True
+    assert bootstrap["n_attempted"] == 0
+    assert bootstrap["n_success"] == 0
+    assert bootstrap["invalid_reasons"] == ("insufficient_samples_per_stratum",)
+    warning_messages = tuple(str(record.message) for record in warning_records)
+    assert any(
+        "two samples per AB/BA stratum" in message for message in warning_messages
+    )
+    assert not any("Fewer than two" in message for message in warning_messages)
+
+
+def test_four_trials_support_non_degenerate_stratified_bootstrap() -> None:
+    """Two samples in each AB/BA stratum should permit varying uncertainty."""
+    rng = np.random.default_rng(204)
+    n_cliffords = np.asarray([0, 1, 2, 4, 8, 16, 32, 64], dtype=np.int64)
+    n_trials = 4
+    shape = (len(n_cliffords), n_trials)
+    paired_noise = rng.normal(0.0, 0.004, size=shape)
+    reference = (
+        0.48 * 0.98 ** n_cliffords[:, None]
+        + 0.50
+        + paired_noise
+        + rng.normal(0.0, 0.002, size=shape)
+    )
+    interleaved = (
+        0.48 * 0.95 ** n_cliffords[:, None]
+        + 0.50
+        + paired_noise
+        + rng.normal(0.0, 0.002, size=shape)
+    )
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    with pytest.warns(RuntimeWarning, match="n_trials"):
+        result = analyze_paired_irb(raw, n_bootstrap=40, bootstrap_seed=19)
+
+    target = result["Q0"]
+    bootstrap = target["bootstrap"]
+    assert bootstrap["stratum_counts"] == (
+        {"reference_first": 2, "interleaved_first": 2},
+    ) * len(n_cliffords)
+    assert bootstrap["optimizer_valid"] is True
+    assert bootstrap["resampling_valid"] is True
+    assert bootstrap["valid"] is True
+    assert target["diagnostics"]["bootstrap_optimizer_valid"] is True
+    assert target["diagnostics"]["bootstrap_resampling_valid"] is True
+    assert bootstrap["invalid_reasons"] == ()
+    assert np.ptp(bootstrap["fidelities"]) > 0.0
+    assert bootstrap["fidelity_std"] > 0.0
+    assert target["gate_fidelity_err"] > 0.0
+    assert target["gate_fidelity_ci95"] is not None
+
+
+def test_stratification_avoids_variance_from_artificial_order_imbalance() -> None:
+    """Stratification should remove variance caused only by changing AB/BA counts."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    first_protocols = np.asarray(
+        [["reference", "reference", "reference", "interleaved", "interleaved"]]
+    )
+    order_effect = np.asarray([[1.0, 1.0, 1.0, 0.0, 0.0]])
+    no_order_effect = np.ones((1, 5), dtype=np.float64)
+    ordinary_rng = np.random.default_rng(91)
+    stratified_rng = np.random.default_rng(91)
+    ordinary_means = []
+    stratified_means = []
+
+    for _ in range(200):
+        ordinary_indices = ordinary_rng.integers(0, 5, size=(1, 5))
+        stratified_indices = module._stratified_paired_resample_indices(  # noqa: SLF001
+            first_protocols,
+            rng=stratified_rng,
+        )
+        ordinary_means.append(float(np.mean(order_effect[:, ordinary_indices[0]])))
+        stratified_means.append(float(np.mean(order_effect[:, stratified_indices[0]])))
+        assert np.mean(no_order_effect[:, ordinary_indices[0]]) == pytest.approx(1.0)
+        assert np.mean(no_order_effect[:, stratified_indices[0]]) == pytest.approx(1.0)
+
+    assert np.var(ordinary_means) > 0.01
+    assert np.var(stratified_means) == pytest.approx(0.0, abs=1e-15)
+
+
+def test_ordinary_and_stratified_resampling_agree_without_order_effect() -> None:
+    """Equivalent AB/BA strata should give comparable bootstrap mean variance."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    first_protocols = np.asarray([[*["reference"] * 15, *["interleaved"] * 15]])
+    shared_values = np.linspace(-1.0, 1.0, 15)
+    no_order_effect = np.asarray([[*shared_values, *shared_values]])
+    ordinary_rng = np.random.default_rng(29)
+    stratified_rng = np.random.default_rng(29)
+    ordinary_means = []
+    stratified_means = []
+
+    for _ in range(2_000):
+        ordinary_indices = ordinary_rng.integers(0, 30, size=(1, 30))
+        stratified_indices = module._stratified_paired_resample_indices(  # noqa: SLF001
+            first_protocols,
+            rng=stratified_rng,
+        )
+        ordinary_means.append(float(np.mean(no_order_effect[:, ordinary_indices[0]])))
+        stratified_means.append(
+            float(np.mean(no_order_effect[:, stratified_indices[0]]))
+        )
+
+    assert np.mean(stratified_means) == pytest.approx(
+        np.mean(ordinary_means),
+        abs=0.01,
+    )
+    assert np.var(stratified_means) == pytest.approx(
+        np.var(ordinary_means),
+        rel=0.1,
+    )
+
+
+def test_analysis_rejects_unpaired_trial_shapes() -> None:
+    """Analysis should reject trial matrices that cannot be paired cell-wise."""
+    n_cliffords = np.array([0, 1, 2, 4], dtype=np.int64)
+    reference = np.full((4, 3), 0.9)
+    interleaved = np.full((4, 2), 0.8)
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    with pytest.raises(ValueError, match="same shape"):
+        analyze_paired_irb(raw, n_bootstrap=10)
+
+
+def test_analysis_rejects_n_trials_metadata_mismatch() -> None:
+    """Recorded trial count must match the paired matrix columns."""
+    n_cliffords = np.array([0, 1, 2, 4], dtype=np.int64)
+    trials = np.full((4, 3), 0.9)
+    raw = _raw_result(trials, trials.copy(), n_cliffords=n_cliffords)
+    raw.data["Q0"]["acquisition"]["n_trials"] = 4
+
+    with pytest.raises(ValueError, match=r"n_trials.*columns"):
+        analyze_paired_irb(raw, n_bootstrap=0)
+
+
+def test_analysis_rejects_an_unknown_raw_schema_version() -> None:
+    """Analysis should fail explicitly when the raw schema is unsupported."""
+    n_cliffords = np.array([0, 1, 2, 4], dtype=np.int64)
+    trials = np.full((4, 3), 0.9)
+    raw = _raw_result(
+        trials,
+        trials.copy(),
+        n_cliffords=n_cliffords,
+        schema_version=2,
+    )
+
+    with pytest.raises(ValueError, match=r"schema_version.*2"):
+        analyze_paired_irb(raw, n_bootstrap=0)
+
+
+def test_analysis_rejects_inconsistent_target_dimension_metadata() -> None:
+    """Target kind and Hilbert-space dimension must describe the same system."""
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    offsets = np.linspace(-0.003, 0.003, 20)
+    mean = 0.48 * 0.97**n_cliffords + 0.5
+    trials = mean[:, None] + offsets[None, :]
+    raw = _raw_result(trials, trials.copy(), n_cliffords=n_cliffords, dimension=2)
+    raw.data["Q0"]["metadata"]["is_two_qubit"] = True
+
+    with pytest.raises(ValueError, match=r"dimension.*is_two_qubit"):
+        analyze_paired_irb(raw, n_bootstrap=0)
+
+
+def test_analysis_requires_complete_acquisition_order_metadata() -> None:
+    """Schema-v1 analysis should require one AB/BA label for every trial cell."""
+    n_cliffords = np.array([0, 1, 2, 4], dtype=np.int64)
+    offsets = np.linspace(-0.003, 0.003, 4)
+    mean = 0.48 * 0.97**n_cliffords + 0.5
+    trials = mean[:, None] + offsets[None, :]
+    raw = _raw_result(trials, trials.copy(), n_cliffords=n_cliffords)
+    del raw.data["Q0"]["acquisition"]["planned_order"]
+
+    with pytest.raises(TypeError, match="planned_order"):
+        analyze_paired_irb(raw, n_bootstrap=0)
+
+
+@pytest.mark.parametrize(
+    "invalid_case",
+    ["wrong_count", "invalid_cell", "duplicate_cell", "invalid_protocol", "imbalanced"],
+)
+def test_analysis_rejects_invalid_acquisition_order_metadata(
+    invalid_case: str,
+) -> None:
+    """Malformed or unbalanced AB/BA metadata should fail before resampling."""
+    n_cliffords = np.array([0, 1, 2, 4], dtype=np.int64)
+    offsets = np.linspace(-0.003, 0.003, 4)
+    mean = 0.48 * 0.97**n_cliffords + 0.5
+    trials = mean[:, None] + offsets[None, :]
+    raw = _raw_result(trials, trials.copy(), n_cliffords=n_cliffords)
+    plan = [dict(pair) for pair in raw.data["Q0"]["acquisition"]["planned_order"]]
+    if invalid_case == "wrong_count":
+        plan.pop()
+    elif invalid_case == "invalid_cell":
+        plan[0]["length_index"] = len(n_cliffords)
+    elif invalid_case == "duplicate_cell":
+        plan[1]["length_index"] = plan[0]["length_index"]
+        plan[1]["trial_index"] = plan[0]["trial_index"]
+    elif invalid_case == "invalid_protocol":
+        plan[0]["first_protocol"] = "unknown"
+    else:
+        for pair in plan[:4]:
+            pair["first_protocol"] = "reference"
+    raw.data["Q0"]["acquisition"]["planned_order"] = plan
+
+    with pytest.raises(ValueError, match=r"planned_order|acquisition-plan|AB/BA"):
+        analyze_paired_irb(raw, n_bootstrap=0)
+
+
+@pytest.mark.parametrize(
+    ("error_bar", "error_type"),
+    [(1, TypeError), ("variance", ValueError)],
+)
+def test_analysis_rejects_invalid_error_bar_values(
+    error_bar: Any,
+    error_type: type[Exception],
+) -> None:
+    """Error-bar type errors and unsupported names should remain distinguishable."""
+    n_cliffords = np.array([0, 1, 2, 4], dtype=np.int64)
+    offsets = np.array([-0.01, 0.0, 0.01])
+    means = 0.48 * 0.97**n_cliffords + 0.5
+    trials = means[:, None] + offsets[None, :]
+    raw = _raw_result(trials, trials.copy(), n_cliffords=n_cliffords)
+
+    with pytest.raises(error_type, match="error_bar"):
+        analyze_paired_irb(
+            raw,
+            n_bootstrap=0,
+            error_bar=error_bar,
+        )
+
+
+def test_automatic_sem_floor_uses_the_paired_empirical_sem_scale() -> None:
+    """Zero-SEM points should receive a finite weight comparable to other points."""
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    offsets = np.linspace(-1.0, 1.0, 20)
+    reference_mean = 0.48 * 0.98**n_cliffords + 0.49
+    interleaved_mean = 0.47 * 0.95**n_cliffords + 0.50
+    reference_scales = np.array([0.0, 0.002, 0.003, 0.004, 0.005, 0.006])
+    interleaved_scales = np.array([0.0, 0.003, 0.004, 0.005, 0.006, 0.007])
+    reference = reference_mean[:, None] + reference_scales[:, None] * offsets
+    interleaved = interleaved_mean[:, None] + interleaved_scales[:, None] * offsets
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+    reference_sem = np.std(reference, axis=1, ddof=1) / np.sqrt(20)
+    interleaved_sem = np.std(interleaved, axis=1, ddof=1) / np.sqrt(20)
+    reference_sem[reference_scales == 0.0] = 0.0
+    interleaved_sem[interleaved_scales == 0.0] = 0.0
+    positive_sem = np.concatenate(
+        (reference_sem[reference_sem > 0], interleaved_sem[interleaved_sem > 0])
+    )
+    expected_floor = 0.25 * float(np.median(positive_sem))
+
+    with pytest.warns(RuntimeWarning, match="SEM floor"):
+        result = analyze_paired_irb(raw, n_bootstrap=0)
+
+    target = result["Q0"]
+    assert target["diagnostics"]["sem_floor"] == pytest.approx(expected_floor)
+    assert target["diagnostics"]["sem_floor_mode"] == "automatic"
+    assert target["reference"]["sem_used"][0] == pytest.approx(expected_floor)
+    assert target["interleaved"]["sem_used"][0] == pytest.approx(expected_floor)
+    assert target["diagnostics"]["sem_floor_applied"] == {
+        "reference": 1,
+        "interleaved": 1,
+    }
+
+
+def test_all_zero_sem_uses_probability_scale_fallback_during_bootstrap() -> None:
+    """Exact rows should fit and bootstrap without machine-epsilon weights."""
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    reference_mean = 0.48 * 0.98**n_cliffords + 0.49
+    interleaved_mean = 0.47 * 0.95**n_cliffords + 0.50
+    reference = np.broadcast_to(reference_mean[:, None], (6, 20)).copy()
+    interleaved = np.broadcast_to(interleaved_mean[:, None], (6, 20)).copy()
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    with pytest.warns(RuntimeWarning) as warning_records:
+        result = analyze_paired_irb(raw, n_bootstrap=20, bootstrap_seed=7)
+
+    assert any("SEM floor" in str(record.message) for record in warning_records)
+    assert any("non-empirical" in str(record.message) for record in warning_records)
+
+    target = result["Q0"]
+    assert target["diagnostics"]["sem_floor"] == pytest.approx(1e-3)
+    assert target["diagnostics"]["sem_floor_applied"] == {
+        "reference": 6,
+        "interleaved": 6,
+    }
+    assert np.all(np.isfinite(target["reference"]["fit"]["predicted"]))
+    assert np.all(np.isfinite(target["interleaved"]["fit"]["predicted"]))
+    assert target["bootstrap"]["n_success"] == 20
+    assert target["bootstrap"]["valid"] is True
+
+
+def test_explicit_sem_floor_is_recorded_as_a_fixed_analysis_option() -> None:
+    """A numeric SEM floor should remain fixed and identifiable in the result."""
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    offsets = np.linspace(-0.002, 0.002, 20)
+    reference_mean = 0.48 * 0.98**n_cliffords + 0.49
+    interleaved_mean = 0.47 * 0.95**n_cliffords + 0.50
+    reference = reference_mean[:, None] + offsets[None, :]
+    interleaved = interleaved_mean[:, None] + offsets[None, :]
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    with pytest.warns(RuntimeWarning) as warning_records:
+        result = analyze_paired_irb(raw, n_bootstrap=5, sem_floor=0.01)
+
+    assert any("SEM floor" in str(record.message) for record in warning_records)
+    assert any("non-empirical" in str(record.message) for record in warning_records)
+
+    diagnostics = result["Q0"]["diagnostics"]
+    assert diagnostics["sem_floor"] == pytest.approx(0.01)
+    assert diagnostics["sem_floor_mode"] == "fixed"
+    assert diagnostics["fit_covariance_scale_empirical"] is False
+    assert diagnostics["gate_fidelity_err_fit_covariance"] is None
+
+
+def test_sem_floor_candidates_are_stable_for_typical_synthetic_data() -> None:
+    """Reasonable SEM floors should agree on typical fit and bootstrap outputs."""
+    rng = np.random.default_rng(2026)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16, 32, 64], dtype=np.int64)
+    n_trials = 30
+    p_reference = 0.985
+    p_interleaved = 0.955
+    reference_mean = 0.47 * p_reference**n_cliffords + 0.49
+    interleaved_mean = 0.46 * p_interleaved**n_cliffords + 0.50
+    noise = rng.normal(size=(len(n_cliffords), n_trials))
+    scales = np.linspace(0.0015, 0.004, len(n_cliffords))[:, None]
+    reference = reference_mean[:, None] + scales * noise
+    interleaved = (
+        interleaved_mean[:, None]
+        + scales * noise
+        + 0.0006 * rng.normal(size=noise.shape)
+    )
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+    combined_sem = np.concatenate(
+        (
+            np.std(reference, axis=1, ddof=1) / np.sqrt(n_trials),
+            np.std(interleaved, axis=1, ddof=1) / np.sqrt(n_trials),
+        )
+    )
+    positive_sem = combined_sem[combined_sem > 0.0]
+    median_sem = float(np.median(positive_sem))
+    candidate_floors = (
+        0.1 * median_sem,
+        0.25 * median_sem,
+        float(np.percentile(positive_sem, 10)),
+        0.5 * median_sem,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        targets = [
+            analyze_paired_irb(
+                raw,
+                n_bootstrap=30,
+                bootstrap_seed=7,
+                sem_floor=floor,
+            )["Q0"]
+            for floor in candidate_floors
+        ]
+
+    p_reference_values = [target["reference"]["fit"]["p"] for target in targets]
+    p_interleaved_values = [target["interleaved"]["fit"]["p"] for target in targets]
+    fidelities = [target["gate_fidelity"] for target in targets]
+    bootstrap_sigmas = [target["gate_fidelity_err"] for target in targets]
+    ci95 = [target["gate_fidelity_ci95"] for target in targets]
+    residual_rms = [
+        float(
+            np.sqrt(
+                np.mean(
+                    np.concatenate(
+                        (
+                            target["reference"]["fit"]["residuals"],
+                            target["interleaved"]["fit"]["residuals"],
+                        )
+                    )
+                    ** 2
+                )
+            )
+        )
+        for target in targets
+    ]
+
+    assert np.ptp(p_reference_values) < 5e-5
+    assert np.ptp(p_interleaved_values) < 5e-5
+    assert np.ptp(fidelities) < 1e-5
+    assert all(value is not None for value in bootstrap_sigmas)
+    assert np.ptp(bootstrap_sigmas) < 1e-5
+    assert all(value is not None for value in ci95)
+    assert np.ptp([value[0] for value in ci95]) < 5e-5
+    assert np.ptp([value[1] for value in ci95]) < 5e-5
+    assert np.ptp(residual_rms) < 5e-6
+
+
+def test_sem_floor_candidates_are_stable_when_only_m_zero_has_zero_sem() -> None:
+    """A zero-SEM origin should not make fit or bootstrap outputs floor-sensitive."""
+    rng = np.random.default_rng(2028)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16, 32, 64], dtype=np.int64)
+    n_trials = 30
+    reference_mean = 0.47 * 0.985**n_cliffords + 0.49
+    interleaved_mean = 0.46 * 0.955**n_cliffords + 0.50
+    noise = rng.normal(size=(len(n_cliffords), n_trials))
+    scales = np.full((len(n_cliffords), 1), 0.003)
+    scales[0] = 0.0
+    reference = reference_mean[:, None] + scales * noise
+    interleaved = interleaved_mean[:, None] + scales * noise
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+    combined_sem = np.concatenate(
+        (
+            np.std(reference, axis=1, ddof=1) / np.sqrt(n_trials),
+            np.std(interleaved, axis=1, ddof=1) / np.sqrt(n_trials),
+        )
+    )
+    positive_sem = combined_sem[combined_sem > 0.0]
+    median_sem = float(np.median(positive_sem))
+    candidate_floors = (
+        0.1 * median_sem,
+        0.25 * median_sem,
+        float(np.percentile(positive_sem, 10)),
+        0.5 * median_sem,
+    )
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        targets = [
+            analyze_paired_irb(
+                raw,
+                n_bootstrap=20,
+                bootstrap_seed=7,
+                sem_floor=floor,
+            )["Q0"]
+            for floor in candidate_floors
+        ]
+
+    assert np.ptp([target["reference"]["fit"]["p"] for target in targets]) < 2e-4
+    assert np.ptp([target["interleaved"]["fit"]["p"] for target in targets]) < 2e-4
+    assert np.ptp([target["gate_fidelity"] for target in targets]) < 1e-5
+    assert np.ptp([target["gate_fidelity_err"] for target in targets]) < 3e-5
+    assert np.ptp([target["gate_fidelity_ci95"][0] for target in targets]) < 1e-4
+    assert np.ptp([target["gate_fidelity_ci95"][1] for target in targets]) < 1e-4
+
+
+def test_conservative_sem_floor_reduces_tiny_sem_point_influence() -> None:
+    """The default floor should reduce bias from one implausibly precise point."""
+    rng = np.random.default_rng(2027)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16, 32, 64], dtype=np.int64)
+    n_trials = 30
+    p_reference = 0.985
+    p_interleaved = 0.955
+    reference_mean = 0.47 * p_reference**n_cliffords + 0.49
+    interleaved_mean = 0.46 * p_interleaved**n_cliffords + 0.50
+    noise = rng.normal(size=(len(n_cliffords), n_trials))
+    scales = np.full((len(n_cliffords), 1), 0.003)
+    scales[2] = 1e-6
+    reference = reference_mean[:, None] + scales * noise
+    interleaved = interleaved_mean[:, None] + scales * noise
+    reference[2] += 0.004
+    interleaved[2] -= 0.004
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+    combined_sem = np.concatenate(
+        (
+            np.std(reference, axis=1, ddof=1) / np.sqrt(n_trials),
+            np.std(interleaved, axis=1, ddof=1) / np.sqrt(n_trials),
+        )
+    )
+    median_sem = float(np.median(combined_sem[combined_sem > 0.0]))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", RuntimeWarning)
+        low_floor = analyze_paired_irb(
+            raw,
+            n_bootstrap=30,
+            bootstrap_seed=7,
+            sem_floor=0.1 * median_sem,
+        )["Q0"]
+        default_floor = analyze_paired_irb(
+            raw,
+            n_bootstrap=30,
+            bootstrap_seed=7,
+        )["Q0"]
+
+    expected_fidelity = 1.0 - 0.5 * (1.0 - p_interleaved / p_reference)
+    low_residual = np.linalg.norm(
+        np.concatenate(
+            (
+                low_floor["reference"]["fit"]["residuals"],
+                low_floor["interleaved"]["fit"]["residuals"],
+            )
+        )
+    )
+    default_residual = np.linalg.norm(
+        np.concatenate(
+            (
+                default_floor["reference"]["fit"]["residuals"],
+                default_floor["interleaved"]["fit"]["residuals"],
+            )
+        )
+    )
+
+    assert default_floor["diagnostics"]["sem_floor"] == pytest.approx(0.25 * median_sem)
+    assert abs(default_floor["gate_fidelity"] - expected_fidelity) < abs(
+        low_floor["gate_fidelity"] - expected_fidelity
+    )
+    assert default_residual < low_residual
+    assert default_floor["gate_fidelity_err"] is not None
+    assert default_floor["gate_fidelity_ci95"] is not None
+
+
+def test_fit_bound_hits_are_reported_without_rejecting_bootstrap_samples(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Bound-hit fits should remain sampled while making fit quality invalid."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    rng = np.random.default_rng(31)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    reference = 0.48 * 0.98 ** n_cliffords[:, None] + 0.49
+    reference = reference + rng.normal(0.0, 0.003, size=(6, 20))
+    interleaved = reference - 0.01 * (1.0 - 0.95 ** n_cliffords[:, None])
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+    original_fit = module._fit_rb_decay  # noqa: SLF001
+    call_count = 0
+
+    def mark_selected_fits_at_bounds(*args: Any, **kwargs: Any) -> Any:
+        """Mark full fits and selected successful bootstrap fits at bounds."""
+        nonlocal call_count
+        call_count += 1
+        fit = original_fit(*args, **kwargs)
+        if call_count == 1:
+            return replace(fit, parameters_at_bound=("A",))
+        if call_count == 2:
+            return replace(fit, parameters_at_bound=("p",))
+        replicate_index = (call_count - 3) // 2
+        is_reference = (call_count - 3) % 2 == 0
+        if is_reference and replicate_index < 6:
+            return replace(fit, parameters_at_bound=("p",))
+        if not is_reference and replicate_index < 4:
+            return replace(fit, parameters_at_bound=("A",))
+        return fit
+
+    monkeypatch.setattr(module, "_fit_rb_decay", mark_selected_fits_at_bounds)
+
+    with pytest.warns(RuntimeWarning) as warning_records:
+        result = analyze_paired_irb(raw, n_bootstrap=20, bootstrap_seed=12)
+
+    target = result["Q0"]
+    bootstrap = target["bootstrap"]
+    diagnostics = target["diagnostics"]
+    assert target["gate_fidelity"] is not None
+    assert target["gate_fidelity_err"] is not None
+    assert bootstrap["n_success"] == 20
+    assert bootstrap["valid"] is True
+    assert bootstrap["parameter_bound_quality_valid"] is False
+    assert bootstrap["parameter_bound_quality_thresholds"] == {
+        "any_bound_fraction_max": 0.10,
+        "p_bound_fraction_max": 0.05,
+    }
+    assert bootstrap["reference_any_bound_count"] == 6
+    assert bootstrap["reference_any_bound_fraction"] == pytest.approx(0.3)
+    assert bootstrap["reference_p_bound_count"] == 6
+    assert bootstrap["reference_p_bound_fraction"] == pytest.approx(0.3)
+    assert bootstrap["interleaved_any_bound_count"] == 4
+    assert bootstrap["interleaved_any_bound_fraction"] == pytest.approx(0.2)
+    assert bootstrap["interleaved_p_bound_count"] == 0
+    assert bootstrap["interleaved_p_bound_fraction"] == pytest.approx(0.0)
+    assert diagnostics["parameter_bound_quality_valid"] is False
+    assert diagnostics["reference_p_at_bound"] is False
+    assert diagnostics["interleaved_p_at_bound"] is True
+    assert diagnostics["bootstrap_parameter_bound_quality_valid"] is False
+    assert any(
+        "bootstrap" in str(record.message) and "bound" in str(record.message)
+        for record in warning_records
+    )
+
+
+def test_bootstrap_skips_failed_fits_and_retains_successful_samples(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A failed bootstrap fit should not discard valid replicates or raw data."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    rng = np.random.default_rng(8)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    trials = 0.47 * 0.97 ** n_cliffords[:, None] + 0.5
+    trials = trials + rng.normal(0.0, 0.003, size=(6, 20))
+    raw = _raw_result(trials, trials - 0.002, n_cliffords=n_cliffords)
+    original_fit = module._fit_rb_decay  # noqa: SLF001
+    call_count = 0
+
+    def fail_first_bootstrap_fit(*args: Any, **kwargs: Any) -> Any:
+        """Fail only the first fit after the two full-data fits."""
+        nonlocal call_count
+        call_count += 1
+        if call_count == 3:
+            raise RuntimeError("synthetic optimizer failure")
+        return original_fit(*args, **kwargs)
+
+    monkeypatch.setattr(module, "_fit_rb_decay", fail_first_bootstrap_fit)
+
+    result = analyze_paired_irb(raw, n_bootstrap=10, bootstrap_seed=1)
+
+    bootstrap = result["Q0"]["bootstrap"]
+    assert bootstrap["n_success"] == 9
+    assert bootstrap["n_failed"] == 1
+    assert bootstrap["fidelities"].shape == (9,)
+
+
+def test_analysis_reports_when_every_bootstrap_fit_fails(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Zero successful replicates should explicitly report unavailable intervals."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    rng = np.random.default_rng(21)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    trials = 0.47 * 0.97 ** n_cliffords[:, None] + 0.5
+    trials = trials + rng.normal(0.0, 0.003, size=(6, 20))
+    raw = _raw_result(trials, trials - 0.002, n_cliffords=n_cliffords)
+    original_fit = module._fit_rb_decay  # noqa: SLF001
+    call_count = 0
+
+    def fail_every_bootstrap_fit(*args: Any, **kwargs: Any) -> Any:
+        """Allow full-data fits and reject all bootstrap fits."""
+        nonlocal call_count
+        call_count += 1
+        if call_count > 2:
+            raise RuntimeError("synthetic optimizer failure")
+        return original_fit(*args, **kwargs)
+
+    monkeypatch.setattr(module, "_fit_rb_decay", fail_every_bootstrap_fit)
+
+    with pytest.warns(RuntimeWarning) as warning_records:
+        result = analyze_paired_irb(raw, n_bootstrap=3, bootstrap_seed=2)
+
+    assert any("Fewer than two" in str(record.message) for record in warning_records)
+    bootstrap_warnings = [
+        record
+        for record in warning_records
+        if "bootstrap replicates" in str(record.message)
+    ]
+    assert len(bootstrap_warnings) == 1
+    target = result["Q0"]
+    assert target["bootstrap"]["n_success"] == 0
+    assert target["gate_fidelity_err"] is None
+    assert target["gate_fidelity_ci95"] is None
+    assert target["uncertainty_method"] == "unavailable"
+    assert target["bootstrap"]["valid"] is False
+    assert target["bootstrap"]["optimizer_valid"] is False
+    assert target["bootstrap"]["parameter_bound_quality_valid"] is None
+
+
+def test_low_bootstrap_success_rate_invalidates_primary_uncertainty(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A selected subset of bootstrap fits must not define primary uncertainty."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    rng = np.random.default_rng(22)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    reference = 0.48 * 0.98 ** n_cliffords[:, None] + 0.49
+    reference = reference + rng.normal(0.0, 0.003, size=(6, 20))
+    interleaved = reference - 0.01 * (1.0 - 0.95 ** n_cliffords[:, None])
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+    original_fit = module._fit_rb_decay  # noqa: SLF001
+    call_count = 0
+
+    def reject_three_bootstrap_replicates(*args: Any, **kwargs: Any) -> Any:
+        """Allow full-data fits, reject three replicates, then allow two."""
+        nonlocal call_count
+        call_count += 1
+        if 3 <= call_count <= 5:
+            raise RuntimeError("synthetic optimizer failure")
+        return original_fit(*args, **kwargs)
+
+    monkeypatch.setattr(module, "_fit_rb_decay", reject_three_bootstrap_replicates)
+    monkeypatch.setattr(module.go.Figure, "show", lambda self: None)
+
+    with pytest.warns(RuntimeWarning, match="80%"):
+        result = analyze_paired_irb(
+            raw,
+            n_bootstrap=5,
+            bootstrap_seed=3,
+            plot=True,
+        )
+
+    target = result["Q0"]
+    assert target["bootstrap"]["n_success"] == 2
+    assert target["bootstrap"]["success_rate"] == pytest.approx(0.4)
+    assert target["bootstrap"]["valid"] is False
+    assert target["bootstrap"]["optimizer_valid"] is False
+    assert target["bootstrap"]["parameter_bound_quality_valid"] is True
+    assert target["bootstrap"]["fidelity_std"] is not None
+    assert target["gate_fidelity_err"] is None
+    assert target["gate_fidelity_ci68"] is None
+    assert target["gate_fidelity_ci95"] is None
+    assert target["uncertainty_method"] == "paired_bootstrap_unreliable"
+    assert result.figure is not None
+    figure: Any = result.figure
+    annotation = figure.layout.annotations[0].text
+    assert "bootstrap σ = unavailable" in annotation
+    assert "95% CI = unavailable" in annotation
+
+
+def test_fidelity_estimates_outside_the_physical_range_are_not_clipped() -> None:
+    """Finite-sample fidelity values above one should remain visible diagnostics."""
+    rng = np.random.default_rng(12)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16, 32, 64], dtype=np.int64)
+    paired_noise = rng.normal(0.0, 0.001, size=(8, 20))
+    reference = 0.47 * 0.96 ** n_cliffords[:, None] + 0.50 + paired_noise
+    interleaved = 0.47 * 0.99 ** n_cliffords[:, None] + 0.50 + paired_noise
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    with pytest.warns(RuntimeWarning, match="not clipped"):
+        result = analyze_paired_irb(raw, n_bootstrap=20, bootstrap_seed=6)
+
+    assert result["Q0"]["gate_fidelity"] > 1.0
+    assert np.any(result["Q0"]["bootstrap"]["fidelities"] > 1.0)
+
+
+def test_one_successful_bootstrap_sample_does_not_define_an_interval() -> None:
+    """A single bootstrap value should not be reported as a confidence interval."""
+    rng = np.random.default_rng(18)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    reference = 0.48 * 0.98 ** n_cliffords[:, None] + 0.49
+    reference = reference + rng.normal(0.0, 0.003, size=(6, 20))
+    interleaved = reference - 0.01 * (1.0 - 0.95 ** n_cliffords[:, None])
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    with pytest.warns(RuntimeWarning, match="Fewer than two"):
+        result = analyze_paired_irb(raw, n_bootstrap=1, bootstrap_seed=4)
+
+    assert result["Q0"]["bootstrap"]["n_success"] == 1
+    assert result["Q0"]["bootstrap"]["valid"] is False
+    assert result["Q0"]["gate_fidelity_err"] is None
+    assert result["Q0"]["uncertainty_method"] == "unavailable"
+
+
+def test_unavailable_fit_covariance_does_not_discard_decay_estimates(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Fit covariance failure should remain diagnostic when decay fits converge."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    rng = np.random.default_rng(20)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    reference = 0.48 * 0.98 ** n_cliffords[:, None] + 0.49
+    reference = reference + rng.normal(0.0, 0.003, size=(6, 20))
+    interleaved = reference - 0.01 * (1.0 - 0.95 ** n_cliffords[:, None])
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+    original_curve_fit = module.curve_fit
+
+    def return_invalid_covariance(*args: Any, **kwargs: Any) -> Any:
+        """Retain converged parameters while replacing covariance with infinity."""
+        parameters, _ = original_curve_fit(*args, **kwargs)
+        return parameters, np.full((3, 3), np.inf)
+
+    monkeypatch.setattr(module, "curve_fit", return_invalid_covariance)
+
+    with pytest.warns(RuntimeWarning, match="covariance is unavailable"):
+        result = analyze_paired_irb(raw, n_bootstrap=2, bootstrap_seed=5)
+
+    target = result["Q0"]
+    assert target["reference"]["fit"]["covariance"] is None
+    assert target["reference"]["fit"]["standard_errors"] is None
+    assert target["bootstrap"]["n_success"] == 2
+    assert target["diagnostics"]["gate_fidelity_err_fit_covariance"] is None
+    assert target["gate_fidelity_ci68"] is not None
+    assert target["gate_fidelity_ci95"] is not None
+
+
+def test_all_zero_sem_marks_fit_covariance_scale_as_nonempirical() -> None:
+    """All-zero SEM should suppress covariance-derived fidelity uncertainty."""
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    reference_mean = 0.48 * 0.98**n_cliffords + 0.49
+    interleaved_mean = 0.47 * 0.95**n_cliffords + 0.50
+    reference = np.broadcast_to(reference_mean[:, None], (6, 20)).copy()
+    interleaved = np.broadcast_to(interleaved_mean[:, None], (6, 20)).copy()
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    with pytest.warns(RuntimeWarning) as warning_records:
+        result = analyze_paired_irb(raw, n_bootstrap=0)
+
+    assert any("SEM floor" in str(record.message) for record in warning_records)
+    assert any("non-empirical" in str(record.message) for record in warning_records)
+
+    diagnostics = result["Q0"]["diagnostics"]
+    assert diagnostics["fit_covariance_scale_empirical"] is False
+    assert diagnostics["gate_fidelity_err_fit_covariance"] is None
+
+
+def test_fewer_than_six_clifford_lengths_produces_a_diagnostic_warning() -> None:
+    """A low-degree-of-freedom decay fit should remain usable but be flagged."""
+    n_cliffords = np.array([0, 1, 2, 4, 8], dtype=np.int64)
+    offsets = np.linspace(-0.003, 0.003, 20)
+    reference_mean = 0.48 * 0.98**n_cliffords + 0.49
+    interleaved_mean = 0.47 * 0.95**n_cliffords + 0.50
+    reference = reference_mean[:, None] + offsets[None, :]
+    interleaved = interleaved_mean[:, None] + offsets[None, :]
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    with pytest.warns(RuntimeWarning, match="Clifford-length points"):
+        result = analyze_paired_irb(raw, n_bootstrap=0)
+
+    assert any(
+        "Clifford-length points" in message
+        for message in result["Q0"]["diagnostics"]["warnings"]
+    )
+
+
+@pytest.mark.parametrize(
+    ("error_bar", "statistics_key"),
+    [(None, None), ("sem", "sem"), ("std", "std")],
+)
+def test_figure_uses_the_selected_error_bars(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    error_bar: str | None,
+    statistics_key: str | None,
+) -> None:
+    """The public analysis API should plot the selected mean uncertainty."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    monkeypatch.setattr(module.go.Figure, "show", lambda self: None)
+    rng = np.random.default_rng(19)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    reference = 0.48 * 0.98 ** n_cliffords[:, None] + 0.49
+    reference = reference + rng.normal(0.0, 0.003, size=(6, 20))
+    interleaved = reference - 0.01 * (1.0 - 0.95 ** n_cliffords[:, None])
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    result = analyze_paired_irb(
+        raw,
+        n_bootstrap=0,
+        error_bar=error_bar,  # type: ignore[arg-type]
+        plot=True,
+    )
+
+    assert result["Q0"]["gate_fidelity_err"] is None
+    assert result.figure is not None
+    figure: Any = result.figure
+    assert len(figure.data) == 4
+    assert figure.data[0].name == "Reference"
+    assert figure.data[0].mode == "lines"
+    assert figure.data[0].line.color == "#0C5DA5"
+    assert figure.data[1].mode == "markers"
+    assert figure.data[1].marker.color == "#0C5DA5"
+    assert figure.data[1].showlegend is False
+    assert figure.data[2].name == "Interleaved"
+    assert figure.data[2].mode == "lines"
+    assert figure.data[2].line.color == "#00B945"
+    assert figure.data[3].mode == "markers"
+    assert figure.data[3].marker.color == "#00B945"
+    assert figure.data[3].showlegend is False
+    assert figure.layout.yaxis.title.text == "Normalized signal"
+    if statistics_key is None:
+        assert figure.data[1].error_y.array is None
+        assert figure.data[3].error_y.array is None
+    else:
+        np.testing.assert_allclose(
+            figure.data[1].error_y.array,
+            result["Q0"]["reference"][statistics_key],
+        )
+        np.testing.assert_allclose(
+            figure.data[3].error_y.array,
+            result["Q0"]["interleaved"][statistics_key],
+        )
+
+
+def test_figure_title_reports_fidelity_and_uncertainty_in_percent(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Figure annotations should not mix fractions and percentage points."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    monkeypatch.setattr(module.go.Figure, "show", lambda self: None)
+    rng = np.random.default_rng(23)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    reference = 0.48 * 0.98 ** n_cliffords[:, None] + 0.49
+    reference = reference + rng.normal(0.0, 0.003, size=(6, 20))
+    interleaved = reference - 0.01 * (1.0 - 0.95 ** n_cliffords[:, None])
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    result = analyze_paired_irb(raw, n_bootstrap=10, bootstrap_seed=4, plot=True)
+
+    target = result["Q0"]
+    figure: Any = result.figure
+    title = figure.layout.title.text
+    annotation = figure.layout.annotations[0].text
+    ci95 = target["gate_fidelity_ci95"]
+    assert ci95 is not None
+    assert title == "Paired interleaved randomized benchmarking of X90 : Q0"
+    assert f"F = {100.0 * target['gate_fidelity']:.4f} %" in annotation
+    assert f"bootstrap σ = {100.0 * target['gate_fidelity_err']:.4f} pp" in annotation
+    assert f"95% CI = [{100.0 * ci95[0]:.4f}, {100.0 * ci95[1]:.4f}] %" in annotation
+
+
+def test_save_image_builds_and_saves_the_figure_without_displaying_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Saving should create one named figure even when interactive plot is disabled."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    save_figure = Mock()
+    monkeypatch.setattr(module.viz, "save_figure", save_figure)
+    rng = np.random.default_rng(29)
+    n_cliffords = np.array([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    reference = 0.48 * 0.98 ** n_cliffords[:, None] + 0.49
+    reference = reference + rng.normal(0.0, 0.003, size=(6, 20))
+    interleaved = reference - 0.01 * (1.0 - 0.95 ** n_cliffords[:, None])
+    raw = _raw_result(reference, interleaved, n_cliffords=n_cliffords)
+
+    result = analyze_paired_irb(raw, n_bootstrap=0, save_image=True)
+
+    assert result.figure is not None
+    save_figure.assert_called_once_with(
+        result.figure,
+        name="paired_interleaved_randomized_benchmarking_Q0",
+    )

--- a/tests/contrib/paired_interleaved_randomized_benchmarking/test_function_api.py
+++ b/tests/contrib/paired_interleaved_randomized_benchmarking/test_function_api.py
@@ -1,0 +1,16 @@
+"""Tests for paired interleaved randomized-benchmarking exports."""
+
+from __future__ import annotations
+
+from qubex.contrib import (
+    analyze_paired_irb,
+    measure_paired_irb,
+    paired_interleaved_randomized_benchmarking,
+)
+
+
+def test_paired_irb_functions_are_exported() -> None:
+    """The contrib package should export measurement, analysis, and composed APIs."""
+    assert callable(measure_paired_irb)
+    assert callable(analyze_paired_irb)
+    assert callable(paired_interleaved_randomized_benchmarking)

--- a/tests/contrib/paired_interleaved_randomized_benchmarking/test_high_level.py
+++ b/tests/contrib/paired_interleaved_randomized_benchmarking/test_high_level.py
@@ -274,10 +274,10 @@ def test_serial_multi_target_auto_range_selects_each_target_independently() -> N
             save_image=False,
         )
 
-    assert result["Q0"]["grid_selection"]["selected_main_grid"][-1] == 18
-    assert result["Q1"]["grid_selection"]["selected_main_grid"][-1] == 94
-    assert result["Q0"]["acquisition"]["n_cliffords"][-1] == 18
-    assert result["Q1"]["acquisition"]["n_cliffords"][-1] == 94
+    assert result["Q0"]["grid_selection"]["selected_main_grid"][-1] == 28
+    assert result["Q1"]["grid_selection"]["selected_main_grid"][-1] == 128
+    assert result["Q0"]["acquisition"]["n_cliffords"][-1] == 28
+    assert result["Q1"]["acquisition"]["n_cliffords"][-1] == 128
 
 
 def test_serial_multi_target_validates_every_explicit_seed_matrix_first() -> None:
@@ -443,7 +443,7 @@ def test_multi_target_schedule_reuse_is_rejected_before_measurement() -> None:
 
 @pytest.mark.parametrize(
     ("decays", "expected_maximum"),
-    [((0.90, 0.85), 18), ((0.98, 0.97), 94)],
+    [((0.90, 0.85), 28), ((0.98, 0.97), 128)],
 )
 def test_auto_range_selects_from_paired_pilot_decay(
     decays: tuple[float, float],
@@ -871,8 +871,17 @@ def test_moderate_fidelity_auto_range_uses_a_shorter_adaptive_grid() -> None:
         )
 
     main_grid = result["Q0"]["grid_selection"]["selected_main_grid"]
-    assert 300 <= main_grid[-1] <= 500
+    assert 550 <= main_grid[-1] <= 650
     assert not {2, 4, 8, 16}.intersection(main_grid)
+    assert result["Q0"]["grid_selection"]["pilot_remaining_fraction"] == 0.10
+    assert result["Q0"]["grid_selection"]["main_remaining_fractions"] == (
+        0.90,
+        0.70,
+        0.50,
+        0.30,
+        0.15,
+        0.05,
+    )
 
 
 def test_two_qubit_auto_range_samples_the_short_decay_region(
@@ -918,7 +927,7 @@ def test_two_qubit_auto_range_samples_the_short_decay_region(
         )
 
     main_grid = result["CR0"]["grid_selection"]["selected_main_grid"]
-    assert main_grid[-1] == 94
+    assert main_grid[-1] == 148
     assert sum(length <= 16 for length in main_grid) >= 6
     assert result["CR0"]["metadata"]["dimension"] == 4
     selection = result["CR0"]["grid_selection"]
@@ -930,8 +939,8 @@ def test_two_qubit_auto_range_samples_the_short_decay_region(
     assert selection["pilot_grid"][-1] < 256
 
 
-def test_very_fast_decay_fills_collapsed_integer_grid_at_short_lengths() -> None:
-    """Rounded contrast collisions should be filled locally to six points."""
+def test_very_fast_decay_uses_the_supplemental_two_percent_target() -> None:
+    """The 2% fallback target should separate a collapsed short-length grid."""
     exp: Any = _Experiment(
         targets=("Q0",),
         decays={"Q0": (0.50, 0.40)},
@@ -952,8 +961,16 @@ def test_very_fast_decay_fills_collapsed_integer_grid_at_short_lengths() -> None
         )
 
     selection = result["Q0"]["grid_selection"]
-    np.testing.assert_array_equal(selection["selected_main_grid"], range(6))
-    np.testing.assert_array_equal(selection["supplemental_integer_grid"], [5])
+    np.testing.assert_array_equal(selection["selected_main_grid"], [0, 1, 2, 3, 4, 6])
+    np.testing.assert_array_equal(selection["supplemental_integer_grid"], [])
+    assert selection["additional_remaining_fractions_used"] == (
+        0.80,
+        0.60,
+        0.40,
+        0.20,
+        0.10,
+        0.02,
+    )
     assert selection["fallback_used"] is False
 
 
@@ -1060,7 +1077,7 @@ def test_similar_decay_parameters_do_not_create_an_excessive_union() -> None:
         )
 
     selection = result["Q0"]["grid_selection"]
-    assert len(selection["selected_main_grid"]) <= 10
+    assert len(selection["selected_main_grid"]) <= 11
     assert selection["near_duplicate_merging_applied"] is True
     assert selection["thinning_applied"] is False
 
@@ -1087,9 +1104,9 @@ def test_different_decay_parameters_contribute_both_candidate_regions() -> None:
         )
 
     selection = result["Q0"]["grid_selection"]
-    assert selection["candidate_reference_grid"][-1] == 378
-    assert selection["candidate_interleaved_grid"][-1] == 37
-    assert 37 in selection["selected_main_grid"]
+    assert selection["candidate_reference_grid"][-1] == 512
+    assert selection["candidate_interleaved_grid"][-1] == 58
+    assert 58 in selection["selected_main_grid"]
     assert 378 in selection["selected_main_grid"]
 
 
@@ -1463,8 +1480,8 @@ def test_pilot_threshold_controls_pilot_cost_but_not_the_adaptive_main_grid() ->
         fidelities.append(result["Q0"]["gate_fidelity"])
         bootstrap_sigmas.append(result["Q0"]["gate_fidelity_err"])
 
-    assert selected_maxima == [23, 23, 23]
-    assert main_measurement_points == [80, 80, 80]
+    assert selected_maxima == [36, 36, 36]
+    assert main_measurement_points == [96, 96, 96]
     assert pilot_measurement_points == [84, 84, 72]
     assert p_reference == pytest.approx([0.92, 0.92, 0.92], abs=1e-8)
     assert p_interleaved == pytest.approx([0.90, 0.90, 0.90], abs=1e-8)
@@ -1523,7 +1540,7 @@ def test_auto_range_extends_when_the_first_pilot_shape_is_poor(
     grid_selection = result["Q0"]["grid_selection"]
     assert grid_selection["pilot_stop_reason"] == "decay_threshold_reached"
     assert grid_selection["pilot_grid"][-1] == 32
-    assert grid_selection["selected_main_grid"][-1] == 18
+    assert grid_selection["selected_main_grid"][-1] == 28
     assert (
         "poor_decay_shape"
         in (
@@ -1699,8 +1716,8 @@ def test_parallel_auto_range_uses_the_slowest_targets_shared_grid() -> None:
             save_image=False,
         )
 
-    assert result["Q0"]["grid_selection"]["target_candidate_main_grid"][-1] == 18
-    assert result["Q1"]["grid_selection"]["target_candidate_main_grid"][-1] == 94
+    assert result["Q0"]["grid_selection"]["target_candidate_main_grid"][-1] == 28
+    assert result["Q1"]["grid_selection"]["target_candidate_main_grid"][-1] == 128
     np.testing.assert_array_equal(
         result["Q0"]["grid_selection"]["selected_main_grid"],
         result["Q1"]["grid_selection"]["selected_main_grid"],
@@ -1712,7 +1729,7 @@ def test_parallel_auto_range_uses_the_slowest_targets_shared_grid() -> None:
     shared_grid = result["Q0"]["grid_selection"]["selected_main_grid"]
     assert len(shared_grid) == 14
     assert 2 in shared_grid
-    assert shared_grid[-1] == 94
+    assert shared_grid[-1] == 128
     assert result["Q0"]["grid_selection"]["thinning_applied"] is True
 
 

--- a/tests/contrib/paired_interleaved_randomized_benchmarking/test_high_level.py
+++ b/tests/contrib/paired_interleaved_randomized_benchmarking/test_high_level.py
@@ -1,0 +1,1926 @@
+"""Tests for high-level paired IRB orchestration."""
+
+from __future__ import annotations
+
+import importlib
+from collections.abc import Collection
+from dataclasses import replace
+from types import SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+from qxpulse import Blank, PulseSchedule
+from scipy.optimize import curve_fit
+
+from qubex.clifford.clifford import Clifford
+from qubex.contrib import paired_interleaved_randomized_benchmarking
+
+
+class _RabiParam:
+    """Map an encoded IQ value to a normalized Bloch-Z value."""
+
+    @staticmethod
+    def normalize(iq: Any) -> float:
+        """Decode a synthetic ground-state probability."""
+        return 2.0 * float(np.real(np.mean(np.asarray(iq)))) - 1.0
+
+
+class _MeasurementService:
+    """Execute synthetic serial or parallel sweep schedules."""
+
+    def __init__(
+        self,
+        sequence_calls: list[Any],
+        *,
+        decays: dict[str, tuple[float, float]] | None = None,
+    ) -> None:
+        self.sequence_calls = sequence_calls
+        self.decays = decays or {}
+        self.calls: list[dict[str, Any]] = []
+
+    async def run_sweep_measurement(
+        self,
+        schedule: Any,
+        *,
+        sweep_values: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Return one result containing every target scheduled at each point."""
+        values = np.asarray(sweep_values)
+        call: dict[str, Any] = {
+            "sweep_values": values.copy(),
+            "point_durations": [],
+            "point_markers": [],
+            **kwargs,
+        }
+        self.calls.append(call)
+        results = []
+        for value in values:
+            call_start = len(self.sequence_calls)
+            combined_schedule = schedule(int(value))
+            markers = self.sequence_calls[call_start:]
+            call["point_durations"].append(combined_schedule.duration)
+            call["point_markers"].append(markers)
+            point_data = {}
+            for marker in markers:
+                reference_decay, interleaved_decay = self.decays.get(
+                    marker.target,
+                    (0.98, 0.95),
+                )
+                decay = (
+                    reference_decay
+                    if marker.interleaved_clifford is None
+                    else interleaved_decay
+                )
+                is_two_qubit = marker.target.startswith("CR")
+                amplitude = 0.73 if is_two_qubit else 0.48
+                offset = 0.25 if is_two_qubit else 0.50
+                probability = amplitude * decay**marker.n_cliffords + offset
+                capture_config = SimpleNamespace(
+                    shot_averaging=kwargs["shot_averaging"],
+                    time_integration=kwargs["time_integration"],
+                )
+                point_data[marker.target] = [
+                    SimpleNamespace(
+                        data=np.asarray(probability, dtype=np.complex128),
+                        config=capture_config,
+                    )
+                ]
+            results.append(SimpleNamespace(data=point_data))
+        return SimpleNamespace(results=results)
+
+
+class _Experiment:
+    """Provide the experiment surface used by high-level paired IRB tests."""
+
+    def __init__(
+        self,
+        targets: tuple[str, ...] = ("Q0", "Q1"),
+        *,
+        cr_pairs: dict[str, tuple[str, str]] | None = None,
+        decays: dict[str, tuple[float, float]] | None = None,
+    ) -> None:
+        self.sequence_calls: list[Any] = []
+        self.measurement_service = _MeasurementService(
+            self.sequence_calls,
+            decays=decays,
+        )
+        cr_pairs = cr_pairs or {}
+        target_names = (*targets, *cr_pairs)
+        self.pulse = SimpleNamespace(
+            rabi_params={target: _RabiParam() for target in targets},
+            validate_rabi_params=lambda selected: None,
+        )
+        self.experiment_system = SimpleNamespace(
+            get_target=lambda target: SimpleNamespace(is_cr=target in cr_pairs),
+            resolve_qubit_label=lambda target: target,
+        )
+        physical_qubits = {qubit for pair in cr_pairs.values() for qubit in pair}
+        self.ctx = SimpleNamespace(
+            reset_awg_and_capunits=lambda *, qubits: None,
+            classifiers={qubit: object() for qubit in physical_qubits},
+            calib_note=SimpleNamespace(
+                cr_params={target: object() for target in cr_pairs}
+            ),
+            cr_pair=lambda target: cr_pairs[target],
+        )
+        self.interleaved_1q = Clifford.X90()
+        self.interleaved_2q = Clifford.ZX90()
+        self.benchmarking_service = SimpleNamespace(
+            clifford={
+                "X90": self.interleaved_1q,
+                "ZX90": self.interleaved_2q,
+            }
+        )
+        self._target_duration_offsets = {
+            target: 2.0 * index for index, target in enumerate(target_names)
+        }
+
+    def rb_sequence(self, target: str, **kwargs: Any) -> PulseSchedule:
+        """Record target-specific options and return a valid pulse schedule."""
+        marker = SimpleNamespace(
+            target=target,
+            n_cliffords=kwargs["n"],
+            seed=kwargs["seed"],
+            interleaved_clifford=kwargs["interleaved_clifford"],
+            interleaved_waveform=kwargs["interleaved_waveform"],
+            x90=kwargs["x90"],
+            zx90=kwargs["zx90"],
+        )
+        duration = (
+            2.0 * (marker.n_cliffords + 1) + self._target_duration_offsets[target]
+        )
+        marker.duration = duration
+        self.sequence_calls.append(marker)
+        with PulseSchedule([target]) as schedule:
+            schedule.add(target, Blank(duration=duration))
+        return schedule
+
+
+def test_serial_multi_target_combines_independent_results_and_figures(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Serial targets should retain independent seeds in one combined result."""
+    exp: Any = _Experiment()
+    monkeypatch.setattr("plotly.graph_objects.Figure.show", lambda self: None)
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            ["Q0", "Q1"],
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4, 8, 16],
+            n_trials=4,
+            sequence_seed=7,
+            n_bootstrap=0,
+            pairs_per_sweep=24,
+            plot=True,
+            save_image=False,
+        )
+
+    assert list(result.data) == ["Q0", "Q1"]
+    assert result.figures is not None
+    assert set(result.figures) == {"Q0", "Q1"}
+    assert not np.array_equal(
+        result["Q0"]["acquisition"]["seeds"],
+        result["Q1"]["acquisition"]["seeds"],
+    )
+    assert result["Q0"]["grid_selection"]["pilot_stop_reason"] == "explicit_range"
+    assert result["Q1"]["grid_selection"]["pilot_stop_reason"] == "explicit_range"
+    np.testing.assert_array_equal(
+        result["Q0"]["grid_selection"]["selected_main_grid"],
+        [0, 1, 2, 4, 8, 16],
+    )
+
+
+def test_ordered_target_sequences_preserve_deterministic_seed_assignment() -> None:
+    """Equivalent target lists and tuples should assign identical child seeds."""
+    list_experiment: Any = _Experiment()
+    tuple_experiment: Any = _Experiment()
+    options = {
+        "interleaved_clifford": "X90",
+        "n_cliffords_range": [0, 1, 2, 4, 8, 16],
+        "n_trials": 2,
+        "sequence_seed": 101,
+        "acquisition_seed": 103,
+        "n_bootstrap": 0,
+        "pairs_per_sweep": 100,
+        "plot": False,
+        "save_image": False,
+    }
+
+    with pytest.warns(RuntimeWarning):
+        list_result = paired_interleaved_randomized_benchmarking(
+            list_experiment,
+            ["Q0", "Q1"],
+            **options,
+        )
+    with pytest.warns(RuntimeWarning):
+        tuple_result = paired_interleaved_randomized_benchmarking(
+            tuple_experiment,
+            ("Q0", "Q1"),
+            **options,
+        )
+
+    assert list(list_result.data) == ["Q0", "Q1"]
+    assert list(tuple_result.data) == ["Q0", "Q1"]
+    for target in ("Q0", "Q1"):
+        np.testing.assert_array_equal(
+            list_result[target]["acquisition"]["seeds"],
+            tuple_result[target]["acquisition"]["seeds"],
+        )
+
+
+def test_unordered_target_collection_is_rejected_before_measurement() -> None:
+    """Target collections without stable order should not assign RNG streams."""
+    exp: Any = _Experiment()
+
+    with pytest.raises(TypeError, match="must preserve order"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            {"Q0", "Q1"},  # type: ignore[arg-type]
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4, 8, 16],
+            n_trials=2,
+            n_bootstrap=0,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_serial_multi_target_auto_range_selects_each_target_independently() -> None:
+    """Serial targets should use independent pilot decisions and main grids."""
+    exp: Any = _Experiment(
+        decays={"Q0": (0.90, 0.85), "Q1": (0.98, 0.97)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            ["Q0", "Q1"],
+            interleaved_clifford="X90",
+            auto_range=True,
+            max_n_cliffords=128,
+            n_trials=3,
+            sequence_seed=11,
+            acquisition_seed=13,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    assert result["Q0"]["grid_selection"]["selected_main_grid"][-1] == 18
+    assert result["Q1"]["grid_selection"]["selected_main_grid"][-1] == 94
+    assert result["Q0"]["acquisition"]["n_cliffords"][-1] == 18
+    assert result["Q1"]["acquisition"]["n_cliffords"][-1] == 94
+
+
+def test_serial_multi_target_validates_every_explicit_seed_matrix_first() -> None:
+    """An invalid later seed matrix should fail before measuring any target."""
+    exp: Any = _Experiment()
+    seeds = {
+        "Q0": np.arange(18, dtype=np.int64).reshape(6, 3),
+        "Q1": np.arange(15, dtype=np.int64).reshape(5, 3),
+    }
+
+    with pytest.raises(ValueError, match=r"shape \(6, 3\)"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            ["Q0", "Q1"],
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4, 8, 16],
+            n_trials=3,
+            seeds=seeds,
+            n_bootstrap=0,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_multi_target_seed_mapping_rejects_none_before_measurement() -> None:
+    """Every entry of an explicit multi-target seed mapping must be a matrix."""
+    exp: Any = _Experiment()
+    seeds = {
+        "Q0": np.arange(8, dtype=np.int64).reshape(4, 2),
+        "Q1": None,
+    }
+
+    with pytest.raises(TypeError, match=r"explicit matrix.*Q1"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            ("Q0", "Q1"),
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4],
+            n_trials=2,
+            seeds=seeds,  # type: ignore[arg-type]
+            n_bootstrap=0,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_high_level_rejects_conflicting_range_controls_before_measurement() -> None:
+    """An explicit grid and maximum must remain mutually exclusive."""
+    exp: Any = _Experiment(targets=("Q0",))
+
+    with pytest.raises(ValueError, match="Specify only one"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4],
+            max_n_cliffords=8,
+            n_trials=2,
+            n_bootstrap=0,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+@pytest.mark.parametrize(
+    ("overrides", "message"),
+    [
+        ({"x90": Blank(duration=2.0)}, "physical-qubit waveform mapping"),
+        (
+            {"interleaved_waveform": Blank(duration=2.0)},
+            "PulseSchedule",
+        ),
+    ],
+)
+def test_two_qubit_waveform_overrides_are_rejected_before_measurement(
+    overrides: dict[str, Any],
+    message: str,
+) -> None:
+    """2Q waveform-shape errors should not reach the measurement service."""
+    exp: Any = _Experiment(targets=(), cr_pairs={"CR0": ("Q0", "Q1")})
+
+    with pytest.raises(TypeError, match=message):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            "CR0",
+            interleaved_clifford="ZX90",
+            n_cliffords_range=[0, 1, 2, 4, 8, 16],
+            n_trials=2,
+            n_bootstrap=0,
+            plot=False,
+            save_image=False,
+            **overrides,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_missing_target_override_is_rejected_before_measurement() -> None:
+    """A partial high-level TargetMap must not silently fall back to defaults."""
+    exp: Any = _Experiment()
+
+    with pytest.raises(ValueError, match=r"interleaved_waveform.*Q1"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            ("Q0", "Q1"),
+            interleaved_clifford="X90",
+            interleaved_waveform={"Q0": Blank(duration=2.0)},
+            n_cliffords_range=[0, 1, 2, 4],
+            n_trials=2,
+            n_bootstrap=0,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_incomplete_two_qubit_x90_map_is_rejected_before_measurement() -> None:
+    """A CR X90 override must provide waveforms for both physical qubits."""
+    exp: Any = _Experiment(targets=(), cr_pairs={"CR0": ("Q0", "Q1")})
+
+    with pytest.raises(ValueError, match=r"x90.*Q1"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            "CR0",
+            interleaved_clifford="ZX90",
+            x90={"Q0": Blank(duration=2.0)},
+            n_cliffords_range=[0, 1, 2, 4],
+            n_trials=2,
+            n_bootstrap=0,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_multi_target_schedule_reuse_is_rejected_before_measurement() -> None:
+    """One target-containing schedule must not be reused across target labels."""
+    exp: Any = _Experiment()
+
+    with pytest.raises(ValueError, match="cannot reuse"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            ("Q0", "Q1"),
+            interleaved_clifford="X90",
+            interleaved_waveform=PulseSchedule(),
+            n_cliffords_range=[0, 1, 2, 4],
+            n_trials=2,
+            n_bootstrap=0,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+@pytest.mark.parametrize(
+    ("decays", "expected_maximum"),
+    [((0.90, 0.85), 18), ((0.98, 0.97), 94)],
+)
+def test_auto_range_selects_from_paired_pilot_decay(
+    decays: tuple[float, float],
+    expected_maximum: int,
+) -> None:
+    """Fast and slow paired decays should select correspondingly sized ranges."""
+    exp: Any = _Experiment(targets=("Q0",), decays={"Q0": decays})
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            auto_range=True,
+            pilot_n_trials=6,
+            auto_range_remaining_fraction=0.2,
+            max_n_cliffords=128,
+            n_trials=4,
+            sequence_seed=17,
+            acquisition_seed=19,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    target = result["Q0"]
+    grid_selection = target["grid_selection"]
+    pilot = grid_selection["pilot_raw_result"]
+    assert grid_selection["pilot_stop_reason"] == "decay_threshold_reached"
+    assert grid_selection["selected_main_grid"][-1] == expected_maximum
+    assert grid_selection["pilot_reference_fit"]["model"] == "A * p**m + 1/d"
+    assert grid_selection["pilot_reference_fit"]["C"] == pytest.approx(0.5)
+    assert grid_selection["pilot_reference_fit"]["weighting"] == "unweighted"
+    assert grid_selection["pilot_fit_quality"]["reference"]["valid"] is True
+    assert grid_selection["pilot_fit_quality"]["reference"]["decay_significance"] >= 3.0
+    assert pilot["reference"]["trials"].shape[1] == 6
+    assert target["reference"]["trials"].shape[1] == 4
+    assert not np.array_equal(
+        pilot["acquisition"]["seeds"],
+        target["acquisition"]["seeds"],
+    )
+    assert target["reference"]["trials"].shape[0] == len(
+        grid_selection["selected_main_grid"]
+    )
+
+
+def test_high_fidelity_auto_range_repositions_the_main_grid(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """High-fidelity decay should move main points into informative long lengths."""
+    monkeypatch.setattr("plotly.graph_objects.Figure.show", lambda self: None)
+    exp: Any = _Experiment(
+        targets=("Q0",),
+        decays={"Q0": (0.9995, 0.9990)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            auto_range=True,
+            max_n_cliffords=2_048,
+            n_trials=4,
+            sequence_seed=71,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=True,
+            save_image=False,
+        )
+
+    grid_selection = result["Q0"]["grid_selection"]
+    main_grid = grid_selection["selected_main_grid"]
+    np.testing.assert_array_equal(
+        grid_selection["pilot_grid"],
+        [0, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1_024, 2_048],
+    )
+    assert main_grid[0] == 0
+    assert main_grid[-1] <= 2_048
+    assert any(length >= 100 for length in main_grid)
+    assert not {2, 4, 8, 16}.intersection(main_grid)
+    assert not np.array_equal(main_grid, grid_selection["pilot_grid"])
+    assert grid_selection["maximum_anchor_added"] is True
+    assert grid_selection["fallback_used"] is False
+    np.testing.assert_array_equal(
+        result["Q0"]["acquisition"]["n_cliffords"],
+        main_grid,
+    )
+    assert result.figure is not None
+    figure: Any = result.figure
+    np.testing.assert_array_equal(figure.data[1].x, main_grid)
+    assert figure.layout.xaxis.type == "linear"
+
+
+def test_fixed_offset_pilot_prevents_high_fidelity_premature_stopping() -> None:
+    """A noisy slow 1Q decay should not be mistaken for a short decay scale."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    n_cliffords = np.asarray([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    rng = np.random.default_rng(20_260_911)
+    legacy_premature_stops = 0
+    fixed_offset_premature_stops = 0
+    fixed_offset_estimates: tuple[list[float], list[float]] = ([], [])
+    n_experiments = 1_000
+
+    for _ in range(n_experiments):
+        paired_noise = rng.normal(0.0, 0.008, size=(len(n_cliffords), 6))
+        reference_trials = (
+            0.48 * 0.999 ** n_cliffords[:, None]
+            + 0.5
+            + paired_noise
+            + rng.normal(0.0, 0.006, size=(len(n_cliffords), 6))
+        )
+        interleaved_trials = (
+            0.48 * 0.998 ** n_cliffords[:, None]
+            + 0.5
+            + paired_noise
+            + rng.normal(0.0, 0.006, size=(len(n_cliffords), 6))
+        )
+        legacy_fits = []
+        pilot_fits = []
+        significances = []
+        for arm_index, trials in enumerate((reference_trials, interleaved_trials)):
+            mean = np.mean(trials, axis=1)
+            sem = np.std(trials, axis=1, ddof=1) / np.sqrt(trials.shape[1])
+            legacy_fits.append(
+                module._fit_rb_decay(  # noqa: SLF001
+                    n_cliffords,
+                    mean,
+                    np.maximum(sem, 1e-3),
+                )
+            )
+            pilot_fit = module._fit_pilot_decay(  # noqa: SLF001
+                n_cliffords,
+                mean,
+                dimension=2,
+            )
+            pilot_fits.append(pilot_fit)
+            fixed_offset_estimates[arm_index].append(pilot_fit.decay_parameter)
+            significances.append(
+                module._observed_decay_significance(mean, sem)  # noqa: SLF001
+            )
+
+        legacy_premature_stops += int(
+            all(
+                not fit.parameters_at_bound
+                and fit.r_squared is not None
+                and fit.r_squared >= 0.5
+                for fit in legacy_fits
+            )
+            and max(fit.decay_parameter**16 for fit in legacy_fits) <= 0.2
+        )
+        fixed_offset_premature_stops += int(
+            all(not fit.parameters_at_bound for fit in pilot_fits)
+            and max(fit.decay_parameter**16 for fit in pilot_fits) <= 0.2
+            and min(significances) >= 3.0
+        )
+
+    assert legacy_premature_stops / n_experiments >= 0.05
+    assert fixed_offset_premature_stops / n_experiments <= 0.01
+    assert np.mean(fixed_offset_estimates[0]) == pytest.approx(0.999, abs=1e-4)
+    assert np.mean(fixed_offset_estimates[1]) == pytest.approx(0.998, abs=1e-4)
+
+
+@pytest.mark.parametrize(
+    ("dimension", "amplitude", "offset", "decay_parameter"),
+    [(2, 0.5, 0.5, 0.99), (4, 0.75, 0.25, 0.95)],
+)
+def test_ideal_pilot_accepts_the_physical_amplitude_upper_bound(
+    dimension: int,
+    amplitude: float,
+    offset: float,
+    decay_parameter: float,
+) -> None:
+    """Ideal 1Q and 2Q contrast maxima should produce valid pilot fits."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    n_cliffords = np.asarray([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    mean = amplitude * decay_parameter**n_cliffords + offset
+    trials = mean[:, None] + np.linspace(-1e-4, 1e-4, 6)[None, :]
+
+    assessment = module._assess_pilot_arm(  # noqa: SLF001
+        n_cliffords,
+        module._trial_moments(trials),  # noqa: SLF001
+        dimension=dimension,
+    )
+
+    assert assessment.valid is True
+    assert assessment.fit is not None
+    assert "A" in assessment.fit.parameters_at_bound
+    assert "pathological_amplitude" not in assessment.invalid_reasons
+
+
+def test_pilot_rejects_a_small_decay_amplitude() -> None:
+    """A fitted contrast too small to identify decay should remain invalid."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    n_cliffords = np.asarray([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    mean = 0.01 * 0.8**n_cliffords + 0.5
+    trials = mean[:, None] + np.linspace(-1e-5, 1e-5, 6)[None, :]
+
+    assessment = module._assess_pilot_arm(  # noqa: SLF001
+        n_cliffords,
+        module._trial_moments(trials),  # noqa: SLF001
+        dimension=2,
+    )
+
+    assert assessment.valid is False
+    assert "pathological_amplitude" in assessment.invalid_reasons
+
+
+@pytest.mark.parametrize("decay_parameter", [0.0, 1.0])
+def test_pilot_rejects_decay_parameters_at_either_bound(
+    decay_parameter: float,
+) -> None:
+    """A pilot decay scale at either fit bound should remain invalid."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    n_cliffords = np.asarray([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    mean = 0.4 * decay_parameter**n_cliffords + 0.5
+    trials = mean[:, None] + np.linspace(-1e-5, 1e-5, 6)[None, :]
+
+    assessment = module._assess_pilot_arm(  # noqa: SLF001
+        n_cliffords,
+        module._trial_moments(trials),  # noqa: SLF001
+        dimension=2,
+    )
+
+    assert assessment.valid is False
+    assert "decay_parameter_at_bound" in assessment.invalid_reasons
+
+
+def test_non_exponential_pilot_shape_is_invalid_despite_endpoint_decay() -> None:
+    """Significant endpoint decay should not rescue a poor exponential shape."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    n_cliffords = np.asarray([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    mean = np.asarray([0.99, 0.80, 0.97, 0.70, 0.92, 0.60])
+    trials = mean[:, None] + np.linspace(-0.002, 0.002, 6)[None, :]
+
+    assessment = module._assess_pilot_arm(  # noqa: SLF001
+        n_cliffords,
+        module._trial_moments(trials),  # noqa: SLF001
+        dimension=2,
+    )
+
+    assert assessment.decay_significance > 3.0
+    assert assessment.fit is not None
+    assert assessment.fit.r_squared is not None
+    assert assessment.fit.r_squared < 0.5
+    assert assessment.valid is False
+    assert "poor_decay_shape" in assessment.invalid_reasons
+
+
+def test_upper_bound_contrast_does_not_enable_high_fidelity_premature_stop() -> None:
+    """A noisy ideal-contrast slow decay should not stop at 16 Cliffords."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    n_cliffords = np.asarray([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    rng = np.random.default_rng(20_260_912)
+    premature_stops = 0
+    upper_bound_hits = 0
+    n_experiments = 1_000
+
+    for _ in range(n_experiments):
+        paired_noise = rng.normal(0.0, 0.008, size=(len(n_cliffords), 6))
+        assessments = []
+        for decay_parameter in (0.999, 0.998):
+            trials = (
+                0.5 * decay_parameter ** n_cliffords[:, None]
+                + 0.5
+                + paired_noise
+                + rng.normal(0.0, 0.006, size=(len(n_cliffords), 6))
+            )
+            assessment = module._assess_pilot_arm(  # noqa: SLF001
+                n_cliffords,
+                module._trial_moments(trials),  # noqa: SLF001
+                dimension=2,
+            )
+            assessments.append(assessment)
+            upper_bound_hits += int(
+                assessment.fit is not None and "A" in assessment.fit.parameters_at_bound
+            )
+        fits = tuple(assessment.fit for assessment in assessments)
+        premature_stops += int(
+            all(assessment.valid for assessment in assessments)
+            and all(fit is not None for fit in fits)
+            and max(fit.decay_parameter**16 for fit in fits if fit is not None) <= 0.2
+        )
+
+    assert upper_bound_hits > 0
+    assert premature_stops / n_experiments <= 0.01
+
+
+def test_unweighted_pilot_is_stabler_than_noisy_sem_weighting() -> None:
+    """Noisy six-trial SEM weights should not control the pilot decay scale."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    n_cliffords = np.asarray([0, 1, 2, 4, 8, 16], dtype=np.int64)
+    rng = np.random.default_rng(20_260_911)
+    weighted_estimates = []
+    unweighted_estimates = []
+
+    def fixed_offset_decay(
+        lengths: np.ndarray,
+        amplitude: float,
+        decay_parameter: float,
+    ) -> np.ndarray:
+        return amplitude * decay_parameter**lengths + 0.5
+
+    for _ in range(1_000):
+        trials = (
+            0.48 * 0.999 ** n_cliffords[:, None]
+            + 0.5
+            + rng.normal(0.0, 0.01, size=(len(n_cliffords), 6))
+        )
+        mean = np.mean(trials, axis=1)
+        sem = np.std(trials, axis=1, ddof=1) / np.sqrt(trials.shape[1])
+        weighted_parameters, _ = curve_fit(
+            fixed_offset_decay,
+            n_cliffords.astype(np.float64),
+            mean,
+            p0=(0.48, 0.98),
+            sigma=np.maximum(sem, 1e-3),
+            absolute_sigma=True,
+            bounds=((0.0, 0.0), (0.5, 1.0)),
+            maxfev=20_000,
+        )
+        weighted_estimates.append(float(weighted_parameters[1]))
+        unweighted_estimates.append(
+            module._fit_pilot_decay(  # noqa: SLF001
+                n_cliffords,
+                mean,
+                dimension=2,
+            ).decay_parameter
+        )
+
+    assert abs(np.mean(unweighted_estimates) - 0.999) < 1e-4
+    assert np.std(unweighted_estimates) < 0.95 * np.std(weighted_estimates)
+
+
+def test_observed_decay_safeguard_overrides_a_spurious_fast_pilot_fit(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A low-significance first stage should continue despite a small fitted p."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    original_fit = module._fit_pilot_decay  # noqa: SLF001
+    original_significance = module._observed_decay_significance  # noqa: SLF001
+
+    def biased_first_fit(
+        n_cliffords: np.ndarray,
+        mean: np.ndarray,
+        **kwargs: Any,
+    ) -> Any:
+        fit = original_fit(n_cliffords, mean, **kwargs)
+        if len(n_cliffords) == 6:
+            return replace(fit, decay_parameter=0.80)
+        return fit
+
+    def low_first_significance(mean: np.ndarray, sem: np.ndarray) -> float:
+        if len(mean) == 6:
+            return 0.0
+        return original_significance(mean, sem)
+
+    monkeypatch.setattr(module, "_fit_pilot_decay", biased_first_fit)
+    monkeypatch.setattr(
+        module,
+        "_observed_decay_significance",
+        low_first_significance,
+    )
+    exp: Any = _Experiment(
+        targets=("Q0",),
+        decays={"Q0": (0.999, 0.998)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            max_n_cliffords=64,
+            n_trials=3,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    selection = result["Q0"]["grid_selection"]
+    assert selection["pilot_grid"][-1] == 64
+    assert selection["pilot_stage_diagnostics"][0]["decision"] == (
+        "insufficient_observed_decay"
+    )
+
+
+def test_moderate_fidelity_auto_range_uses_a_shorter_adaptive_grid() -> None:
+    """Moderate 1Q decay should place the main grid below the high-fidelity scale."""
+    exp: Any = _Experiment(
+        targets=("Q0",),
+        decays={"Q0": (0.995, 0.990)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            max_n_cliffords=2_048,
+            n_trials=4,
+            sequence_seed=73,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    main_grid = result["Q0"]["grid_selection"]["selected_main_grid"]
+    assert 300 <= main_grid[-1] <= 500
+    assert not {2, 4, 8, 16}.intersection(main_grid)
+
+
+def test_two_qubit_auto_range_samples_the_short_decay_region(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A 2Q-like decay should allocate several main points at short lengths."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    exp: Any = _Experiment(
+        targets=(),
+        cr_pairs={"CR0": ("Q0", "Q1")},
+        decays={"CR0": (0.98, 0.95)},
+    )
+
+    def convert(point_result: Any, **kwargs: Any) -> Any:
+        """Expose the synthetic marker probability as a 2Q `P(00)` value."""
+        probability = float(np.real(point_result.data["CR0"][-1].data))
+        return SimpleNamespace(
+            get_mitigated_probabilities=lambda qubits: {"00": probability},
+            get_probabilities=lambda qubits: {"00": probability},
+        )
+
+    monkeypatch.setattr(
+        module.MeasurementResultConverter,
+        "to_measure_result",
+        Mock(side_effect=convert),
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "CR0",
+            interleaved_clifford="ZX90",
+            max_n_cliffords=256,
+            n_trials=4,
+            sequence_seed=79,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            mitigate_readout=False,
+            plot=False,
+            save_image=False,
+        )
+
+    main_grid = result["CR0"]["grid_selection"]["selected_main_grid"]
+    assert main_grid[-1] == 94
+    assert sum(length <= 16 for length in main_grid) >= 6
+    assert result["CR0"]["metadata"]["dimension"] == 4
+    selection = result["CR0"]["grid_selection"]
+    assert selection["pilot_reference_fit"]["C"] == pytest.approx(0.25)
+    assert selection["pilot_interleaved_fit"]["C"] == pytest.approx(0.25)
+    assert selection["pilot_model"]["used_for_main_fit"] is False
+    assert selection["pilot_model"]["unmitigated_2q_readout_caveat"] is not None
+    assert selection["pilot_stop_reason"] == "decay_threshold_reached"
+    assert selection["pilot_grid"][-1] < 256
+
+
+def test_very_fast_decay_fills_collapsed_integer_grid_at_short_lengths() -> None:
+    """Rounded contrast collisions should be filled locally to six points."""
+    exp: Any = _Experiment(
+        targets=("Q0",),
+        decays={"Q0": (0.50, 0.40)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            max_n_cliffords=128,
+            n_trials=4,
+            sequence_seed=81,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    selection = result["Q0"]["grid_selection"]
+    np.testing.assert_array_equal(selection["selected_main_grid"], range(6))
+    np.testing.assert_array_equal(selection["supplemental_integer_grid"], [5])
+    assert selection["fallback_used"] is False
+
+
+def test_short_grid_fill_does_not_enumerate_a_large_clifford_range() -> None:
+    """Sparse-grid completion should remain bounded for a very large maximum."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+
+    grid, added = module._fill_short_main_grid(  # noqa: SLF001
+        np.asarray([0, 1, 10**12], dtype=np.int64),
+        maximum=10**12,
+    )
+
+    assert len(grid) == 6
+    assert len(added) == 3
+    assert grid[0] == 0
+    assert grid[-1] == 10**12
+    assert np.all(np.diff(grid) > 0)
+
+
+def test_default_grid_rejects_a_maximum_larger_than_the_storage_dtype() -> None:
+    """An out-of-range maximum should fail clearly instead of overflowing."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+
+    with pytest.raises(ValueError, match="signed 64-bit integer"):
+        module._default_n_cliffords(np.iinfo(np.int64).max + 1)  # noqa: SLF001
+
+
+def test_auto_range_includes_a_non_power_of_two_maximum_candidate() -> None:
+    """Auto-range should measure its exact configured exploration ceiling."""
+    exp: Any = _Experiment(
+        targets=("Q0",),
+        decays={"Q0": (0.999, 0.998)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            max_n_cliffords=100,
+            n_trials=3,
+            sequence_seed=107,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    selection = result["Q0"]["grid_selection"]
+    np.testing.assert_array_equal(
+        selection["candidate_pilot_grid"],
+        [0, 1, 2, 4, 8, 16, 32, 64, 100],
+    )
+    assert selection["pilot_grid"][-1] == 100
+
+
+def test_fixed_power_of_two_grid_does_not_add_a_non_power_of_two_maximum() -> None:
+    """Disabling auto-range should retain the legacy fixed-grid behavior."""
+    exp: Any = _Experiment(targets=("Q0",))
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            auto_range=False,
+            max_n_cliffords=100,
+            n_trials=3,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    np.testing.assert_array_equal(
+        result["Q0"]["acquisition"]["n_cliffords"],
+        [0, 1, 2, 4, 8, 16, 32, 64],
+    )
+
+
+def test_similar_decay_parameters_do_not_create_an_excessive_union() -> None:
+    """Similar fitted decays should deduplicate most arm-specific grid points."""
+    exp: Any = _Experiment(
+        targets=("Q0",),
+        decays={"Q0": (0.980, 0.979)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            max_n_cliffords=128,
+            n_trials=4,
+            sequence_seed=83,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    selection = result["Q0"]["grid_selection"]
+    assert len(selection["selected_main_grid"]) <= 10
+    assert selection["near_duplicate_merging_applied"] is True
+    assert selection["thinning_applied"] is False
+
+
+def test_different_decay_parameters_contribute_both_candidate_regions() -> None:
+    """Different arm decays should both contribute informative main lengths."""
+    exp: Any = _Experiment(
+        targets=("Q0",),
+        decays={"Q0": (0.995, 0.950)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            max_n_cliffords=512,
+            n_trials=4,
+            sequence_seed=89,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    selection = result["Q0"]["grid_selection"]
+    assert selection["candidate_reference_grid"][-1] == 378
+    assert selection["candidate_interleaved_grid"][-1] == 37
+    assert 37 in selection["selected_main_grid"]
+    assert 378 in selection["selected_main_grid"]
+
+
+@pytest.mark.parametrize(
+    ("fractions", "expected_maximum", "expected_points", "expected_sequence_cost"),
+    [
+        ((0.9, 0.7, 0.5, 0.3, 0.15), 378, 11, 9_616),
+        ((0.9, 0.75, 0.6, 0.45, 0.3, 0.2), 321, 13, 9_528),
+        ((0.8, 0.6, 0.4, 0.2, 0.1), 459, 12, 13_312),
+    ],
+)
+def test_main_contrast_fraction_designs_produce_stable_bounded_grids(
+    fractions: tuple[float, ...],
+    expected_maximum: int,
+    expected_points: int,
+    expected_sequence_cost: int,
+) -> None:
+    """Supported contrast designs should retain exact noiseless fit estimates."""
+    exp: Any = _Experiment(
+        targets=("Q0",),
+        decays={"Q0": (0.995, 0.990)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            max_n_cliffords=512,
+            main_remaining_fractions=fractions,
+            n_trials=4,
+            sequence_seed=101,
+            n_bootstrap=5,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    target = result["Q0"]
+    selection = target["grid_selection"]
+    main_grid = selection["selected_main_grid"]
+    expected_fidelity = 1.0 - 0.5 * (1.0 - 0.990 / 0.995)
+    assert selection["main_remaining_fractions"] == fractions
+    assert len(main_grid) == expected_points
+    assert main_grid[-1] == expected_maximum
+    assert target["reference"]["fit"]["p"] == pytest.approx(0.995, abs=1e-8)
+    assert target["interleaved"]["fit"]["p"] == pytest.approx(0.990, abs=1e-8)
+    assert target["gate_fidelity"] == pytest.approx(expected_fidelity, abs=1e-8)
+    assert target["gate_fidelity_err"] == pytest.approx(0.0, abs=1e-12)
+    assert target["gate_fidelity_ci95"] == pytest.approx(
+        (expected_fidelity, expected_fidelity),
+        abs=1e-8,
+    )
+    assert target["acquisition"]["n_measurement_points"] == 8 * len(main_grid)
+    assert 8 * int(np.sum(main_grid)) == expected_sequence_cost
+
+
+def test_main_contrast_fractions_are_validated_before_measurement() -> None:
+    """Invalid contrast ordering should fail without making a hardware call."""
+    exp: Any = _Experiment(targets=("Q0",))
+
+    with pytest.raises(ValueError, match="strictly decreasing"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            main_remaining_fractions=(0.5, 0.7),
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+@pytest.mark.parametrize(
+    "fractions",
+    [
+        {0.90, 0.70, 0.50, 0.30, 0.15},
+        frozenset({0.90, 0.70, 0.50, 0.30, 0.15}),
+    ],
+)
+def test_unordered_main_contrast_fractions_are_rejected_before_measurement(
+    fractions: Collection[float],
+) -> None:
+    """Unordered contrast targets should fail before assigning a main grid."""
+    exp: Any = _Experiment(targets=("Q0",))
+
+    with pytest.raises(TypeError, match="must preserve order"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            main_remaining_fractions=fractions,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_main_contrast_fraction_mapping_is_rejected_before_measurement() -> None:
+    """Mapping keys must not be mistaken for an ordered contrast sequence."""
+    exp: Any = _Experiment(targets=("Q0",))
+
+    with pytest.raises(TypeError, match="not a mapping"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            main_remaining_fractions={0.9: "high", 0.5: "middle", 0.1: "low"},
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_serial_auto_range_validates_main_trials_before_pilot() -> None:
+    """Invalid main trial count should fail before any pilot hardware call."""
+    exp: Any = _Experiment(targets=("Q0",))
+
+    with pytest.raises(ValueError, match=r"n_trials.*at least 2"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            n_trials=1,
+            max_n_cliffords=32,
+            n_bootstrap=0,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_unit_decay_uses_an_auditable_power_of_two_fallback() -> None:
+    """An unidentifiable `p=1` pilot should safely retain the bounded pilot grid."""
+    exp: Any = _Experiment(
+        targets=("Q0",),
+        decays={"Q0": (1.0, 1.0)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            max_n_cliffords=32,
+            n_trials=4,
+            sequence_seed=97,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    selection = result["Q0"]["grid_selection"]
+    assert selection["fallback_used"] is True
+    assert selection["fallback_reason"] == "pilot_fit_unusable"
+    assert selection["pilot_stop_reason"] == "max_n_cliffords_reached"
+    assert selection["pilot_stop_detail"] == "fit_unusable"
+    assert selection["pilot_fit_quality"]["reference"]["valid"] is False
+    assert (
+        "insufficient_observed_decay"
+        in selection["pilot_fit_quality"]["reference"]["invalid_reasons"]
+    )
+    np.testing.assert_array_equal(
+        selection["selected_main_grid"],
+        [0, 1, 2, 4, 8, 16, 32],
+    )
+
+
+def test_invalid_pilot_decay_uses_the_power_of_two_fallback() -> None:
+    """Non-finite pilot decay parameters must not enter logarithmic mapping."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    fallback_grid = module._default_n_cliffords(32)  # noqa: SLF001
+
+    selection = module._select_decay_adapted_main_grid(  # noqa: SLF001
+        (
+            SimpleNamespace(decay_parameter=np.nan),
+            SimpleNamespace(decay_parameter=0.95),
+        ),
+        remaining_fractions=(0.9, 0.7, 0.5, 0.3, 0.15),
+        maximum=32,
+        fallback_grid=fallback_grid,
+    )
+
+    assert selection.fallback_used is True
+    assert selection.fallback_reason is not None
+    assert selection.fallback_reason.startswith("invalid_pilot_decay")
+    np.testing.assert_array_equal(selection.selected_grid, fallback_grid)
+
+
+def test_auto_range_rejects_explicit_seed_matrix_before_measurement() -> None:
+    """An unknown main range must not accept a fixed-shape seed matrix."""
+    exp: Any = _Experiment(targets=("Q0",))
+
+    with pytest.raises(ValueError, match=r"auto_range.*seeds"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            auto_range=True,
+            max_n_cliffords=32,
+            seeds=np.arange(24, dtype=np.int64).reshape(6, 4),
+            n_trials=4,
+            n_bootstrap=0,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_auto_range_rejects_a_ceiling_with_too_few_pilot_lengths() -> None:
+    """Auto-range should fail before hardware when six pilot points cannot fit."""
+    exp: Any = _Experiment(targets=("Q0",))
+
+    with pytest.raises(ValueError, match="at least six pilot lengths"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            max_n_cliffords=8,
+            n_trials=2,
+            n_bootstrap=0,
+            pairs_per_sweep=100,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_auto_range_rejects_fewer_than_four_pilot_trials() -> None:
+    """An unstable pilot trial count should fail before hardware acquisition."""
+    exp: Any = _Experiment(targets=("Q0",))
+
+    with pytest.raises(ValueError, match=r"pilot_n_trials.*at least 4"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            pilot_n_trials=3,
+            max_n_cliffords=32,
+            n_bootstrap=0,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_disabled_auto_range_measures_the_complete_default_grid_without_pilot() -> None:
+    """Disabling auto-range should run one fresh acquisition on the full grid."""
+    exp: Any = _Experiment(targets=("Q0",))
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            auto_range=False,
+            max_n_cliffords=32,
+            n_trials=3,
+            sequence_seed=21,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    grid_selection = result["Q0"]["grid_selection"]
+    np.testing.assert_array_equal(
+        result["Q0"]["acquisition"]["n_cliffords"],
+        [0, 1, 2, 4, 8, 16, 32],
+    )
+    assert grid_selection["enabled"] is False
+    assert grid_selection["pilot_stop_reason"] == "auto_range_disabled"
+    assert grid_selection["pilot_raw_result"] is None
+    assert len(exp.measurement_service.calls) == 1
+
+
+def test_auto_range_records_when_the_decay_threshold_is_not_reached(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """A slow pilot decay should use the full allowed range and record why."""
+    exp: Any = _Experiment(
+        targets=("Q0",),
+        decays={"Q0": (0.999, 0.998)},
+    )
+
+    caplog.set_level(
+        "INFO",
+        logger="qubex.contrib.experiment.paired_interleaved_randomized_benchmarking",
+    )
+    with pytest.warns(RuntimeWarning) as warning_records:
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            auto_range=True,
+            auto_range_remaining_fraction=0.1,
+            max_n_cliffords=32,
+            n_trials=4,
+            sequence_seed=23,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    assert any(
+        "maximum Clifford length" in str(record.message) for record in warning_records
+    )
+    grid_selection = result["Q0"]["grid_selection"]
+    assert grid_selection["pilot_stop_reason"] == "max_n_cliffords_reached"
+    assert grid_selection["selected_main_grid"][-1] == 32
+    assert grid_selection["pilot_grid"][-1] == 32
+    np.testing.assert_array_equal(
+        grid_selection["supplemental_integer_grid"],
+        [3, 7, 15],
+    )
+    assert grid_selection["fallback_used"] is False
+    assert "max_n_cliffords_reached" in caplog.text
+    assert "maximum reached" in caplog.text
+
+
+def test_pilot_threshold_controls_pilot_cost_but_not_the_adaptive_main_grid() -> None:
+    """Pilot thresholds may change pilot cost without changing a fitted main grid."""
+    selected_maxima = []
+    main_measurement_points = []
+    pilot_measurement_points = []
+    p_reference = []
+    p_interleaved = []
+    fidelities = []
+    bootstrap_sigmas = []
+    for threshold in (0.1, 0.2, 0.3):
+        exp: Any = _Experiment(
+            targets=("Q0",),
+            decays={"Q0": (0.92, 0.90)},
+        )
+        with pytest.warns(RuntimeWarning):
+            result = paired_interleaved_randomized_benchmarking(
+                exp,
+                "Q0",
+                interleaved_clifford="X90",
+                auto_range=True,
+                auto_range_remaining_fraction=threshold,
+                max_n_cliffords=128,
+                n_trials=4,
+                sequence_seed=29,
+                n_bootstrap=10,
+                pairs_per_sweep=1_000,
+                plot=False,
+                save_image=False,
+            )
+        grid_selection = result["Q0"]["grid_selection"]
+        selected_maxima.append(grid_selection["selected_main_grid"][-1])
+        main_measurement_points.append(
+            result["Q0"]["acquisition"]["n_measurement_points"]
+        )
+        pilot_measurement_points.append(
+            grid_selection["pilot_raw_result"]["acquisition"]["n_measurement_points"]
+        )
+        p_reference.append(result["Q0"]["reference"]["fit"]["p"])
+        p_interleaved.append(result["Q0"]["interleaved"]["fit"]["p"])
+        fidelities.append(result["Q0"]["gate_fidelity"])
+        bootstrap_sigmas.append(result["Q0"]["gate_fidelity_err"])
+
+    assert selected_maxima == [23, 23, 23]
+    assert main_measurement_points == [80, 80, 80]
+    assert pilot_measurement_points == [84, 84, 72]
+    assert p_reference == pytest.approx([0.92, 0.92, 0.92], abs=1e-8)
+    assert p_interleaved == pytest.approx([0.90, 0.90, 0.90], abs=1e-8)
+    assert fidelities == pytest.approx(
+        [1.0 - 0.5 * (1.0 - 0.90 / 0.92)] * 3,
+        abs=1e-8,
+    )
+    assert bootstrap_sigmas == pytest.approx([0.0, 0.0, 0.0], abs=1e-12)
+
+
+def test_auto_range_extends_when_the_first_pilot_shape_is_poor(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A poor first decay shape should force another length before selection."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    original_fit = module._fit_pilot_decay  # noqa: SLF001
+
+    def mark_six_point_fit_as_poor_shape(
+        n_cliffords: np.ndarray,
+        mean: np.ndarray,
+        **kwargs: Any,
+    ) -> Any:
+        """Lower only the minimum-size fit's shape diagnostic."""
+        fit = original_fit(n_cliffords, mean, **kwargs)
+        if len(n_cliffords) == 6:
+            return replace(fit, r_squared=0.1)
+        return fit
+
+    monkeypatch.setattr(
+        module,
+        "_fit_pilot_decay",
+        mark_six_point_fit_as_poor_shape,
+    )
+    exp: Any = _Experiment(
+        targets=("Q0",),
+        decays={"Q0": (0.90, 0.85)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            auto_range=True,
+            max_n_cliffords=64,
+            n_trials=3,
+            sequence_seed=61,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            plot=False,
+            save_image=False,
+        )
+
+    grid_selection = result["Q0"]["grid_selection"]
+    assert grid_selection["pilot_stop_reason"] == "decay_threshold_reached"
+    assert grid_selection["pilot_grid"][-1] == 32
+    assert grid_selection["selected_main_grid"][-1] == 18
+    assert (
+        "poor_decay_shape"
+        in (
+            grid_selection["pilot_stage_diagnostics"][0]["fit_quality"]["reference"][
+                "invalid_reasons"
+            ]
+        )
+    )
+
+
+def test_parallel_targets_share_points_but_keep_independent_sequence_seeds() -> None:
+    """Parallel acquisition should align schedules and preserve per-target pairs."""
+    exp: Any = _Experiment()
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            ["Q0", "Q1"],
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4, 8, 16],
+            n_trials=3,
+            sequence_seed=31,
+            acquisition_seed=37,
+            n_bootstrap=0,
+            pairs_per_sweep=100,
+            in_parallel=True,
+            plot=False,
+            save_image=False,
+        )
+
+    q0_acquisition = result["Q0"]["acquisition"]
+    q1_acquisition = result["Q1"]["acquisition"]
+    assert not np.array_equal(q0_acquisition["seeds"], q1_acquisition["seeds"])
+    assert q0_acquisition["pair_chunks"][0] is not q1_acquisition["pair_chunks"][0]
+    assert [pair["first_protocol"] for pair in q0_acquisition["planned_order"]] == [
+        pair["first_protocol"] for pair in q1_acquisition["planned_order"]
+    ]
+    assert (
+        sum(len(call["sweep_values"]) for call in exp.measurement_service.calls)
+        == (q0_acquisition["n_measurement_points"])
+    )
+    for call in exp.measurement_service.calls:
+        for markers, duration in zip(
+            call["point_markers"],
+            call["point_durations"],
+            strict=True,
+        ):
+            assert {marker.target for marker in markers} == {"Q0", "Q1"}
+            assert len({marker.interleaved_clifford is None for marker in markers}) == 1
+            assert duration == max(marker.duration for marker in markers)
+
+
+def test_parallel_rejects_overlapping_two_qubit_targets_before_measurement() -> None:
+    """CR targets sharing a physical qubit must not be scheduled together."""
+    exp: Any = _Experiment(
+        targets=(),
+        cr_pairs={"CR0": ("Q0", "Q1"), "CR1": ("Q1", "Q2")},
+    )
+
+    with pytest.raises(ValueError, match="share physical qubits"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            ["CR0", "CR1"],
+            interleaved_clifford="ZX90",
+            n_cliffords_range=[0, 1, 2, 4, 8, 16],
+            n_trials=3,
+            n_bootstrap=0,
+            in_parallel=True,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_parallel_rejects_mixed_one_and_two_qubit_targets() -> None:
+    """The initial parallel implementation should require one target kind."""
+    exp: Any = _Experiment(
+        targets=("Q0",),
+        cr_pairs={"CR0": ("Q1", "Q2")},
+    )
+
+    with pytest.raises(ValueError, match="cannot mix 1Q and 2Q"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            ["Q0", "CR0"],
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4, 8, 16],
+            n_trials=3,
+            n_bootstrap=0,
+            in_parallel=True,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls == []
+
+
+def test_parallel_two_qubit_targets_use_unaveraged_shared_measurement_points(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Disjoint CR targets should share points and retain separate `P(00)` data."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    exp: Any = _Experiment(
+        targets=(),
+        cr_pairs={"CR0": ("Q0", "Q1"), "CR1": ("Q2", "Q3")},
+    )
+    x90 = {qubit: Blank(duration=2.0) for qubit in ("Q0", "Q1", "Q2", "Q3")}
+    zx90 = {target: PulseSchedule() for target in ("CR0", "CR1")}
+    interleaved = {target: PulseSchedule() for target in ("CR0", "CR1")}
+    converted = SimpleNamespace(
+        get_mitigated_probabilities=lambda qubits: {"00": 0.91},
+        get_probabilities=lambda qubits: {"00": 0.89},
+    )
+    monkeypatch.setattr(
+        module.MeasurementResultConverter,
+        "to_measure_result",
+        Mock(return_value=converted),
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            ["CR0", "CR1"],
+            interleaved_clifford="ZX90",
+            interleaved_waveform=interleaved,
+            n_cliffords_range=[0, 1, 2, 4, 8, 16],
+            n_trials=3,
+            sequence_seed=39,
+            n_bootstrap=0,
+            pairs_per_sweep=100,
+            x90=x90,
+            zx90=zx90,
+            in_parallel=True,
+            plot=False,
+            save_image=False,
+        )
+
+    assert exp.measurement_service.calls[0]["shot_averaging"] is False
+    np.testing.assert_allclose(result["CR0"]["reference"]["trials"], 0.91)
+    np.testing.assert_allclose(result["CR1"]["interleaved"]["trials"], 0.91)
+    assert result["CR0"]["metadata"]["dimension"] == 4
+    assert result["CR1"]["metadata"]["dimension"] == 4
+    for marker in exp.sequence_calls:
+        assert marker.x90 is x90
+        assert marker.zx90 is zx90[marker.target]
+        if marker.interleaved_clifford is not None:
+            assert marker.interleaved_waveform is interleaved[marker.target]
+
+
+def test_parallel_auto_range_uses_the_slowest_targets_shared_grid() -> None:
+    """Parallel main acquisition should use the longest range needed by the group."""
+    exp: Any = _Experiment(
+        decays={"Q0": (0.90, 0.85), "Q1": (0.98, 0.97)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            ["Q0", "Q1"],
+            interleaved_clifford="X90",
+            auto_range=True,
+            max_n_cliffords=128,
+            n_trials=3,
+            sequence_seed=41,
+            acquisition_seed=43,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            in_parallel=True,
+            plot=False,
+            save_image=False,
+        )
+
+    assert result["Q0"]["grid_selection"]["target_candidate_main_grid"][-1] == 18
+    assert result["Q1"]["grid_selection"]["target_candidate_main_grid"][-1] == 94
+    np.testing.assert_array_equal(
+        result["Q0"]["grid_selection"]["selected_main_grid"],
+        result["Q1"]["grid_selection"]["selected_main_grid"],
+    )
+    assert (
+        result["Q0"]["grid_selection"]["selected_main_grid"]
+        is not result["Q1"]["grid_selection"]["selected_main_grid"]
+    )
+    shared_grid = result["Q0"]["grid_selection"]["selected_main_grid"]
+    assert len(shared_grid) == 14
+    assert 2 in shared_grid
+    assert shared_grid[-1] == 94
+    assert result["Q0"]["grid_selection"]["thinning_applied"] is True
+
+
+def test_parallel_shared_grid_retains_each_targets_informative_region() -> None:
+    """Parallel thinning should preserve six points from every target design."""
+    decays = {
+        "Q0": (0.9995, 0.9990),
+        "Q1": (0.9950, 0.9900),
+        "Q2": (0.9800, 0.9500),
+    }
+    parallel_exp: Any = _Experiment(targets=tuple(decays), decays=decays)
+    serial_exp: Any = _Experiment(targets=tuple(decays), decays=decays)
+    options = {
+        "interleaved_clifford": "X90",
+        "max_n_cliffords": 2_048,
+        "n_trials": 4,
+        "sequence_seed": 109,
+        "acquisition_seed": 113,
+        "n_bootstrap": 10,
+        "pairs_per_sweep": 1_000,
+        "plot": False,
+        "save_image": False,
+    }
+
+    with pytest.warns(RuntimeWarning):
+        parallel = paired_interleaved_randomized_benchmarking(
+            parallel_exp,
+            tuple(decays),
+            in_parallel=True,
+            **options,
+        )
+    with pytest.warns(RuntimeWarning):
+        serial = paired_interleaved_randomized_benchmarking(
+            serial_exp,
+            tuple(decays),
+            **options,
+        )
+
+    shared_grid = parallel["Q0"]["grid_selection"]["selected_main_grid"]
+    assert len(shared_grid) > 14
+    for target, (p_reference, p_interleaved) in decays.items():
+        selection = parallel[target]["grid_selection"]
+        retained = selection["target_retained_main_grid"]
+        assert selection["target_retained_point_count"] >= 6
+        assert set(retained).issubset(shared_grid)
+        assert parallel[target]["reference"]["fit"]["p"] == pytest.approx(
+            p_reference,
+            abs=1e-8,
+        )
+        assert parallel[target]["interleaved"]["fit"]["p"] == pytest.approx(
+            p_interleaved,
+            abs=1e-8,
+        )
+        assert parallel[target]["gate_fidelity"] == pytest.approx(
+            serial[target]["gate_fidelity"],
+            abs=1e-10,
+        )
+        assert parallel[target]["gate_fidelity_err"] == pytest.approx(
+            serial[target]["gate_fidelity_err"],
+            abs=1e-12,
+        )
+
+
+def test_parallel_shared_grid_preserves_fallback_target_anchors() -> None:
+    """Fallback targets should retain endpoints and representative midpoints."""
+    exp: Any = _Experiment(
+        decays={"Q0": (1.0, 1.0), "Q1": (0.98, 0.95)},
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            ("Q0", "Q1"),
+            interleaved_clifford="X90",
+            max_n_cliffords=128,
+            n_trials=3,
+            sequence_seed=127,
+            n_bootstrap=0,
+            pairs_per_sweep=1_000,
+            in_parallel=True,
+            plot=False,
+            save_image=False,
+        )
+
+    selection = result["Q0"]["grid_selection"]
+    retained = selection["target_retained_main_grid"]
+    assert selection["fallback_used"] is True
+    assert selection["target_retained_point_count"] == 6
+    assert {0, 1, 128}.issubset(retained)
+    assert set(retained).issubset(selection["selected_main_grid"])
+
+
+def test_target_maps_resolve_waveforms_and_ignore_zx90_for_one_qubit_targets() -> None:
+    """Resolve 1Q waveforms while keeping the 2Q-only ZX90 override out of RB."""
+    exp: Any = _Experiment()
+    x90 = {"Q0": Blank(duration=2), "Q1": Blank(duration=4)}
+    interleaved = {"Q0": Blank(duration=6), "Q1": Blank(duration=8)}
+    zx90 = {"Q0": PulseSchedule(), "Q1": PulseSchedule()}
+
+    with pytest.warns(RuntimeWarning):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            ["Q0", "Q1"],
+            interleaved_clifford="X90",
+            interleaved_waveform=interleaved,
+            n_cliffords_range=[0, 1, 2, 4, 8, 16],
+            n_trials=3,
+            sequence_seed=47,
+            n_bootstrap=0,
+            pairs_per_sweep=100,
+            x90=x90,
+            zx90=zx90,
+            plot=False,
+            save_image=False,
+        )
+
+    for target in ("Q0", "Q1"):
+        markers = [marker for marker in exp.sequence_calls if marker.target == target]
+        assert all(marker.x90 is x90[target] for marker in markers)
+        assert all(marker.zx90 is None for marker in markers)
+        interleaved_markers = [
+            marker for marker in markers if marker.interleaved_clifford is not None
+        ]
+        assert all(
+            marker.interleaved_waveform is interleaved[target]
+            for marker in interleaved_markers
+        )
+
+
+def test_high_level_defaults_plot_save_and_log_bootstrap_summary(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Legacy-facing defaults should produce a figure, save it, and log statistics."""
+    exp: Any = _Experiment(targets=("Q0",))
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    show = Mock()
+    save = Mock()
+    monkeypatch.setattr("plotly.graph_objects.Figure.show", show)
+    monkeypatch.setattr(module.viz, "save_figure", save)
+    caplog.set_level(
+        "INFO",
+        logger="qubex.contrib.experiment.paired_interleaved_randomized_benchmarking",
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4, 8, 16],
+            n_trials=4,
+            sequence_seed=53,
+            n_bootstrap=5,
+            pairs_per_sweep=100,
+        )
+
+    assert result.figure is not None
+    assert result.figures is not None
+    assert set(result.figures) == {"Q0"}
+    show.assert_called_once()
+    save.assert_called_once()
+    assert "Paired IRB: Q0" in caplog.text
+    assert "p_ref =" in caplog.text
+    assert "p_irb =" in caplog.text
+    assert "Gate fidelity =" in caplog.text
+    assert "95% bootstrap CI" in caplog.text
+    assert "decay_threshold_reached" not in caplog.text
+    assert "explicit_range" in caplog.text
+
+
+def test_high_level_explicit_false_disables_plot_and_save_and_logs_unavailable(
+    monkeypatch: pytest.MonkeyPatch,
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """Explicit false flags should remain side-effect free and log invalid uncertainty."""
+    exp: Any = _Experiment(targets=("Q0",))
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    show = Mock()
+    save = Mock()
+    monkeypatch.setattr("plotly.graph_objects.Figure.show", show)
+    monkeypatch.setattr(module.viz, "save_figure", save)
+    caplog.set_level(
+        "INFO",
+        logger="qubex.contrib.experiment.paired_interleaved_randomized_benchmarking",
+    )
+
+    with pytest.warns(RuntimeWarning):
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4, 8, 16],
+            n_trials=4,
+            sequence_seed=59,
+            n_bootstrap=0,
+            pairs_per_sweep=100,
+            plot=False,
+            save_image=False,
+        )
+
+    assert result.figure is None
+    assert result.figures is None
+    show.assert_not_called()
+    save.assert_not_called()
+    assert "Statistical uncertainty unavailable" in caplog.text
+    assert "optimizer = disabled" in caplog.text

--- a/tests/contrib/paired_interleaved_randomized_benchmarking/test_measurement.py
+++ b/tests/contrib/paired_interleaved_randomized_benchmarking/test_measurement.py
@@ -1,0 +1,710 @@
+"""Tests for paired interleaved randomized-benchmarking acquisition."""
+
+from __future__ import annotations
+
+import importlib
+import random
+from types import MethodType, SimpleNamespace
+from typing import Any
+from unittest.mock import Mock
+
+import numpy as np
+import pytest
+
+from qubex.clifford.clifford import Clifford
+from qubex.clifford.clifford_generator import CliffordGenerator
+from qubex.contrib import (
+    measure_paired_irb,
+    paired_interleaved_randomized_benchmarking,
+)
+from qubex.measurement.models import CaptureData, MeasurementConfig, MeasurementResult
+from qubex.measurement.services.measurement_execution_service import (
+    MeasurementExecutionService,
+)
+
+
+class _RabiParam:
+    """Map an encoded IQ value to a normalized Bloch-Z value."""
+
+    @staticmethod
+    def normalize(iq: Any) -> float:
+        """Decode a synthetic ground-state probability."""
+        return 2.0 * float(np.real(np.mean(np.asarray(iq)))) - 1.0
+
+
+class _MeasurementService:
+    """Execute synthetic sweep points while retaining call boundaries."""
+
+    def __init__(
+        self,
+        *,
+        include_leading_capture: bool = False,
+        encode_association: bool = False,
+    ) -> None:
+        self.calls: list[dict[str, Any]] = []
+        self.include_leading_capture = include_leading_capture
+        self.encode_association = encode_association
+
+    async def run_sweep_measurement(
+        self,
+        schedule: Any,
+        *,
+        sweep_values: Any,
+        **kwargs: Any,
+    ) -> Any:
+        """Return one canonical-shaped synthetic result per schedule."""
+        values = np.asarray(sweep_values)
+        self.calls.append({"sweep_values": values.copy(), **kwargs})
+        results = []
+        for value in values:
+            marker = schedule(int(value))
+            decay = 0.98 if marker.interleaved_clifford is None else 0.95
+            probability = (
+                0.2
+                + 0.4 * marker.seed / 2**32
+                + 0.1 * (marker.interleaved_clifford is not None)
+                if self.encode_association
+                else 0.48 * decay**marker.n_cliffords + 0.5
+            )
+            capture_config = SimpleNamespace(
+                shot_averaging=kwargs["shot_averaging"],
+                time_integration=kwargs["time_integration"],
+            )
+            capture_data = (
+                np.asarray(probability, dtype=np.complex128)
+                if kwargs["time_integration"]
+                else np.full(2, probability / 2.0, dtype=np.complex128)
+            )
+            captures = [SimpleNamespace(data=capture_data, config=capture_config)]
+            if self.include_leading_capture:
+                captures.insert(
+                    0,
+                    SimpleNamespace(
+                        data=np.asarray(0.01, dtype=np.complex128),
+                        config=capture_config,
+                    ),
+                )
+            results.append(SimpleNamespace(data={"Q0": captures}))
+        return SimpleNamespace(results=results)
+
+
+class _Experiment:
+    """Provide the public experiment surface used by paired IRB."""
+
+    def __init__(self) -> None:
+        self.sequence_calls: list[Any] = []
+        self.measurement_service = _MeasurementService()
+        self.pulse = SimpleNamespace(
+            rabi_params={"Q0": _RabiParam()},
+            validate_rabi_params=lambda targets: None,
+        )
+        self.experiment_system = SimpleNamespace(
+            get_target=lambda target: SimpleNamespace(is_cr=False),
+            resolve_qubit_label=lambda target: target,
+        )
+        self.ctx = SimpleNamespace(
+            reset_awg_and_capunits=lambda *, qubits: None,
+            classifiers={},
+        )
+        self.interleaved = Clifford.X90()
+        self.benchmarking_service = SimpleNamespace(clifford={"X90": self.interleaved})
+
+    def rb_sequence(self, target: str, **kwargs: Any) -> Any:
+        """Record schedule construction arguments and return a marker."""
+        marker = SimpleNamespace(
+            target=target,
+            n_cliffords=kwargs["n"],
+            seed=kwargs["seed"],
+            interleaved_clifford=kwargs["interleaved_clifford"],
+        )
+        self.sequence_calls.append(marker)
+        return marker
+
+
+@pytest.mark.parametrize(
+    ("clifford_type", "interleaved_clifford"),
+    [("1Q", Clifford.X90()), ("2Q", Clifford.ZX90())],
+)
+def test_reference_and_interleaved_sequences_share_random_cliffords(
+    clifford_type: Any,
+    interleaved_clifford: Clifford,
+) -> None:
+    """A shared seed must generate the same underlying 1Q/2Q Cliffords."""
+    generator = CliffordGenerator()
+    random_state = random.getstate()
+    try:
+        reference_cliffords, _ = generator.create_rb_sequences(
+            n=12,
+            type=clifford_type,
+            seed=314159,
+        )
+        interleaved_cliffords, _ = generator.create_irb_sequences(
+            n=12,
+            interleave=interleaved_clifford,
+            type=clifford_type,
+            seed=314159,
+        )
+    finally:
+        random.setstate(random_state)
+
+    assert reference_cliffords == interleaved_cliffords
+
+
+def test_measurement_batches_whole_pairs_and_reuses_each_cell_seed() -> None:
+    """Each sweep chunk should retain complete adjacent pairs with shared seeds."""
+    exp: Any = _Experiment()
+
+    result = measure_paired_irb(
+        exp,
+        "Q0",
+        interleaved_clifford="X90",
+        n_cliffords_range=[0, 1, 2, 4],
+        n_trials=3,
+        sequence_seed=11,
+        acquisition_seed=22,
+        pairs_per_sweep=2,
+        n_shots=100,
+    )
+
+    assert [len(call["sweep_values"]) for call in exp.measurement_service.calls] == [
+        4,
+        4,
+        4,
+        4,
+        4,
+        4,
+    ]
+    for pair_start in range(0, len(exp.sequence_calls), 2):
+        first, second = exp.sequence_calls[pair_start : pair_start + 2]
+        assert first.n_cliffords == second.n_cliffords
+        assert first.seed == second.seed
+        assert {first.interleaved_clifford, second.interleaved_clifford} == {
+            None,
+            exp.interleaved,
+        }
+
+    acquisition = result["Q0"]["acquisition"]
+    assert acquisition["seeds"].shape == (4, 3)
+    assert len(np.unique(acquisition["seeds"])) == 12
+    assert acquisition["sequence_seed"] == 11
+    assert acquisition["n_sweep_calls"] == 6
+    assert acquisition["n_measurement_points"] == 24
+    first_protocols = [pair["first_protocol"] for pair in acquisition["planned_order"]]
+    assert first_protocols.count("reference") == 6
+    assert first_protocols.count("interleaved") == 6
+    for length_index in range(4):
+        length_protocols = [
+            pair["first_protocol"]
+            for pair in acquisition["planned_order"]
+            if pair["length_index"] == length_index
+        ]
+        assert (
+            abs(
+                length_protocols.count("reference")
+                - length_protocols.count("interleaved")
+            )
+            <= 1
+        )
+
+
+def test_multi_pair_sweep_results_remain_associated_with_planned_cells() -> None:
+    """Returned point order should map every protocol result to its planned cell."""
+    exp: Any = _Experiment()
+    exp.measurement_service = _MeasurementService(encode_association=True)
+
+    result = measure_paired_irb(
+        exp,
+        "Q0",
+        interleaved_clifford="X90",
+        n_cliffords_range=[0, 1, 2, 4],
+        n_trials=3,
+        sequence_seed=13,
+        acquisition_seed=27,
+        pairs_per_sweep=4,
+    )
+
+    target = result["Q0"]
+    for pair in target["acquisition"]["planned_order"]:
+        length_index = pair["length_index"]
+        trial_index = pair["trial_index"]
+        base_probability = 0.2 + 0.4 * pair["seed"] / 2**32
+        assert target["reference"]["trials"][length_index, trial_index] == (
+            pytest.approx(base_probability)
+        )
+        assert target["interleaved"]["trials"][length_index, trial_index] == (
+            pytest.approx(base_probability + 0.1)
+        )
+
+
+def test_measurement_rejects_an_incomplete_sweep_result() -> None:
+    """A backend result count mismatch should fail instead of mispairing trials."""
+
+    class _IncompleteMeasurementService(_MeasurementService):
+        async def run_sweep_measurement(
+            self,
+            schedule: Any,
+            *,
+            sweep_values: Any,
+            **kwargs: Any,
+        ) -> Any:
+            """Drop one synthetic point to emulate an incomplete backend result."""
+            sweep = await super().run_sweep_measurement(
+                schedule,
+                sweep_values=sweep_values,
+                **kwargs,
+            )
+            return SimpleNamespace(results=sweep.results[:-1])
+
+    exp: Any = _Experiment()
+    exp.measurement_service = _IncompleteMeasurementService()
+
+    with pytest.raises(RuntimeError, match="result count"):
+        measure_paired_irb(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4],
+            n_trials=2,
+            sequence_seed=17,
+            pairs_per_sweep=8,
+        )
+
+
+def test_measurement_rejects_nonfinite_survival_probability() -> None:
+    """A nonfinite normalized survival should fail before entering raw trials."""
+    exp: Any = _Experiment()
+    exp.pulse.rabi_params["Q0"] = SimpleNamespace(normalize=lambda iq: np.nan)
+
+    with pytest.raises(ValueError, match="survival probability must be finite"):
+        measure_paired_irb(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4],
+            n_trials=2,
+            sequence_seed=19,
+            pairs_per_sweep=8,
+        )
+
+
+def test_real_sweep_service_preserves_multi_pair_result_order() -> None:
+    """The real sweep orchestrator should preserve every requested pair point."""
+    execution: Any = MeasurementExecutionService.__new__(MeasurementExecutionService)
+
+    def cannot_batch(self: Any) -> bool:
+        return False
+
+    async def run_measurement(
+        self: Any,
+        *,
+        schedule: Any,
+        config: MeasurementConfig,
+    ) -> Any:
+        del self
+        decay_offset = 0.1 * (schedule.interleaved_clifford is not None)
+        probability = 0.2 + 0.4 * schedule.seed / 2**32 + decay_offset
+        capture = CaptureData.from_primary_data(
+            target="Q0",
+            data=np.asarray([probability], dtype=np.complex128),
+            config=config,
+            sampling_period=2.0,
+        )
+        return MeasurementResult(
+            data={
+                "Q0": [capture],
+            },
+            measurement_config=config,
+            device_config={},
+        )
+
+    execution._can_use_batch_execution = MethodType(  # noqa: SLF001
+        cannot_batch,
+        execution,
+    )
+    execution.run_measurement = MethodType(run_measurement, execution)
+
+    class _ExecutionBackedService:
+        """Adapt the real ordered sweep method to the experiment test surface."""
+
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+            self.returned_sweep_values: list[list[Any]] = []
+
+        async def run_sweep_measurement(
+            self,
+            schedule: Any,
+            *,
+            sweep_values: Any,
+            **kwargs: Any,
+        ) -> Any:
+            values = np.asarray(sweep_values).tolist()
+            self.calls.append({"sweep_values": values, **kwargs})
+            config = MeasurementConfig(
+                n_shots=kwargs["n_shots"],
+                shot_interval=kwargs["shot_interval"],
+                shot_averaging=kwargs["shot_averaging"],
+                time_integration=kwargs["time_integration"],
+                state_classification=False,
+            )
+            result = await execution.run_sweep_measurement(
+                schedule,
+                sweep_values=values,
+                config=config,
+            )
+            self.returned_sweep_values.append(result.sweep_values)
+            return result
+
+    exp: Any = _Experiment()
+    service = _ExecutionBackedService()
+    exp.measurement_service = service
+
+    result = measure_paired_irb(
+        exp,
+        "Q0",
+        interleaved_clifford="X90",
+        n_cliffords_range=[0, 1, 2, 4],
+        n_trials=3,
+        sequence_seed=13,
+        acquisition_seed=27,
+        pairs_per_sweep=4,
+    )
+
+    assert all(
+        returned == call["sweep_values"]
+        for returned, call in zip(
+            service.returned_sweep_values,
+            service.calls,
+            strict=True,
+        )
+    )
+    target = result["Q0"]
+    for pair in target["acquisition"]["planned_order"]:
+        length_index = pair["length_index"]
+        trial_index = pair["trial_index"]
+        base_probability = 0.2 + 0.4 * pair["seed"] / 2**32
+        assert target["reference"]["trials"][length_index, trial_index] == (
+            pytest.approx(base_probability)
+        )
+        assert target["interleaved"]["trials"][length_index, trial_index] == (
+            pytest.approx(base_probability + 0.1)
+        )
+
+
+def test_ab_ba_order_remains_globally_balanced_for_odd_grid_and_trials() -> None:
+    """An odd number of pairs should have the smallest possible order imbalance."""
+    exp: Any = _Experiment()
+
+    result = measure_paired_irb(
+        exp,
+        "Q0",
+        interleaved_clifford="X90",
+        n_cliffords_range=[0, 1, 2, 4, 8],
+        n_trials=3,
+        sequence_seed=11,
+        acquisition_seed=22,
+        pairs_per_sweep=15,
+    )
+
+    first_protocols = [
+        pair["first_protocol"] for pair in result["Q0"]["acquisition"]["planned_order"]
+    ]
+    assert (
+        abs(first_protocols.count("reference") - first_protocols.count("interleaved"))
+        == 1
+    )
+
+
+def test_acquisition_rng_changes_only_the_pair_order() -> None:
+    """Order randomization should not alter sequence seeds or indexed trial data."""
+    first_exp: Any = _Experiment()
+    second_exp: Any = _Experiment()
+    common_options = {
+        "interleaved_clifford": "X90",
+        "n_cliffords_range": [0, 1, 2, 4],
+        "n_trials": 3,
+        "sequence_seed": 11,
+        "pairs_per_sweep": 12,
+    }
+
+    first = measure_paired_irb(
+        first_exp,
+        "Q0",
+        acquisition_seed=22,
+        **common_options,
+    )
+    second = measure_paired_irb(
+        second_exp,
+        "Q0",
+        acquisition_seed=23,
+        **common_options,
+    )
+
+    first_payload = first["Q0"]
+    second_payload = second["Q0"]
+    np.testing.assert_array_equal(
+        first_payload["acquisition"]["seeds"],
+        second_payload["acquisition"]["seeds"],
+    )
+    assert (
+        first_payload["acquisition"]["planned_order"]
+        != second_payload["acquisition"]["planned_order"]
+    )
+    np.testing.assert_array_equal(
+        first_payload["reference"]["trials"],
+        second_payload["reference"]["trials"],
+    )
+    np.testing.assert_array_equal(
+        first_payload["interleaved"]["trials"],
+        second_payload["interleaved"]["trials"],
+    )
+
+
+def test_acquisition_order_is_random_by_default_and_fully_recorded() -> None:
+    """The default acquisition RNG should be fresh while preserving its exact plan."""
+    exp: Any = _Experiment()
+
+    result = measure_paired_irb(
+        exp,
+        "Q0",
+        interleaved_clifford="X90",
+        n_cliffords_range=[0, 1, 2, 4],
+        n_trials=2,
+        sequence_seed=11,
+        pairs_per_sweep=8,
+    )
+
+    acquisition = result["Q0"]["acquisition"]
+    assert acquisition["acquisition_seed"] is None
+    assert len(acquisition["planned_order"]) == 8
+
+
+def test_measurement_rejects_a_seed_matrix_with_the_wrong_shape() -> None:
+    """Measurement should require one independent seed for every pair cell."""
+    exp: Any = _Experiment()
+
+    with pytest.raises(ValueError, match="shape"):
+        measure_paired_irb(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4],
+            n_trials=3,
+            seeds=np.arange(3),
+        )
+
+
+def test_measurement_rejects_two_length_grid_sources() -> None:
+    """An explicit grid and a default-grid maximum should not conflict."""
+    exp: Any = _Experiment()
+
+    with pytest.raises(ValueError, match="Specify only one"):
+        measure_paired_irb(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4],
+            max_n_cliffords=64,
+            n_trials=2,
+            sequence_seed=7,
+        )
+
+
+def test_measurement_rejects_duplicate_explicit_sequence_seeds() -> None:
+    """Explicit seed matrices should preserve independence between all cells."""
+    exp: Any = _Experiment()
+    seeds = np.arange(12, dtype=np.int64).reshape(4, 3)
+    seeds[3, 2] = seeds[0, 0]
+
+    with pytest.raises(ValueError, match="distinct"):
+        measure_paired_irb(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4],
+            n_trials=3,
+            seeds=seeds,
+        )
+
+
+def test_measurement_rejects_a_clifford_with_the_wrong_qubit_arity() -> None:
+    """A two-qubit Clifford should not be accepted for a one-qubit target."""
+    exp: Any = _Experiment()
+
+    with pytest.raises(ValueError, match="one-qubit"):
+        measure_paired_irb(
+            exp,
+            "Q0",
+            interleaved_clifford=Clifford.IX90(),
+            n_cliffords_range=[0, 1, 2, 4],
+            n_trials=2,
+            sequence_seed=7,
+        )
+
+
+def test_measurement_rejects_truthy_non_boolean_options() -> None:
+    """Measurement flags should not silently coerce strings to true."""
+    exp: Any = _Experiment()
+
+    with pytest.raises(TypeError, match="mitigate_readout"):
+        measure_paired_irb(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4],
+            n_trials=2,
+            sequence_seed=7,
+            mitigate_readout="false",  # type: ignore[arg-type]
+        )
+
+
+def test_one_qubit_measurement_uses_the_terminal_capture() -> None:
+    """A preceding capture should not replace the final RB readout."""
+    exp: Any = _Experiment()
+    exp.measurement_service = _MeasurementService(include_leading_capture=True)
+
+    result = measure_paired_irb(
+        exp,
+        "Q0",
+        interleaved_clifford="X90",
+        n_cliffords_range=[0, 1, 2, 4],
+        n_trials=2,
+        sequence_seed=7,
+        pairs_per_sweep=8,
+        time_integration=False,
+    )
+
+    reference = result["Q0"]["reference"]["trials"]
+    interleaved = result["Q0"]["interleaved"]["trials"]
+    expected_reference = 0.48 * 0.98 ** np.array([0, 1, 2, 4]) + 0.5
+    expected_interleaved = 0.48 * 0.95 ** np.array([0, 1, 2, 4]) + 0.5
+    np.testing.assert_allclose(
+        reference,
+        np.broadcast_to(expected_reference[:, None], reference.shape),
+    )
+    np.testing.assert_allclose(
+        interleaved,
+        np.broadcast_to(expected_interleaved[:, None], interleaved.shape),
+    )
+
+
+@pytest.mark.parametrize(
+    ("mitigate_readout", "expected_probability"),
+    [(True, 0.91), (False, 0.89)],
+)
+def test_two_qubit_measurement_uses_unaveraged_shots_and_p00(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    mitigate_readout: bool,
+    expected_probability: float,
+) -> None:
+    """CR acquisition should retain shots and convert each point to `P(00)`."""
+    module = importlib.import_module(
+        "qubex.contrib.experiment.paired_interleaved_randomized_benchmarking"
+    )
+    exp: Any = _Experiment()
+    exp.experiment_system = SimpleNamespace(
+        get_target=lambda target: SimpleNamespace(is_cr=True),
+    )
+    exp.ctx = SimpleNamespace(
+        reset_awg_and_capunits=lambda *, qubits: None,
+        classifiers={"Q0": object(), "Q1": object()},
+        calib_note=SimpleNamespace(cr_params={"CR0": object()}),
+        cr_pair=lambda target: ("Q0", "Q1"),
+    )
+    exp.interleaved = Clifford.IX90()
+    exp.benchmarking_service.clifford = {"IX90": exp.interleaved}
+    converted = SimpleNamespace(
+        get_mitigated_probabilities=Mock(return_value={"00": 0.91}),
+        get_probabilities=Mock(return_value={"00": 0.89}),
+    )
+    monkeypatch.setattr(
+        module.MeasurementResultConverter,
+        "to_measure_result",
+        Mock(return_value=converted),
+    )
+
+    result = measure_paired_irb(
+        exp,
+        "CR0",
+        interleaved_clifford="IX90",
+        n_cliffords_range=[0, 1, 2, 4],
+        n_trials=2,
+        sequence_seed=5,
+        pairs_per_sweep=8,
+        mitigate_readout=mitigate_readout,
+    )
+
+    call = exp.measurement_service.calls[0]
+    assert call["shot_averaging"] is False
+    assert call["time_integration"] is True
+    np.testing.assert_allclose(
+        result["CR0"]["reference"]["trials"], expected_probability
+    )
+    np.testing.assert_allclose(
+        result["CR0"]["interleaved"]["trials"], expected_probability
+    )
+    selected_probability = (
+        converted.get_mitigated_probabilities
+        if mitigate_readout
+        else converted.get_probabilities
+    )
+    unused_probability = (
+        converted.get_probabilities
+        if mitigate_readout
+        else converted.get_mitigated_probabilities
+    )
+    assert selected_probability.call_count == 16
+    unused_probability.assert_not_called()
+    converter_calls = module.MeasurementResultConverter.to_measure_result.call_args_list
+    assert all(call.kwargs["index"] == -1 for call in converter_calls)
+
+
+def test_composed_api_returns_full_analysis(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    """The composed API should analyze the same paired acquisition in one call."""
+    exp: Any = _Experiment()
+    caplog.set_level(
+        "INFO",
+        logger="qubex.contrib.experiment.paired_interleaved_randomized_benchmarking",
+    )
+
+    with pytest.warns(RuntimeWarning) as warning_records:
+        result = paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4],
+            n_trials=2,
+            sequence_seed=3,
+            n_bootstrap=5,
+            plot=False,
+            save_image=False,
+        )
+
+    assert any("SEM floor" in str(record.message) for record in warning_records)
+    expected = 1.0 - 0.5 * (1.0 - 0.95 / 0.98)
+    assert result["Q0"]["gate_fidelity"] == pytest.approx(expected, abs=1e-8)
+    bootstrap = result["Q0"]["bootstrap"]
+    assert bootstrap["execution_skipped"] is True
+    assert bootstrap["n_attempted"] == 0
+    assert bootstrap["n_success"] == 0
+    assert "optimizer = not_run" in caplog.text
+
+
+def test_composed_api_validates_analysis_options_before_measurement() -> None:
+    """Invalid analysis options should not waste a hardware acquisition."""
+    exp: Any = _Experiment()
+
+    with pytest.raises(ValueError, match="n_bootstrap"):
+        paired_interleaved_randomized_benchmarking(
+            exp,
+            "Q0",
+            interleaved_clifford="X90",
+            n_cliffords_range=[0, 1, 2, 4],
+            n_trials=2,
+            sequence_seed=3,
+            n_bootstrap=-1,
+        )
+
+    assert exp.measurement_service.calls == []


### PR DESCRIPTION
## Summary

This PR adds paired interleaved randomized benchmarking (paired IRB), which measures Reference RB and Interleaved RB using the same random Clifford sequences as adjacent pairs.

It retains the standard IRB gate-fidelity estimator while introducing a paired measurement design, adaptive range selection, weighted fitting, and correlation-preserving uncertainty estimation.

## Motivation

The conventional IRB implementation measures the complete Reference RB dataset before measuring the Interleaved RB dataset. As a result, device drift between the two acquisitions and differences between random sequences may affect the estimated gate fidelity.

The paired design introduced here uses the same random sequence for Reference and Interleaved measurements at each Clifford length and trial. The two measurements are acquired close together in time, making sequence-dependent variation and slow device drift more likely to be shared between the two arms.

## Added APIs

The following APIs are added under `qubex.contrib.experiment`:

- `measure_paired_irb()`
- `analyze_paired_irb()`
- `paired_interleaved_randomized_benchmarking()`

The implementation supports:

- Single-qubit and two-qubit IRB
- Single-target measurement
- Serial multi-target measurement
- Parallel multi-target measurement
- Separate measurement and analysis workflows
- Reanalysis of previously acquired raw data
- Plotting consistent with the conventional IRB workflow

## Paired measurement design

For each `(Clifford length, trial)` cell, the Reference and Interleaved arms use the same sequence seed.

The acquisition order is balanced between:

- AB: Reference followed by Interleaved
- BA: Interleaved followed by Reference

The resulting pairs are globally shuffled across all Clifford lengths. This reduces correlations among the Clifford length, acquisition time, and within-pair measurement order.

Pairs are divided into chunks containing `pairs_per_sweep` complete pairs. Each chunk is submitted through one `measurement_service.run_sweep_measurement()` call, while the Reference and Interleaved points within every pair remain adjacent.

The default is conservatively set to `pairs_per_sweep=1`. Larger values reduce measurement-service call overhead but may increase the time span covered by a sweep chunk. Physical batching within each call remains controlled by the measurement backend.

## Seed design

The implementation uses a two-dimensional seed matrix with shape:

```text
(n_lengths, n_trials)
```

Generated seeds are distinct across cells, while the Reference and Interleaved arms share the seed assigned to the same cell.

Sequence generation and acquisition ordering use separate random streams. When auto-range is enabled, the pilot and main measurements also use independent sequence and acquisition streams.

## Auto-range pilot

When no explicit Clifford-length range is supplied, a paired pilot measurement is used to estimate the required range.

The pilot uses an unweighted two-parameter decay model with a fixed offset:

```text
y(m) = A * p**m + 1/d
```

The Reference and Interleaved arms are assessed independently using:

- Decay-parameter validity
- Parameter bound hits
- Minimum amplitude
- R-squared
- Observed endpoint decay significance

Pilot stopping is evaluated only after at least six Clifford lengths have been measured.

The pilot stops when:

- Both arm fits are valid
- Both arms have an endpoint decay significance of at least 3 sigma
- The slower arm has no more than 10% fitted contrast remaining at the current maximum length

The pilot data is used only for range selection. The main measurement uses fresh sequence seeds and a fresh acquisition order.

## Main-grid selection

The main grid is selected by mapping the following default remaining-contrast targets through the Interleaved pilot fit:

```text
90%, 70%, 50%, 30%, 15%, 5%, 2%
```

Reference candidates are then added only when they lie beyond the largest Interleaved candidate. Clifford lengths `0` and `1` are also included.

The candidate union is not merged or thinned.

If integer rounding causes multiple contrast targets to select the same lengths and leaves fewer than six points, additional well-separated integer lengths are added where possible.

If a requested contrast target exceeds `max_n_cliffords`, the maximum is added as an anchor and the limitation is recorded through a warning and result metadata.

For parallel auto-range, the shared main grid is the unthinned union of the target-specific main grids. This ensures that no target loses a Clifford length selected by its own pilot result.

## Main fit

The main analysis uses the standard three-parameter RB decay model:

```text
y(m) = A * p**m + C
```

The fit is weighted using the standard error of the mean (SEM) at each Clifford length, with `absolute_sigma=True`.

A common SEM floor is applied to the Reference and Interleaved arms to prevent zero or extremely small SEM values from dominating the fit. By default, the floor is 25% of the median positive SEM. If every SEM is zero, a fallback value of `0.001` is used.

## Gate-fidelity estimate

The point estimate uses the standard IRB expression:

```text
F_G = 1 - (d - 1) / d * (1 - p_interleaved / p_reference)
```

The result is not clipped to the interval `[0, 1]`. Values outside this interval are retained and reported with a diagnostic warning.

## Paired bootstrap uncertainty

Primary statistical uncertainty is evaluated using an AB/BA-stratified paired bootstrap.

Trials are resampled independently within each:

```text
Clifford length × AB/BA stratum
```

The same resampled trial indices are applied to the Reference and Interleaved arms. This preserves their pair correlation throughout the statistics, fitting, and gate-fidelity calculation.

The default number of bootstrap replicates is 2,000.

Primary bootstrap uncertainty is reported only when:

- Every AB/BA stratum contains at least two samples
- At least two bootstrap fits succeed
- The bootstrap fit success rate is at least 80%

If these requirements are not satisfied, the point estimate is retained, while `gate_fidelity_err` and the confidence intervals are reported as `None`.

For `n_trials=2` or `n_trials=3`, the point estimate remains available, but the AB/BA strata do not contain enough samples for valid resampling. In this case, bootstrap resampling and fitting are skipped entirely.

Uncertainty propagated from the full-data fit covariance is retained for diagnostics only and is not used as the primary uncertainty.

## Raw data and diagnostics

The returned result retains information required for later reanalysis and acquisition auditing, including:

- Complete Reference and Interleaved trial matrices
- The `(n_lengths, n_trials)` sequence-seed matrix
- Sequence and acquisition seeds
- Balanced AB/BA order
- Global pair order
- Sweep-chunk information
- Chunk-level start and completion timestamps
- `pairs_per_sweep`
- Pilot raw data
- Range-selection diagnostics
- Fit-quality diagnostics
- Bootstrap validity and optimizer diagnostics
- Readout-mitigation settings

This allows the acquired data to be reanalyzed with different bootstrap or SEM-floor settings without repeating the hardware measurement.

## Multi-target validation

The implementation validates multi-target measurement conditions, including:

- Independent random streams for each target
- Shared pair ordering during parallel measurement
- Physical-qubit overlap between two-qubit targets
- Target-specific waveform and pulse-schedule mappings
- Prevention of accidental `PulseSchedule` reuse across multiple CR targets

## Testing

Dedicated tests cover:

- Measurement and raw-result schemas
- Single-qubit and two-qubit analysis
- Paired bootstrap behavior
- Invalid AB/BA stratum handling
- Auto-range pilot behavior
- Main-grid selection
- Serial and parallel multi-target execution
- Target-specific waveform and schedule validation
- Public function exports

The relevant test suite passes:

```text
uv run pytest tests/contrib/paired_interleaved_randomized_benchmarking
129 passed
```

The full test suite was not used because some unrelated tests do not terminate in the current environment.